### PR TITLE
fix: add durable Windows filesystem recovery

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,37 @@ jobs:
       - name: Run tests
         run: python -m pytest -p no:cacheprovider -q tests
 
+  windows:
+    name: Windows / Python ${{ matrix.python-version }}
+    runs-on: windows-2025
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.14"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install test dependency
+        run: python -m pip install "pytest==8.4.2"
+
+      - name: Compile Python source
+        run: python -m py_compile codex-instruct.py
+
+      - name: Run tests
+        run: python -m pytest -p no:cacheprovider -q tests
+
   quality:
     name: Quality / Python 3.14
     runs-on: ubuntu-24.04

--- a/codex-instruct.py
+++ b/codex-instruct.py
@@ -685,7 +685,17 @@ def resolve_codex_dir(
     reject_residue: bool = True,
 ) -> Path:
     """Resolve and validate a user-supplied Codex directory."""
-    codex_root = _FILESYSTEM.resolve_directory(Path(value))
+    requested = Path(value).expanduser()
+    try:
+        codex_root = _FILESYSTEM.resolve_directory(requested)
+    except (FileNotFoundError, NotADirectoryError) as exc:
+        raise FileNotFoundError(
+            _localized(
+                f"指定目录不存在或不是目录: {requested}",
+                "Specified directory does not exist or is not a directory: "
+                f"{requested}",
+            )
+        ) from exc
     if not codex_root.is_dir():
         raise FileNotFoundError(
             _localized(
@@ -991,6 +1001,9 @@ class _PosixFilesystemBackend:
 
     def apply_private_file_security(self, descriptor: int) -> None:
         os.fchmod(descriptor, 0o600)
+
+    def apply_private_path_security(self, path: Path) -> None:
+        del path
 
     def clone_file_security(self, descriptor: int, source_stat: os.stat_result) -> None:
         os.fchmod(descriptor, stat.S_IMODE(source_stat.st_mode))
@@ -1348,6 +1361,7 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
     _READ_CONTROL = 0x00020000
     _WRITE_DAC = 0x00040000
     _FILE_LIST_DIRECTORY = 0x0001
+    _FILE_TRAVERSE = 0x0020
     _FILE_READ_ATTRIBUTES = 0x0080
     _FILE_WRITE_ATTRIBUTES = 0x0100
     _SYNCHRONIZE = 0x00100000
@@ -1747,7 +1761,7 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
             for index, component in enumerate(components):
                 handle = self._open_handle(
                     component,
-                    self._FILE_READ_ATTRIBUTES,
+                    self._FILE_TRAVERSE | self._FILE_READ_ATTRIBUTES,
                     share_mode=self._FILE_SHARE_READ | self._FILE_SHARE_WRITE,
                 )
                 handles.append(handle)
@@ -1966,6 +1980,29 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
             self._security_descriptor,
         ):
             self._raise_last_error("cannot apply private ACL")
+
+    def apply_private_path_security(self, path: Path) -> None:
+        handle = self._open_handle(
+            path,
+            self._GENERIC_READ
+            | self._GENERIC_WRITE
+            | self._READ_CONTROL
+            | self._WRITE_DAC
+            | self._FILE_READ_ATTRIBUTES,
+        )
+        try:
+            self._validate_handle_type(handle, path, is_directory=False)
+            self._validate_ntfs(handle, path)
+            if not self.advapi32.SetKernelObjectSecurity(
+                handle,
+                self._DACL_SECURITY_INFORMATION,
+                self._security_descriptor,
+            ):
+                self._raise_last_error("cannot apply private ACL", path)
+            if not self.kernel32.FlushFileBuffers(handle):
+                self._raise_last_error("cannot persist private ACL", path)
+        finally:
+            self.kernel32.CloseHandle(handle)
 
     def clone_file_security(self, descriptor: int, source_stat: os.stat_result) -> None:
         del source_stat
@@ -3975,7 +4012,10 @@ def _validate_hooks_for_isolation(codex_dir: Path) -> Optional[dict]:
 
 def _atomic_rename_no_replace(source: Path, destination: Path) -> bool:
     """Atomically rename source while preserving an existing destination."""
-    return _FILESYSTEM.atomic_rename_no_replace(source, destination)
+    renamed = _FILESYSTEM.atomic_rename_no_replace(source, destination)
+    if renamed and str(destination.parent) in _OWNED_DIRECTORY_RECORDS:
+        _FILESYSTEM.apply_private_path_security(destination)
+    return renamed
 
 
 def _verify_atomic_rename_support(codex_dir: Path) -> None:

--- a/codex-instruct.py
+++ b/codex-instruct.py
@@ -191,6 +191,10 @@ _ACTIVE_DEPLOYMENT_STATES: Optional[List["DeploymentState"]] = None
 _OWNED_DIRECTORY_RECORDS: Dict[str, Tuple["FileIdentity", Any]] = {}
 _LOADED_JOURNAL_PENDING: Dict[str, Tuple["FileFingerprint", bool]] = {}
 _LOADED_COMPANION_PENDING: Dict[str, Tuple["FileFingerprint", bool]] = {}
+_LOADED_RECOVERY_EVIDENCE: Dict[
+    str,
+    Dict[str, Tuple[bytes, "FileFingerprint"]],
+] = {}
 _FILESYSTEM_CHECKPOINT_HOOK: Optional[Callable[[str], None]] = None
 _EN_REPLACEMENTS = (
     ("未找到 codex-keysmith 部署清单；无需卸载。", "No codex-keysmith deployment manifest was found; nothing to uninstall."),
@@ -527,17 +531,19 @@ def _make_registered_transaction_dir(
         break
     try:
         identity = _register_active_residue(transaction_dir, allowed_members)
+        _OWNED_DIRECTORY_RECORDS[str(transaction_dir)] = (identity, allowed_members)
+        _fsync_directory(parent)
     except BaseException:
         try:
             identity = _directory_identity(transaction_dir)
             _safe_remove_owned_directory(transaction_dir, identity, set())
+            _OWNED_DIRECTORY_RECORDS.pop(str(transaction_dir), None)
         except BaseException as cleanup_exc:
             _print(
                 f"[事务警告] 临时事务目录清理失败，已保留证据: {cleanup_exc}",
                 file=sys.stderr,
             )
         raise
-    _OWNED_DIRECTORY_RECORDS[str(transaction_dir)] = (identity, allowed_members)
     return transaction_dir, identity
 
 
@@ -679,7 +685,7 @@ def resolve_codex_dir(
     reject_residue: bool = True,
 ) -> Path:
     """Resolve and validate a user-supplied Codex directory."""
-    codex_root = Path(value).expanduser().resolve()
+    codex_root = _FILESYSTEM.resolve_directory(Path(value))
     if not codex_root.is_dir():
         raise FileNotFoundError(
             _localized(
@@ -736,7 +742,7 @@ def _codex_dir_candidates() -> List[Path]:
 def _resolve_candidate_directory(candidate: Path) -> Optional[Path]:
     """Resolve an accessible candidate directory without aborting discovery."""
     try:
-        codex_root = candidate.expanduser().resolve()
+        codex_root = _FILESYSTEM.resolve_directory(candidate)
         if not codex_root.is_dir():
             return None
     except OSError:
@@ -968,6 +974,9 @@ class _PosixFilesystemBackend:
         os.mkdir(path, 0o700)
         os.chmod(path, 0o700)
 
+    def resolve_directory(self, path: Path) -> Path:
+        return path.expanduser().resolve()
+
     def create_private_file(self, path: Path, deny_delete: bool = False) -> int:
         del deny_delete
         flags = (
@@ -993,6 +1002,31 @@ class _PosixFilesystemBackend:
             raise HooksConflict(f"private filesystem node has broad mode {oct(mode)}: {path}")
         if mode & expected != expected:
             raise HooksConflict(f"private filesystem node lacks owner access: {path}")
+
+    def verify_recovery_directory_security(self, path: Path) -> None:
+        del path
+
+    def read_verified_recovery_directory(
+        self,
+        path: Path,
+    ) -> Dict[str, Tuple[bytes, FileFingerprint]]:
+        result = {}
+        for name in self.list_directory_names(path):
+            member = path / name
+            content, fingerprint = _read_regular_bytes_with_fingerprint(
+                member,
+                "recovery evidence",
+            )
+            result[name] = (content, fingerprint)
+        return result
+
+    def open_verified_empty_private_directory(
+        self,
+        path: Path,
+        expected_identity: FileIdentity,
+    ) -> _OwnedDirectoryAccess:
+        self.verify_private_security(path, is_directory=True)
+        return self.open_verified_owned_directory(path, expected_identity, {}, True)
 
     def set_file_times(self, path: Path, atime_ns: int, mtime_ns: int) -> None:
         os.utime(
@@ -1345,6 +1379,8 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
     _ERROR_FILE_EXISTS = 80
     _ERROR_ALREADY_EXISTS = 183
     _ERROR_NO_MORE_FILES = 18
+    _MOVEFILE_REPLACE_EXISTING = 0x00000001
+    _MOVEFILE_WRITE_THROUGH = 0x00000008
     _WAIT_OBJECT_0 = 0
     _WAIT_ABANDONED = 0x00000080
     _INFINITE = 0xFFFFFFFF
@@ -1695,6 +1731,42 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
             expected = "directory" if is_directory else "regular file"
             raise HooksConflict(f"filesystem node is not a {expected}: {path}")
 
+    def _open_directory_components(self, path: Path) -> Tuple[Path, List[int]]:
+        absolute = Path(os.path.abspath(str(path.expanduser())))
+        parts = absolute.parts
+        if not parts:
+            raise FileNotFoundError(str(path))
+        current = Path(parts[0])
+        components = [current]
+        for part in parts[1:]:
+            current /= part
+            components.append(current)
+        canonical = absolute
+        handles = []
+        try:
+            for index, component in enumerate(components):
+                handle = self._open_handle(
+                    component,
+                    self._FILE_READ_ATTRIBUTES,
+                    share_mode=self._FILE_SHARE_READ | self._FILE_SHARE_WRITE,
+                )
+                handles.append(handle)
+                self._validate_handle_type(handle, component, is_directory=True)
+                if index == len(components) - 1:
+                    self._validate_ntfs(handle, component)
+                    canonical = self._canonical_path(handle, component)
+        except BaseException:
+            for handle in reversed(handles):
+                self.kernel32.CloseHandle(handle)
+            raise
+        return canonical, handles
+
+    def resolve_directory(self, path: Path) -> Path:
+        canonical, handles = self._open_directory_components(path)
+        for handle in reversed(handles):
+            self.kernel32.CloseHandle(handle)
+        return canonical
+
     def _enumerate(self, handle: int, path: Path) -> Dict[str, _DirectoryEntry]:
         entries: Dict[str, _DirectoryEntry] = {}
         buffer = ctypes.create_string_buffer(65536)
@@ -1801,7 +1873,44 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
             ctypes.byref(self._security_attributes),
         ):
             self._raise_last_error("cannot create private directory", path)
-        self.verify_private_security(path, is_directory=True)
+        identity = _directory_identity(path)
+        try:
+            self.verify_private_security(path, is_directory=True)
+            self.flush_directory(path.parent)
+        except BaseException as primary:
+            def remove_created_directory() -> None:
+                handle = self._open_handle(
+                    path,
+                    self._DELETE
+                    | self._FILE_LIST_DIRECTORY
+                    | self._FILE_READ_ATTRIBUTES,
+                    share_mode=self._FILE_SHARE_READ | self._FILE_SHARE_WRITE,
+                )
+                try:
+                    self._validate_handle_type(handle, path, is_directory=True)
+                    if not self._handle_matches_portable_identity(
+                        self._handle_identity(handle),
+                        identity,
+                    ):
+                        raise HooksConflict(
+                            f"created directory identity changed: {path}"
+                        )
+                    if self._enumerate(handle, path):
+                        raise HooksConflict(
+                            f"created directory is no longer empty: {path}"
+                        )
+                    self._mark_delete(handle, path)
+                finally:
+                    self.kernel32.CloseHandle(handle)
+
+            _run_cleanup_preserving_primary(
+                primary,
+                [
+                    ("删除未持久化的私有目录", remove_created_directory),
+                    ("持久化私有目录清理", lambda: self.flush_directory(path.parent)),
+                ],
+            )
+            raise
 
     def create_private_file(self, path: Path, deny_delete: bool = False) -> int:
         handle = self._open_handle(
@@ -1821,13 +1930,33 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
                 else None
             ),
         )
-        self._validate_handle_type(handle, path, is_directory=False)
-        self._validate_ntfs(handle, path)
-        descriptor = self.msvcrt.open_osfhandle(
-            handle,
-            os.O_RDWR | getattr(os, "O_BINARY", 0),
-        )
-        return descriptor
+        try:
+            self._validate_handle_type(handle, path, is_directory=False)
+            self._validate_ntfs(handle, path)
+            descriptor = self.msvcrt.open_osfhandle(
+                handle,
+                os.O_RDWR | getattr(os, "O_BINARY", 0),
+            )
+            handle = 0
+            try:
+                self.flush_directory(path.parent)
+                return descriptor
+            except BaseException as primary:
+                raw_handle = self.msvcrt.get_osfhandle(descriptor)
+                _run_cleanup_preserving_primary(
+                    primary,
+                    [("删除未持久化的私有文件", lambda: self._mark_delete(raw_handle, path))],
+                )
+                os.close(descriptor)
+                descriptor = None
+                _run_cleanup_preserving_primary(
+                    primary,
+                    [("持久化私有文件清理", lambda: self.flush_directory(path.parent))],
+                )
+                raise
+        finally:
+            if handle:
+                self.kernel32.CloseHandle(handle)
 
     def apply_private_file_security(self, descriptor: int) -> None:
         handle = self.msvcrt.get_osfhandle(descriptor)
@@ -1842,6 +1971,113 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
         del source_stat
         self.apply_private_file_security(descriptor)
 
+    def _handle_acl(
+        self,
+        handle: int,
+        path: Path,
+    ) -> Tuple[bool, Dict[str, Tuple[int, int]]]:
+        needed = wintypes.DWORD()
+        self.advapi32.GetKernelObjectSecurity(
+            handle,
+            self._DACL_SECURITY_INFORMATION,
+            None,
+            0,
+            ctypes.byref(needed),
+        )
+        if not needed.value:
+            self._raise_last_error("cannot size private ACL", path)
+        descriptor = ctypes.create_string_buffer(needed.value)
+        if not self.advapi32.GetKernelObjectSecurity(
+            handle,
+            self._DACL_SECURITY_INFORMATION,
+            descriptor,
+            len(descriptor),
+            ctypes.byref(needed),
+        ):
+            self._raise_last_error("cannot read private ACL", path)
+        control = wintypes.WORD()
+        revision = wintypes.DWORD()
+        if not self.advapi32.GetSecurityDescriptorControl(
+            descriptor,
+            ctypes.byref(control),
+            ctypes.byref(revision),
+        ):
+            self._raise_last_error("cannot inspect private ACL control", path)
+        protected = bool(control.value & self._SE_DACL_PROTECTED)
+        dacl_present = wintypes.BOOL()
+        dacl_defaulted = wintypes.BOOL()
+        dacl = wintypes.LPVOID()
+        if not self.advapi32.GetSecurityDescriptorDacl(
+            descriptor,
+            ctypes.byref(dacl_present),
+            ctypes.byref(dacl),
+            ctypes.byref(dacl_defaulted),
+        ):
+            self._raise_last_error("cannot inspect private DACL", path)
+        if not dacl_present.value or not dacl.value:
+            raise HooksConflict(f"private ACL has no DACL: {path}")
+        acl_header = ctypes.cast(
+            dacl,
+            ctypes.POINTER(self._ACL_HEADER),
+        ).contents
+        principals: Dict[str, Tuple[int, int]] = {}
+        for index in range(int(acl_header.AceCount)):
+            ace_pointer = wintypes.LPVOID()
+            if not self.advapi32.GetAce(dacl, index, ctypes.byref(ace_pointer)):
+                self._raise_last_error("cannot inspect private ACL entry", path)
+            ace_address = int(ace_pointer.value)
+            header = ctypes.cast(
+                ace_address,
+                ctypes.POINTER(self._ACE_HEADER),
+            ).contents
+            if header.AceType != self._ACCESS_ALLOWED_ACE_TYPE:
+                raise HooksConflict(f"private ACL has a non-canonical ACE: {path}")
+            mask = ctypes.cast(
+                ace_address + ctypes.sizeof(self._ACE_HEADER),
+                ctypes.POINTER(wintypes.DWORD),
+            ).contents.value
+            sid_pointer = wintypes.LPVOID(
+                ace_address
+                + ctypes.sizeof(self._ACE_HEADER)
+                + ctypes.sizeof(wintypes.DWORD)
+            )
+            sid_string = wintypes.LPWSTR()
+            if not self.advapi32.ConvertSidToStringSidW(
+                sid_pointer,
+                ctypes.byref(sid_string),
+            ):
+                self._raise_last_error("cannot describe private ACL principal", path)
+            try:
+                sid = sid_string.value
+            finally:
+                self.kernel32.LocalFree(sid_string)
+            if sid in principals:
+                raise HooksConflict(f"private ACL repeats a principal: {path}")
+            principals[sid] = (int(mask), int(header.AceFlags))
+        return protected, principals
+
+    def _verify_handle_private_security(self, handle: int, path: Path) -> None:
+        protected, principals = self._handle_acl(handle, path)
+        if not protected:
+            raise HooksConflict(f"private ACL is not protected: {path}")
+        expected = {self._current_sid, "S-1-5-18"}
+        if set(principals) != expected or any(
+            mask != self._FILE_ALL_ACCESS or flags != 0
+            for mask, flags in principals.values()
+        ):
+            raise HooksConflict(f"private ACL grants unexpected access: {path}")
+
+    def _verify_handle_recovery_security(self, handle: int, path: Path) -> None:
+        _protected, principals = self._handle_acl(handle, path)
+        allowed = {self._current_sid, "S-1-5-18", "S-1-5-32-544"}
+        if self._current_sid not in principals or set(principals) - allowed:
+            raise HooksConflict(f"recovery ACL grants unexpected access: {path}")
+        if any(
+            mask != self._FILE_ALL_ACCESS
+            for mask, _flags in principals.values()
+        ):
+            raise HooksConflict(f"recovery ACL lacks private full control: {path}")
+
     def verify_private_security(self, path: Path, is_directory: bool) -> None:
         handle = self._open_handle(
             path,
@@ -1849,95 +2085,81 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
         )
         try:
             self._validate_handle_type(handle, path, is_directory=is_directory)
-            needed = wintypes.DWORD()
-            self.advapi32.GetKernelObjectSecurity(
-                handle,
-                self._DACL_SECURITY_INFORMATION,
-                None,
-                0,
-                ctypes.byref(needed),
-            )
-            if not needed.value:
-                self._raise_last_error("cannot size private ACL", path)
-            descriptor = ctypes.create_string_buffer(needed.value)
-            if not self.advapi32.GetKernelObjectSecurity(
-                handle,
-                self._DACL_SECURITY_INFORMATION,
-                descriptor,
-                len(descriptor),
-                ctypes.byref(needed),
-            ):
-                self._raise_last_error("cannot read private ACL", path)
-            control = wintypes.WORD()
-            revision = wintypes.DWORD()
-            if not self.advapi32.GetSecurityDescriptorControl(
-                descriptor,
-                ctypes.byref(control),
-                ctypes.byref(revision),
-            ):
-                self._raise_last_error("cannot inspect private ACL control", path)
-            if not control.value & self._SE_DACL_PROTECTED:
-                raise HooksConflict(f"private ACL is not protected: {path}")
-            dacl_present = wintypes.BOOL()
-            dacl_defaulted = wintypes.BOOL()
-            dacl = wintypes.LPVOID()
-            if not self.advapi32.GetSecurityDescriptorDacl(
-                descriptor,
-                ctypes.byref(dacl_present),
-                ctypes.byref(dacl),
-                ctypes.byref(dacl_defaulted),
-            ):
-                self._raise_last_error("cannot inspect private DACL", path)
-            if not dacl_present.value or not dacl.value:
-                raise HooksConflict(f"private ACL has no DACL: {path}")
-            acl_header = ctypes.cast(
-                dacl,
-                ctypes.POINTER(self._ACL_HEADER),
-            ).contents
-            principals: Dict[str, int] = {}
-            for index in range(int(acl_header.AceCount)):
-                ace_pointer = wintypes.LPVOID()
-                if not self.advapi32.GetAce(dacl, index, ctypes.byref(ace_pointer)):
-                    self._raise_last_error("cannot inspect private ACL entry", path)
-                ace_address = int(ace_pointer.value)
-                header = ctypes.cast(
-                    ace_address,
-                    ctypes.POINTER(self._ACE_HEADER),
-                ).contents
-                if (
-                    header.AceType != self._ACCESS_ALLOWED_ACE_TYPE
-                    or header.AceFlags != 0
-                ):
-                    raise HooksConflict(f"private ACL has a non-canonical ACE: {path}")
-                mask = ctypes.cast(
-                    ace_address + ctypes.sizeof(self._ACE_HEADER),
-                    ctypes.POINTER(wintypes.DWORD),
-                ).contents.value
-                sid_pointer = wintypes.LPVOID(
-                    ace_address
-                    + ctypes.sizeof(self._ACE_HEADER)
-                    + ctypes.sizeof(wintypes.DWORD)
-                )
-                sid_string = wintypes.LPWSTR()
-                if not self.advapi32.ConvertSidToStringSidW(
-                    sid_pointer,
-                    ctypes.byref(sid_string),
-                ):
-                    self._raise_last_error("cannot describe private ACL principal", path)
-                try:
-                    sid = sid_string.value
-                finally:
-                    self.kernel32.LocalFree(sid_string)
-                if sid in principals:
-                    raise HooksConflict(f"private ACL repeats a principal: {path}")
-                principals[sid] = int(mask)
-            expected = {self._current_sid, "S-1-5-18"}
-            if set(principals) != expected or any(
-                mask != self._FILE_ALL_ACCESS for mask in principals.values()
-            ):
-                raise HooksConflict(f"private ACL grants unexpected access: {path}")
+            self._verify_handle_private_security(handle, path)
         finally:
             self.kernel32.CloseHandle(handle)
+
+    def verify_recovery_directory_security(self, path: Path) -> None:
+        self.read_verified_recovery_directory(path)
+
+    def read_verified_recovery_directory(
+        self,
+        path: Path,
+    ) -> Dict[str, Tuple[bytes, FileFingerprint]]:
+        handle = self._open_handle(
+            path,
+            self._READ_CONTROL
+            | self._FILE_LIST_DIRECTORY
+            | self._FILE_READ_ATTRIBUTES,
+            share_mode=self._FILE_SHARE_READ | self._FILE_SHARE_WRITE,
+        )
+        result: Dict[str, Tuple[bytes, FileFingerprint]] = {}
+        try:
+            self._validate_handle_type(handle, path, is_directory=True)
+            self._validate_ntfs(handle, path)
+            self._verify_handle_recovery_security(handle, path)
+            entries = self._enumerate(handle, path)
+            for entry in entries.values():
+                if entry.is_directory or entry.is_reparse:
+                    raise HooksConflict(
+                        f"recovery evidence member is not a regular file: "
+                        f"{path / entry.name}"
+                    )
+                member_path = path / entry.name
+                member_handle = self._open_handle(
+                    member_path,
+                    self._GENERIC_READ
+                    | self._READ_CONTROL
+                    | self._FILE_READ_ATTRIBUTES,
+                    share_mode=self._FILE_SHARE_READ,
+                )
+                descriptor = None
+                try:
+                    self._validate_handle_type(
+                        member_handle,
+                        member_path,
+                        is_directory=False,
+                    )
+                    self._verify_handle_recovery_security(
+                        member_handle,
+                        member_path,
+                    )
+                    if self._handle_identity(member_handle) != entry.identity:
+                        raise HooksConflict(
+                            f"recovery evidence changed while opening: {member_path}"
+                        )
+                    descriptor = self.msvcrt.open_osfhandle(
+                        member_handle,
+                        os.O_RDONLY | getattr(os, "O_BINARY", 0),
+                    )
+                    member_handle = 0
+                    before = os.fstat(descriptor)
+                    with os.fdopen(os.dup(descriptor), "rb") as stream:
+                        content = stream.read()
+                    fingerprint = _fingerprint_descriptor(
+                        descriptor,
+                        before,
+                        member_path,
+                    )
+                    result[entry.name] = (content, fingerprint)
+                finally:
+                    if descriptor is not None:
+                        os.close(descriptor)
+                    elif member_handle:
+                        self.kernel32.CloseHandle(member_handle)
+        finally:
+            self.kernel32.CloseHandle(handle)
+        return result
 
     @staticmethod
     def _filetime(value_ns: int) -> wintypes.FILETIME:
@@ -2005,6 +2227,7 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
         try:
             self._validate_handle_type(handle, path, is_directory=True)
             self._validate_ntfs(handle, path)
+            self._verify_handle_recovery_security(handle, path)
             identity = self._handle_identity(handle)
             path_identity = _directory_identity(path)
             if (
@@ -2025,8 +2248,8 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
                     raise HooksConflict(
                         f"事务目录成员不是普通文件，保留证据: {path / name}"
                     )
+                actual = self._fingerprint_member(path, entry, delete_access=False)
                 if expected_members[name] is not None:
-                    actual = self._fingerprint_member(path, entry, delete_access=False)
                     self._validate_expected_fingerprint(
                         path / name,
                         actual,
@@ -2043,19 +2266,61 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
             self.kernel32.CloseHandle(handle)
             raise
 
+    def open_verified_empty_private_directory(
+        self,
+        path: Path,
+        expected_identity: FileIdentity,
+    ) -> _OwnedDirectoryAccess:
+        handle = self._open_handle(
+            path,
+            self._GENERIC_READ
+            | self._GENERIC_WRITE
+            | self._DELETE
+            | self._READ_CONTROL
+            | self._FILE_LIST_DIRECTORY
+            | self._FILE_READ_ATTRIBUTES
+            | self._SYNCHRONIZE,
+            share_mode=self._FILE_SHARE_READ | self._FILE_SHARE_WRITE,
+        )
+        try:
+            self._validate_handle_type(handle, path, is_directory=True)
+            self._validate_ntfs(handle, path)
+            self._verify_handle_private_security(handle, path)
+            identity = self._handle_identity(handle)
+            path_identity = _directory_identity(path)
+            if (
+                not self._handle_matches_portable_identity(identity, expected_identity)
+                or path_identity != expected_identity
+            ):
+                raise HooksConflict(f"empty journal identity changed: {path}")
+            entries = self._enumerate(handle, path)
+            if entries:
+                raise HooksConflict(f"empty journal acquired members: {path}")
+            return _OwnedDirectoryAccess(
+                path=path,
+                identity=identity,
+                names=set(),
+                handle=handle,
+                entries=entries,
+            )
+        except BaseException:
+            self.kernel32.CloseHandle(handle)
+            raise
+
     def _fingerprint_member(
         self,
         parent: Path,
         entry: _DirectoryEntry,
         delete_access: bool,
     ) -> FileFingerprint:
-        access = self._GENERIC_READ | self._FILE_READ_ATTRIBUTES
+        access = self._GENERIC_READ | self._READ_CONTROL | self._FILE_READ_ATTRIBUTES
         if delete_access:
             access |= self._DELETE
         handle = self._open_handle(parent / entry.name, access)
         descriptor = None
         try:
             self._validate_handle_type(handle, parent / entry.name, is_directory=False)
+            self._verify_handle_recovery_security(handle, parent / entry.name)
             if self._handle_identity(handle) != entry.identity:
                 raise HooksConflict(f"事务目录成员在打开期间变化: {parent / entry.name}")
             descriptor = self.msvcrt.open_osfhandle(
@@ -2106,11 +2371,15 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
             raise HooksConflict(f"事务目录成员在删除前变化: {access.path / name}")
         handle = self._open_handle(
             access.path / name,
-            self._GENERIC_READ | self._FILE_READ_ATTRIBUTES | self._DELETE,
+            self._GENERIC_READ
+            | self._READ_CONTROL
+            | self._FILE_READ_ATTRIBUTES
+            | self._DELETE,
         )
         descriptor = None
         try:
             self._validate_handle_type(handle, access.path / name, is_directory=False)
+            self._verify_handle_recovery_security(handle, access.path / name)
             if self._handle_identity(handle) != entry.identity:
                 raise HooksConflict(f"事务目录成员在删除前变化: {access.path / name}")
             descriptor = self.msvcrt.open_osfhandle(
@@ -2138,6 +2407,7 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
             raise HooksConflict(f"事务目录成员删除后仍存在: {access.path / name}")
         access.entries = entries
         access.names = set(entries)
+        self.flush_directory(access.path)
 
     def remove_verified_file(
         self,
@@ -2147,12 +2417,16 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
     ) -> None:
         handle = self._open_handle(
             path,
-            self._GENERIC_READ | self._FILE_READ_ATTRIBUTES | self._DELETE,
+            self._GENERIC_READ
+            | self._READ_CONTROL
+            | self._FILE_READ_ATTRIBUTES
+            | self._DELETE,
             share_mode=self._FILE_SHARE_READ | self._FILE_SHARE_WRITE,
         )
         descriptor = None
         try:
             self._validate_handle_type(handle, path, is_directory=False)
+            self._verify_handle_recovery_security(handle, path)
             if not self._handle_matches_portable_identity(
                 self._handle_identity(handle),
                 expected_identity,
@@ -2175,6 +2449,7 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
                 self.kernel32.CloseHandle(handle)
         if _path_entry_exists(path):
             raise HooksConflict(f"待删除文件删除后仍存在，保留证据: {path}")
+        self.flush_directory(path.parent)
 
     def flush_owned_directory(self, access: _OwnedDirectoryAccess) -> None:
         if access.handle is None:
@@ -2199,6 +2474,7 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
         self.close_owned_directory(access)
         if _path_entry_exists(access.path):
             raise HooksConflict(f"事务目录删除后仍存在: {access.path}")
+        self.flush_directory(access.path.parent)
 
     def list_directory_names(self, path: Path) -> set:
         handle = self._open_handle(
@@ -2212,7 +2488,14 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
             self.kernel32.CloseHandle(handle)
 
     def atomic_rename_no_replace(self, source: Path, destination: Path) -> bool:
-        if self.kernel32.MoveFileExW(self._path(source), self._path(destination), 0):
+        if self.kernel32.MoveFileExW(
+            self._path(source),
+            self._path(destination),
+            self._MOVEFILE_WRITE_THROUGH,
+        ):
+            self.flush_directory(source.parent)
+            if destination.parent != source.parent:
+                self.flush_directory(destination.parent)
             return True
         error = ctypes.get_last_error()
         if error in {self._ERROR_FILE_EXISTS, self._ERROR_ALREADY_EXISTS}:
@@ -2221,13 +2504,16 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
         return False
 
     def replace_atomic(self, source: Path, destination: Path) -> None:
-        flags = 0x00000001 | 0x00000008
+        flags = self._MOVEFILE_REPLACE_EXISTING | self._MOVEFILE_WRITE_THROUGH
         if not self.kernel32.MoveFileExW(
             self._path(source),
             self._path(destination),
             flags,
         ):
             self._raise_last_error("atomic replace failed", destination)
+        self.flush_directory(source.parent)
+        if destination.parent != source.parent:
+            self.flush_directory(destination.parent)
 
     def _canonical_path(self, handle: int, fallback: Path) -> Path:
         length = self.kernel32.GetFinalPathNameByHandleW(handle, None, 0, 0)
@@ -2244,51 +2530,33 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
         return Path(value)
 
     def directory_lock_key(self, path: Path) -> Tuple[Tuple[Any, ...], Path]:
-        handle = self._open_handle(
-            path,
-            self._FILE_LIST_DIRECTORY | self._FILE_READ_ATTRIBUTES,
-        )
+        canonical, handles = self._open_directory_components(path)
+        handle = handles[-1]
         try:
-            self._validate_handle_type(handle, path, is_directory=True)
-            self._validate_ntfs(handle, path)
             identity = self._handle_identity(handle)
-            canonical = self._canonical_path(handle, path)
-            key = (
-                identity.device,
-                identity.inode,
-                os.path.normcase(str(canonical)),
-            )
+            key = (identity.device, identity.inode)
             return key, canonical
         finally:
-            self.kernel32.CloseHandle(handle)
+            for component_handle in reversed(handles):
+                self.kernel32.CloseHandle(component_handle)
 
-    def pin_directory_for_lock(self, path: Path, key: Tuple[Any, ...]) -> int:
-        handle = self._open_handle(
-            path,
-            self._FILE_LIST_DIRECTORY
-            | self._FILE_READ_ATTRIBUTES
-            | self._SYNCHRONIZE,
-            share_mode=self._FILE_SHARE_READ | self._FILE_SHARE_WRITE,
-        )
+    def pin_directory_for_lock(self, path: Path, key: Tuple[Any, ...]) -> List[int]:
+        _canonical, handles = self._open_directory_components(path)
+        handle = handles[-1]
         try:
-            self._validate_handle_type(handle, path, is_directory=True)
-            self._validate_ntfs(handle, path)
             identity = self._handle_identity(handle)
-            canonical = self._canonical_path(handle, path)
-            current_key = (
-                identity.device,
-                identity.inode,
-                os.path.normcase(str(canonical)),
-            )
+            current_key = (identity.device, identity.inode)
             if current_key != key:
                 raise HooksConflict(f"锁定目录在加锁期间被替换: {path}")
-            return handle
+            return handles
         except BaseException:
-            self.kernel32.CloseHandle(handle)
+            for component_handle in reversed(handles):
+                self.kernel32.CloseHandle(component_handle)
             raise
 
-    def release_pinned_directory(self, token: int) -> None:
-        self.kernel32.CloseHandle(token)
+    def release_pinned_directory(self, token: List[int]) -> None:
+        for handle in reversed(token):
+            self.kernel32.CloseHandle(handle)
 
     def acquire_directory_lock(self, key: Tuple[Any, ...]) -> int:
         digest = hashlib.sha256(repr(key).encode("utf-8")).hexdigest()
@@ -3281,6 +3549,7 @@ def _create_deployment_journals(
                 _portable_identity(state.journal_identity)
             )
             state.journal_data = journal_data
+            _fsync_directory(state.codex_dir)
 
         for state in states:
             journal_dir = state.journal_dir
@@ -3321,15 +3590,21 @@ def _create_deployment_journals(
                         raise HooksConflict(
                             f"初始化失败的 journal 缺少所有权记录: {state.journal_dir}"
                         )
-                    _safe_remove_owned_directory(
-                        state.journal_dir,
-                        state.journal_identity,
-                        _journal_expected_members(
+                    initializing_empty = not any(state.journal_dir.iterdir())
+                    expected_members = (
+                        {}
+                        if initializing_empty
+                        else _journal_expected_members(
                             state.journal_data,
                             str(state.codex_dir.resolve()),
                             state.journal_dir,
                             require_all_snapshots=False,
-                        ),
+                        )
+                    )
+                    _safe_remove_owned_directory(
+                        state.journal_dir,
+                        state.journal_identity,
+                        expected_members,
                         require_exact_members=True,
                     )
                     _fsync_directory(state.codex_dir)
@@ -3795,6 +4070,23 @@ def _cleanup_transaction_dir_after_error(transaction_dir: Path) -> None:
         _print(f"[事务警告] {exc}", file=sys.stderr)
 
 
+def _run_cleanup_preserving_primary(
+    primary_exception: BaseException,
+    steps: List[Tuple[str, Callable[[], None]]],
+) -> None:
+    """Run best-effort cleanup without replacing the operation's primary error."""
+    for label, action in steps:
+        try:
+            action()
+        except BaseException as cleanup_exception:
+            _print(
+                "[事务警告] "
+                f"{label} 失败；保留原始异常 {primary_exception!r}；"
+                f"cleanup 异常: {cleanup_exception!r}",
+                file=sys.stderr,
+            )
+
+
 def _copy_to_unique_backup(
     source: Path,
     original_path: Path,
@@ -4062,29 +4354,42 @@ def _rollback_owned_file(
             raise HooksConflict(f"无法原子认领待回滚文件: {destination}")
         claimed_fingerprint = _fingerprint_regular_file(installed_claim)
         if claimed_fingerprint != installed_fingerprint:
-            _rollback_claim(installed_claim, destination, timestamp)
             raise HooksConflict(f"待回滚文件已被并发替换: {destination}")
         claim_verified = True
 
         if backup:
-            try:
-                restored = _copy_file_no_replace(backup, destination)
-            except BaseException:
-                _rollback_claim(installed_claim, destination, timestamp)
-                raise
+            restored = _copy_file_no_replace(backup, destination)
             if not restored:
-                installed_claim.unlink()
-                raise HooksConflict(f"回滚目标被并发创建，已保留当前文件: {destination}")
+                primary = HooksConflict(
+                    f"回滚目标被并发创建，已保留当前文件: {destination}"
+                )
+                _run_cleanup_preserving_primary(
+                    primary,
+                    [("删除已认领的回滚文件", installed_claim.unlink)],
+                )
+                raise primary
 
         installed_claim.unlink()
         _cleanup_transaction_dir_after_error(transaction_dir)
-    except BaseException:
-        if _path_entry_exists(installed_claim):
+    except BaseException as primary:
+        def cleanup_claim() -> None:
+            if not _path_entry_exists(installed_claim):
+                return
             if claim_verified and _path_entry_exists(destination):
                 installed_claim.unlink()
             else:
                 _rollback_claim(installed_claim, destination, timestamp)
-        _cleanup_transaction_dir_after_error(transaction_dir)
+
+        _run_cleanup_preserving_primary(
+            primary,
+            [
+                ("回滚已认领文件", cleanup_claim),
+                (
+                    "清理文件回滚事务目录",
+                    lambda: _cleanup_transaction_dir_after_error(transaction_dir),
+                ),
+            ],
+        )
         raise
 
 
@@ -4236,29 +4541,55 @@ def isolate_hooks(
             isolated_fingerprint=active_fingerprint,
             previous_disabled_backup=previous_disabled_backup,
         )
-    except BaseException:
-        if published and active_fingerprint and _path_has_fingerprint(
-            disabled_path,
-            active_fingerprint,
-        ) and not _path_entry_exists(hooks_path):
-            _atomic_rename_no_replace(disabled_path, hooks_path)
-        elif published:
-            if _path_entry_exists(disabled_path):
-                _move_to_unique_recovery(disabled_path, hooks_path, timestamp)
-            if hooks_backup and not _path_entry_exists(hooks_path):
-                _copy_file_no_replace(
-                    hooks_backup,
-                    hooks_path,
-                    expected_content=active_fingerprint,
-                )
-        else:
-            _rollback_claim(active_claim, hooks_path, timestamp)
+    except BaseException as primary:
+        def restore_active() -> None:
+            if published and active_fingerprint and _path_has_fingerprint(
+                disabled_path,
+                active_fingerprint,
+            ) and not _path_entry_exists(hooks_path):
+                if not _atomic_rename_no_replace(disabled_path, hooks_path):
+                    raise HooksConflict(
+                        f"cleanup could not restore hooks.json: {hooks_path}"
+                    )
+            elif published:
+                if _path_entry_exists(disabled_path):
+                    _move_to_unique_recovery(disabled_path, hooks_path, timestamp)
+                if hooks_backup and not _path_entry_exists(hooks_path):
+                    if not _copy_file_no_replace(
+                        hooks_backup,
+                        hooks_path,
+                        expected_content=active_fingerprint,
+                    ):
+                        raise HooksConflict(
+                            f"cleanup could not copy hooks.json: {hooks_path}"
+                        )
+            else:
+                _rollback_claim(active_claim, hooks_path, timestamp)
 
-        if _path_entry_exists(disabled_claim):
-            _rollback_claim(disabled_claim, disabled_path, timestamp)
-        elif previous_disabled_backup and not _path_entry_exists(disabled_path):
-            _atomic_rename_no_replace(previous_disabled_backup, disabled_path)
-        _cleanup_transaction_dir_after_error(transaction_dir)
+        def restore_disabled() -> None:
+            if _path_entry_exists(disabled_claim):
+                _rollback_claim(disabled_claim, disabled_path, timestamp)
+            elif previous_disabled_backup and not _path_entry_exists(disabled_path):
+                if not _atomic_rename_no_replace(
+                    previous_disabled_backup,
+                    disabled_path,
+                ):
+                    raise HooksConflict(
+                        "cleanup could not restore hooks.json.disabled: "
+                        f"{disabled_path}"
+                    )
+
+        _run_cleanup_preserving_primary(
+            primary,
+            [
+                ("恢复 hooks.json", restore_active),
+                ("恢复 hooks.json.disabled", restore_disabled),
+                (
+                    "清理 hooks 隔离事务目录",
+                    lambda: _cleanup_transaction_dir_after_error(transaction_dir),
+                ),
+            ],
+        )
         raise
 
 
@@ -4283,19 +4614,11 @@ def rollback_hooks_isolation(isolation: HooksIsolation) -> None:
         )
         claimed_fingerprint = _fingerprint_regular_file(disabled_claim)
         if claimed_fingerprint != isolation.isolated_fingerprint:
-            _rollback_claim(disabled_claim, disabled_path, timestamp)
-            if not _path_entry_exists(hooks_path):
-                _copy_file_no_replace(
-                    isolation.hooks_backup,
-                    hooks_path,
-                    expected_content=isolation.isolated_fingerprint,
-                )
             raise HooksConflict(
                 f"回滚时 hooks.json.disabled 已发生变化: {disabled_path}"
             )
 
         if not _atomic_rename_no_replace(disabled_claim, hooks_path):
-            _rollback_claim(disabled_claim, disabled_path, timestamp)
             raise HooksConflict(f"回滚时 hooks.json 被并发创建: {hooks_path}")
         published = True
         if not _path_has_fingerprint(hooks_path, isolation.isolated_fingerprint):
@@ -4310,22 +4633,45 @@ def rollback_hooks_isolation(isolation: HooksIsolation) -> None:
                     f"回滚时 hooks.json.disabled 被并发创建: {disabled_path}"
                 )
         _remove_transaction_dir(transaction_dir)
-    except BaseException:
-        if not published:
-            _rollback_claim(disabled_claim, disabled_path, timestamp)
-        elif not _path_has_fingerprint(
-            hooks_path,
-            isolation.isolated_fingerprint,
-        ):
-            if _path_entry_exists(hooks_path):
-                _move_to_unique_recovery(hooks_path, hooks_path, timestamp)
-            if not _path_entry_exists(hooks_path):
-                _copy_file_no_replace(
-                    isolation.hooks_backup,
-                    hooks_path,
-                    expected_content=isolation.isolated_fingerprint,
-                )
-        _cleanup_transaction_dir_after_error(transaction_dir)
+    except BaseException as primary:
+        def restore_hooks() -> None:
+            if not published:
+                _rollback_claim(disabled_claim, disabled_path, timestamp)
+                if not _path_entry_exists(hooks_path):
+                    if not _copy_file_no_replace(
+                        isolation.hooks_backup,
+                        hooks_path,
+                        expected_content=isolation.isolated_fingerprint,
+                    ):
+                        raise HooksConflict(
+                            f"cleanup could not restore hooks.json: {hooks_path}"
+                        )
+            elif not _path_has_fingerprint(
+                hooks_path,
+                isolation.isolated_fingerprint,
+            ):
+                if _path_entry_exists(hooks_path):
+                    _move_to_unique_recovery(hooks_path, hooks_path, timestamp)
+                if not _path_entry_exists(hooks_path):
+                    if not _copy_file_no_replace(
+                        isolation.hooks_backup,
+                        hooks_path,
+                        expected_content=isolation.isolated_fingerprint,
+                    ):
+                        raise HooksConflict(
+                            f"cleanup could not copy hooks.json: {hooks_path}"
+                        )
+
+        _run_cleanup_preserving_primary(
+            primary,
+            [
+                ("恢复 hooks 回滚状态", restore_hooks),
+                (
+                    "清理 hooks 回滚事务目录",
+                    lambda: _cleanup_transaction_dir_after_error(transaction_dir),
+                ),
+            ],
+        )
         raise
 
 
@@ -4604,16 +4950,15 @@ def archive_legacy_file(
     )
     legacy_claim = transaction_dir / "legacy"
     archive = None
+    archive_validated = False
     try:
         if not _atomic_rename_no_replace(legacy_path, legacy_claim):
             raise HooksConflict(f"无法原子认领旧版文件: {legacy_path}")
         claimed_fingerprint = _fingerprint_regular_file(legacy_claim)
         if claimed_fingerprint != expected_fingerprint:
-            _rollback_claim(legacy_claim, legacy_path, timestamp)
             raise HooksConflict(f"旧版文件在预检后发生变化: {legacy_path}")
         config_path = state.codex_dir / "config.toml"
         if not _path_has_fingerprint(config_path, expected_config_fingerprint):
-            _rollback_claim(legacy_claim, legacy_path, timestamp)
             raise HooksConflict(f"config.toml 在旧版文件认领后发生变化: {config_path}")
 
         archive = _move_to_unique_backup(
@@ -4623,20 +4968,34 @@ def archive_legacy_file(
             expected_fingerprint.identity,
         )
         if not _path_has_fingerprint(archive, expected_fingerprint):
-            if not _path_entry_exists(legacy_path):
-                _atomic_rename_no_replace(archive, legacy_path)
-            elif _path_entry_exists(archive):
-                _move_to_unique_recovery(archive, legacy_path, timestamp)
             raise HooksConflict(f"旧版文件归档后发生变化: {archive}")
+        archive_validated = True
 
         state.legacy_fingerprint = expected_fingerprint
         state.legacy_backup = archive
         _remove_transaction_dir(transaction_dir)
         return archive
-    except BaseException:
-        if _path_entry_exists(legacy_claim):
-            _rollback_claim(legacy_claim, legacy_path, timestamp)
-        _cleanup_transaction_dir_after_error(transaction_dir)
+    except BaseException as primary:
+        def restore_legacy() -> None:
+            if _path_entry_exists(legacy_claim):
+                _rollback_claim(legacy_claim, legacy_path, timestamp)
+            elif archive and not archive_validated and _path_entry_exists(archive):
+                if not _path_entry_exists(legacy_path):
+                    if not _atomic_rename_no_replace(archive, legacy_path):
+                        _move_to_unique_recovery(archive, legacy_path, timestamp)
+                else:
+                    _move_to_unique_recovery(archive, legacy_path, timestamp)
+
+        _run_cleanup_preserving_primary(
+            primary,
+            [
+                ("恢复旧版提示词归档", restore_legacy),
+                (
+                    "清理旧版提示词事务目录",
+                    lambda: _cleanup_transaction_dir_after_error(transaction_dir),
+                ),
+            ],
+        )
         raise
 
 
@@ -5263,11 +5622,21 @@ def _validate_canonical_residue(
             )
 
 
-def _load_cleanup_intent(path: Path) -> Tuple[Dict[str, Any], FileFingerprint]:
-    content, fingerprint = _read_regular_text_with_fingerprint(
-        path,
-        "deployment cleanup intent",
-    )
+def _load_cleanup_intent(
+    path: Path,
+    record: Optional[Tuple[bytes, FileFingerprint]] = None,
+) -> Tuple[Dict[str, Any], FileFingerprint]:
+    if record is None:
+        content, fingerprint = _read_regular_text_with_fingerprint(
+            path,
+            "deployment cleanup intent",
+        )
+    else:
+        raw, fingerprint = record
+        try:
+            content = raw.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError(f"deployment cleanup intent 不是 UTF-8: {path}") from exc
     try:
         data = json.loads(content)
     except json.JSONDecodeError as exc:
@@ -5386,7 +5755,16 @@ def _finish_cleanup_intent_artifact(
         CLEANUP_MARKER_SUFFIX
     )
     intent_path = path if marker_mode else path / INTENT_FILENAME
-    intent, fingerprint = _load_cleanup_intent(intent_path)
+    if marker_mode:
+        intent, fingerprint = _load_cleanup_intent(intent_path)
+        verified_names = None
+    else:
+        evidence = _FILESYSTEM.read_verified_recovery_directory(path)
+        intent_record = evidence.get(INTENT_FILENAME)
+        if intent_record is None:
+            raise HooksConflict(f"cleanup directory lost its intent: {path}")
+        intent, fingerprint = _load_cleanup_intent(intent_path, intent_record)
+        verified_names = set(evidence)
     transaction_id = intent["transaction_id"]
     owner = intent_path.parent if marker_mode else path.parent
     owner_key = str(owner.resolve())
@@ -5425,7 +5803,11 @@ def _finish_cleanup_intent_artifact(
     if not marker_mode:
         if cleanup_dir is None or _directory_identity(cleanup_dir) != expected_identity:
             raise HooksConflict(f"cleanup 目录 identity 已变化: {cleanup_dir}")
-        names = _FILESYSTEM.list_directory_names(cleanup_dir)
+        names = (
+            verified_names
+            if cleanup_dir == path and verified_names is not None
+            else _FILESYSTEM.list_directory_names(cleanup_dir)
+        )
         allowed = {INTENT_FILENAME, MANIFEST_INTENT_FILENAME}
         if not names <= allowed or INTENT_FILENAME not in names:
             raise HooksConflict(f"cleanup 目录包含未授权成员: {cleanup_dir}")
@@ -5558,8 +5940,13 @@ def _recover_cleanup_artifacts(
                 _print(f"[恢复] 发现事务 journal cleanup 目录: {journal}")
                 actions.append(("journal", journal, data))
             elif _is_regular_path(journal / INTENT_FILENAME):
+                evidence = _FILESYSTEM.read_verified_recovery_directory(journal)
+                intent_record = evidence.get(INTENT_FILENAME)
+                if intent_record is None:
+                    raise HooksConflict(f"cleanup intent disappeared: {journal}")
                 intent, _fingerprint = _load_cleanup_intent(
-                    journal / INTENT_FILENAME
+                    journal / INTENT_FILENAME,
+                    intent_record,
                 )
                 if cleanup_intent is None:
                     cleanup_intent = intent
@@ -5757,14 +6144,33 @@ def _remove_retained_cleanup_markers(
         _fsync_directory(marker.parent)
 
 
+def _recovery_member_text(
+    evidence: Dict[str, Tuple[bytes, FileFingerprint]],
+    journal_dir: Path,
+    name: str,
+    label: str,
+) -> Tuple[str, FileFingerprint]:
+    record = evidence.get(name)
+    if record is None:
+        raise FileNotFoundError(f"{label} is missing: {journal_dir / name}")
+    content, fingerprint = record
+    try:
+        return content.decode("utf-8"), fingerprint
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"{label} is not UTF-8: {journal_dir / name}") from exc
+
+
 def _load_deployment_journal(journal_dir: Path) -> Dict[str, Any]:
+    evidence = _FILESYSTEM.read_verified_recovery_directory(journal_dir)
+    _LOADED_RECOVERY_EVIDENCE[str(journal_dir)] = evidence
     node = _classify_node(journal_dir)
     if node.kind != "directory":
         raise ValueError(f"恢复事务节点是 {node.kind}，不是目录: {journal_dir}")
     journal_path = journal_dir / JOURNAL_FILENAME
-    pending_path = journal_dir / JOURNAL_PENDING_FILENAME
-    content, _fingerprint = _read_regular_text_with_fingerprint(
-        journal_path,
+    content, _fingerprint = _recovery_member_text(
+        evidence,
+        journal_dir,
+        JOURNAL_FILENAME,
         "部署恢复日志",
     )
     try:
@@ -5772,9 +6178,11 @@ def _load_deployment_journal(journal_dir: Path) -> Dict[str, Any]:
     except json.JSONDecodeError as exc:
         raise ValueError(f"部署恢复日志不是有效 JSON: {journal_dir}") from exc
     base_data = data
-    if _path_entry_exists(pending_path):
-        pending_content, pending_fingerprint = _read_regular_text_with_fingerprint(
-            pending_path,
+    if JOURNAL_PENDING_FILENAME in evidence:
+        pending_content, pending_fingerprint = _recovery_member_text(
+            evidence,
+            journal_dir,
+            JOURNAL_PENDING_FILENAME,
             "部署恢复日志 pending",
         )
         try:
@@ -5959,8 +6367,10 @@ def _load_deployment_journal(journal_dir: Path) -> Dict[str, Any]:
         "journal owner",
     ):
         raise ValueError(f"部署恢复日志目录 identity 不匹配: {journal_dir}")
-    intent_content, _intent_fingerprint = _read_regular_text_with_fingerprint(
-        journal_dir / INTENT_FILENAME,
+    intent_content, _intent_fingerprint = _recovery_member_text(
+        evidence,
+        journal_dir,
+        INTENT_FILENAME,
         "immutable deployment intent",
     )
     try:
@@ -5970,9 +6380,8 @@ def _load_deployment_journal(journal_dir: Path) -> Dict[str, Any]:
     if intent != _immutable_journal_intent(data):
         raise ValueError(f"部署 journal 与 immutable intent 不一致: {journal_dir}")
     companion_path = journal_dir / MANIFEST_INTENT_FILENAME
-    companion_exists = _path_entry_exists(companion_path)
-    companion_pending_path = journal_dir / MANIFEST_INTENT_PENDING_FILENAME
-    companion_pending_exists = _path_entry_exists(companion_pending_path)
+    companion_exists = MANIFEST_INTENT_FILENAME in evidence
+    companion_pending_exists = MANIFEST_INTENT_PENDING_FILENAME in evidence
     if companion_exists and companion_pending_exists:
         raise ValueError(f"manifest intent 与 pending 同时存在: {journal_dir}")
     phase_requires_companion = data["phase"] in {
@@ -5982,22 +6391,22 @@ def _load_deployment_journal(journal_dir: Path) -> Dict[str, Any]:
     }
     companion = None
     if companion_exists:
-        companion_content, _companion_fingerprint = (
-            _read_regular_text_with_fingerprint(
-                companion_path,
-                "manifest intent",
-            )
+        companion_content, _companion_fingerprint = _recovery_member_text(
+            evidence,
+            journal_dir,
+            MANIFEST_INTENT_FILENAME,
+            "manifest intent",
         )
         try:
             companion = json.loads(companion_content)
         except json.JSONDecodeError as exc:
             raise ValueError(f"manifest intent 无效: {journal_dir}") from exc
     elif companion_pending_exists:
-        companion_content, companion_pending_fingerprint = (
-            _read_regular_text_with_fingerprint(
-                companion_pending_path,
-                "manifest intent pending",
-            )
+        companion_content, companion_pending_fingerprint = _recovery_member_text(
+            evidence,
+            journal_dir,
+            MANIFEST_INTENT_PENDING_FILENAME,
+            "manifest intent pending",
         )
         try:
             companion = json.loads(companion_content)
@@ -6042,8 +6451,11 @@ def _load_deployment_journal(journal_dir: Path) -> Dict[str, Any]:
 
 
 def _journal_operation(journal_dir: Path) -> str:
-    content, _fingerprint = _read_regular_text_with_fingerprint(
-        journal_dir / JOURNAL_FILENAME,
+    evidence = _FILESYSTEM.read_verified_recovery_directory(journal_dir)
+    content, _fingerprint = _recovery_member_text(
+        evidence,
+        journal_dir,
+        JOURNAL_FILENAME,
         "transaction journal",
     )
     try:
@@ -6057,13 +6469,16 @@ def _journal_operation(journal_dir: Path) -> str:
 
 
 def _load_uninstall_journal(journal_dir: Path) -> Dict[str, Any]:
+    evidence = _FILESYSTEM.read_verified_recovery_directory(journal_dir)
+    _LOADED_RECOVERY_EVIDENCE[str(journal_dir)] = evidence
     node = _classify_node(journal_dir)
     if node.kind != "directory":
         raise ValueError(f"卸载恢复事务节点是 {node.kind}: {journal_dir}")
     journal_path = journal_dir / JOURNAL_FILENAME
-    pending_path = journal_dir / JOURNAL_PENDING_FILENAME
-    content, _fingerprint = _read_regular_text_with_fingerprint(
-        journal_path,
+    content, _fingerprint = _recovery_member_text(
+        evidence,
+        journal_dir,
+        JOURNAL_FILENAME,
         "卸载恢复日志",
     )
     try:
@@ -6071,9 +6486,11 @@ def _load_uninstall_journal(journal_dir: Path) -> Dict[str, Any]:
     except json.JSONDecodeError as exc:
         raise ValueError(f"卸载恢复日志不是有效 JSON: {journal_dir}") from exc
     base_data = data
-    if _path_entry_exists(pending_path):
-        pending_content, pending_fingerprint = _read_regular_text_with_fingerprint(
-            pending_path,
+    if JOURNAL_PENDING_FILENAME in evidence:
+        pending_content, pending_fingerprint = _recovery_member_text(
+            evidence,
+            journal_dir,
+            JOURNAL_PENDING_FILENAME,
             "卸载恢复日志 pending",
         )
         try:
@@ -6269,8 +6686,10 @@ def _load_uninstall_journal(journal_dir: Path) -> Dict[str, Any]:
         "uninstall journal owner",
     ):
         raise ValueError(f"卸载恢复日志目录 identity 不匹配: {journal_dir}")
-    intent_content, _intent_fingerprint = _read_regular_text_with_fingerprint(
-        journal_dir / INTENT_FILENAME,
+    intent_content, _intent_fingerprint = _recovery_member_text(
+        evidence,
+        journal_dir,
+        INTENT_FILENAME,
         "immutable uninstall intent",
     )
     try:
@@ -6279,7 +6698,7 @@ def _load_uninstall_journal(journal_dir: Path) -> Dict[str, Any]:
         raise ValueError(f"immutable uninstall intent 无效: {journal_dir}") from exc
     if intent != _immutable_journal_intent(data):
         raise ValueError(f"卸载 journal 与 immutable intent 不一致: {journal_dir}")
-    if _path_entry_exists(journal_dir / MANIFEST_INTENT_FILENAME):
+    if MANIFEST_INTENT_FILENAME in evidence:
         raise ValueError(f"卸载 journal 不应包含 manifest companion: {journal_dir}")
     return data
 
@@ -6289,12 +6708,15 @@ def _load_initializing_uninstall_pending(
     expected_intent: Dict[str, Any],
 ) -> Dict[str, Any]:
     """Validate the first durable journal write before its atomic publication."""
+    evidence = _FILESYSTEM.read_verified_recovery_directory(journal_dir)
+    _LOADED_RECOVERY_EVIDENCE[str(journal_dir)] = evidence
     journal_path = journal_dir / JOURNAL_FILENAME
-    pending_path = journal_dir / JOURNAL_PENDING_FILENAME
-    if _path_entry_exists(journal_path):
+    if JOURNAL_FILENAME in evidence:
         raise ValueError(f"initializing uninstall journal is already published: {journal_dir}")
-    content, pending_fingerprint = _read_regular_text_with_fingerprint(
-        pending_path,
+    content, pending_fingerprint = _recovery_member_text(
+        evidence,
+        journal_dir,
+        JOURNAL_PENDING_FILENAME,
         "initializing uninstall journal pending",
     )
     try:
@@ -6362,14 +6784,20 @@ def _load_initializing_uninstall_pending(
         raise ValueError(
             f"initializing uninstall journal directory identity changed: {journal_dir}"
         )
+    intent_record = evidence.get(INTENT_FILENAME)
+    if intent_record is None:
+        raise ValueError(
+            f"initializing uninstall journal lost its immutable intent: {journal_dir}"
+        )
     intent, _intent_fingerprint = _load_cleanup_intent(
-        journal_dir / INTENT_FILENAME
+        journal_dir / INTENT_FILENAME,
+        intent_record,
     )
     if intent != expected_intent:
         raise ValueError(
             f"initializing uninstall intent changed before journal publication: {journal_dir}"
         )
-    if _path_entry_exists(journal_dir / MANIFEST_INTENT_FILENAME):
+    if MANIFEST_INTENT_FILENAME in evidence:
         raise ValueError(
             f"initializing uninstall journal contains a manifest companion: {journal_dir}"
         )
@@ -6518,6 +6946,16 @@ def _validate_recovery_snapshot(
     if snapshot_name is None:
         raise HooksConflict("恢复日志缺少原文件快照")
     snapshot = journal_dir / snapshot_name
+    verified = _LOADED_RECOVERY_EVIDENCE.get(str(journal_dir), {}).get(snapshot_name)
+    if verified is not None:
+        _content, fingerprint = verified
+        if (
+            fingerprint.size != before["size"]
+            or fingerprint.modified_ns != before["mtime_ns"]
+            or fingerprint.sha256 != before["sha256"]
+        ):
+            raise HooksConflict(f"恢复快照已漂移: {snapshot}")
+        return fingerprint
     if not _portable_matches(snapshot, before):
         raise HooksConflict(f"恢复快照已漂移: {snapshot}")
     return _fingerprint_regular_file(snapshot)
@@ -6953,7 +7391,15 @@ def _recover_uninstall(codex_dirs: List[str], yes: bool) -> None:
             intents.append(_immutable_journal_intent(data))
             continue
         if _is_regular_path(path / INTENT_FILENAME):
-            intent, _fingerprint = _load_cleanup_intent(path / INTENT_FILENAME)
+            evidence = _FILESYSTEM.read_verified_recovery_directory(path)
+            _LOADED_RECOVERY_EVIDENCE[str(path)] = evidence
+            intent_record = evidence.get(INTENT_FILENAME)
+            if intent_record is None:
+                raise HooksConflict(f"恢复范围中的 immutable intent 已变化: {path}")
+            intent, _fingerprint = _load_cleanup_intent(
+                path / INTENT_FILENAME,
+                intent_record,
+            )
             if intent["operation"] != "uninstall":
                 raise HooksConflict(f"恢复范围包含非 uninstall intent: {path}")
             intents.append(intent)
@@ -6999,13 +7445,16 @@ def _recover_uninstall(codex_dirs: List[str], yes: bool) -> None:
             )
             if _directory_identity(expected) != expected_identity:
                 raise HooksConflict(f"初始化 uninstall journal identity 已变化: {expected}")
-            names = _FILESYSTEM.list_directory_names(expected)
+            evidence = _FILESYSTEM.read_verified_recovery_directory(expected)
+            _LOADED_RECOVERY_EVIDENCE[str(expected)] = evidence
+            names = set(evidence)
             if not names:
                 partial_journals.append((expected, {}))
                 continue
             if names == {INTENT_FILENAME}:
                 intent, fingerprint = _load_cleanup_intent(
-                    expected / INTENT_FILENAME
+                    expected / INTENT_FILENAME,
+                    evidence[INTENT_FILENAME],
                 )
                 if intent != expected_intent:
                     raise HooksConflict(f"初始化 uninstall intent 不一致: {expected}")
@@ -7133,6 +7582,31 @@ def _recover_uninstall(codex_dirs: List[str], yes: bool) -> None:
     _print(f"[完成] 已恢复卸载事务 {transaction_id}。")
 
 
+def _empty_initializing_journals(
+    codex_dirs: List[str],
+) -> List[Tuple[Path, FileIdentity]]:
+    result = []
+    pattern = re.compile(re.escape(JOURNAL_PREFIX) + r"[0-9a-f]{32}")
+    for directory in codex_dirs:
+        for journal in _deployment_journal_dirs(Path(directory)):
+            if _cleanup_claim_base(journal.name) is not None or not pattern.fullmatch(
+                journal.name
+            ):
+                continue
+            try:
+                identity = _directory_identity(journal)
+                access = _FILESYSTEM.open_verified_empty_private_directory(
+                    journal,
+                    identity,
+                )
+            except (OSError, HooksConflict):
+                continue
+            else:
+                _FILESYSTEM.close_owned_directory(access)
+                result.append((journal, identity))
+    return result
+
+
 def _recover_deployment_locked(codex_dirs: List[str], yes: bool) -> None:
     """Preview or safely recover an interrupted durable deployment."""
     global _ACTIVE_DEPLOYMENT_STATES, _ACTIVE_DEPLOYMENT_TRANSACTION_ID
@@ -7145,6 +7619,30 @@ def _recover_deployment_locked(codex_dirs: List[str], yes: bool) -> None:
         ) = _recover_cleanup_artifacts(
             codex_dirs,
         )
+        empty_journals = _empty_initializing_journals(recovery_dirs)
+        if empty_journals and not yes:
+            _print(
+                _localized(
+                    "[预览] 发现尚未发布 intent 的空初始化 journal；"
+                    "未修改，确认清理请添加 --yes。",
+                    "[Preview] Found an empty initializing journal before intent "
+                    "publication; nothing changed. Add --yes to remove it.",
+                )
+            )
+            return
+        for journal, identity in empty_journals:
+            access = _FILESYSTEM.open_verified_empty_private_directory(
+                journal,
+                identity,
+            )
+            _FILESYSTEM.close_owned_directory(access)
+            _safe_remove_owned_directory(
+                journal,
+                identity,
+                {},
+                require_exact_members=True,
+            )
+            _fsync_directory(journal.parent)
         selected_journals = [
             journal
             for directory in recovery_dirs
@@ -7176,8 +7674,15 @@ def _recover_deployment_locked(codex_dirs: List[str], yes: bool) -> None:
                     or not _is_regular_path(journal / INTENT_FILENAME)
                 ):
                     continue
+                evidence = _FILESYSTEM.read_verified_recovery_directory(journal)
+                intent_record = evidence.get(INTENT_FILENAME)
+                if intent_record is None:
+                    raise HooksConflict(
+                        f"incomplete transaction intent disappeared: {journal}"
+                    )
                 intent, _fingerprint = _load_cleanup_intent(
-                    journal / INTENT_FILENAME
+                    journal / INTENT_FILENAME,
+                    intent_record,
                 )
                 owner = str(journal.parent.resolve())
                 expected_identity = _identity_from_portable(
@@ -7193,7 +7698,7 @@ def _recover_deployment_locked(codex_dirs: List[str], yes: bool) -> None:
                     raise HooksConflict(
                         "remaining intent does not match the verified cleanup intent"
                     )
-                names = _FILESYSTEM.list_directory_names(journal)
+                names = set(evidence)
                 if names == {INTENT_FILENAME}:
                     continue
                 if (
@@ -7891,6 +8396,7 @@ def _create_uninstall_journals(
                 _portable_identity(state.journal_identity)
             )
             state.journal_data = journal_data
+            _fsync_directory(state.codex_dir)
 
         for state in states:
             if state.journal_dir is None:
@@ -7932,15 +8438,21 @@ def _create_uninstall_journals(
                             "初始化失败的 uninstall journal 缺少所有权: "
                             f"{state.journal_dir}"
                         )
-                    _safe_remove_owned_directory(
-                        state.journal_dir,
-                        state.journal_identity,
-                        _journal_expected_members(
+                    initializing_empty = not any(state.journal_dir.iterdir())
+                    expected_members = (
+                        {}
+                        if initializing_empty
+                        else _journal_expected_members(
                             state.journal_data,
                             str(state.codex_dir.resolve()),
                             state.journal_dir,
                             require_all_snapshots=False,
-                        ),
+                        )
+                    )
+                    _safe_remove_owned_directory(
+                        state.journal_dir,
+                        state.journal_identity,
+                        expected_members,
                         require_exact_members=True,
                     )
                     state.journal_dir = None
@@ -7990,13 +8502,20 @@ def _remove_owned_file(path: Path, expected: FileFingerprint) -> None:
             raise HooksConflict(f"无法原子认领待删除文件: {path}")
         claimed = _fingerprint_regular_file(claim)
         if claimed != expected:
-            _rollback_claim(claim, path, timestamp)
             raise HooksConflict(f"待删除文件已漂移: {path}")
         claim.unlink()
         _remove_transaction_dir(transaction_dir)
-    except BaseException:
-        _rollback_claim(claim, path, timestamp)
-        _cleanup_transaction_dir_after_error(transaction_dir)
+    except BaseException as primary:
+        _run_cleanup_preserving_primary(
+            primary,
+            [
+                ("恢复待删除文件", lambda: _rollback_claim(claim, path, timestamp)),
+                (
+                    "清理文件删除事务目录",
+                    lambda: _cleanup_transaction_dir_after_error(transaction_dir),
+                ),
+            ],
+        )
         raise
 
 

--- a/codex-instruct.py
+++ b/codex-instruct.py
@@ -1642,6 +1642,16 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
         inode = (int(info.nFileIndexHigh) << 32) | int(info.nFileIndexLow)
         return FileIdentity(int(info.dwVolumeSerialNumber), inode)
 
+    @staticmethod
+    def _handle_matches_portable_identity(
+        handle_identity: FileIdentity,
+        portable_identity: FileIdentity,
+    ) -> bool:
+        return (
+            handle_identity.inode == portable_identity.inode
+            and handle_identity.device == portable_identity.device & 0xFFFFFFFF
+        )
+
     def _handle_attributes(self, handle: int) -> _FILE_ATTRIBUTE_TAG_INFO_STRUCT:
         info = self._FILE_ATTRIBUTE_TAG_INFO_STRUCT()
         if not self.kernel32.GetFileInformationByHandleEx(
@@ -1997,7 +2007,10 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
             self._validate_ntfs(handle, path)
             identity = self._handle_identity(handle)
             path_identity = _directory_identity(path)
-            if identity != expected_identity or path_identity != expected_identity:
+            if (
+                not self._handle_matches_portable_identity(identity, expected_identity)
+                or path_identity != expected_identity
+            ):
                 raise HooksConflict(
                     "受管事务目录 identity 已变化，保留证据: "
                     f"{path}; expected={expected_identity}, handle={identity}, "
@@ -2140,7 +2153,10 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
         descriptor = None
         try:
             self._validate_handle_type(handle, path, is_directory=False)
-            if self._handle_identity(handle) != expected_identity:
+            if not self._handle_matches_portable_identity(
+                self._handle_identity(handle),
+                expected_identity,
+            ):
                 raise HooksConflict(f"待删除文件 identity 已变化，保留证据: {path}")
             descriptor = self.msvcrt.open_osfhandle(
                 handle,

--- a/codex-instruct.py
+++ b/codex-instruct.py
@@ -555,6 +555,14 @@ def normalize_md_name(name: str) -> str:
         raise ValueError("--name 不能包含 '..'")
     if not SAFE_NAME_RE.fullmatch(raw):
         raise ValueError("--name 只能包含字母、数字、点、下划线和连字符")
+    windows_stem = raw.split(".", 1)[0].upper()
+    if (
+        windows_stem in {"CON", "PRN", "AUX", "NUL", "CONIN$", "CONOUT$"}
+        or re.fullmatch(r"COM[1-9]", windows_stem)
+        or re.fullmatch(r"LPT[1-9]", windows_stem)
+        or raw.endswith(".")
+    ):
+        raise ValueError("--name uses a Windows reserved device name")
     if raw == LEGACY_MD_FILENAME[:-3]:
         raise ValueError(
             f"--name 保留给旧版迁移，不能使用 {LEGACY_MD_FILENAME[:-3]}"

--- a/codex-instruct.py
+++ b/codex-instruct.py
@@ -1783,7 +1783,9 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
     def set_file_times(self, path: Path, atime_ns: int, mtime_ns: int) -> None:
         handle = self._open_handle(
             path,
-            self._FILE_READ_ATTRIBUTES | self._FILE_WRITE_ATTRIBUTES,
+            self._GENERIC_WRITE
+            | self._FILE_READ_ATTRIBUTES
+            | self._FILE_WRITE_ATTRIBUTES,
         )
         try:
             self._validate_handle_type(handle, path, is_directory=False)

--- a/codex-instruct.py
+++ b/codex-instruct.py
@@ -1996,8 +1996,13 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
             self._validate_handle_type(handle, path, is_directory=True)
             self._validate_ntfs(handle, path)
             identity = self._handle_identity(handle)
-            if identity != expected_identity or _directory_identity(path) != expected_identity:
-                raise HooksConflict(f"受管事务目录 identity 已变化，保留证据: {path}")
+            path_identity = _directory_identity(path)
+            if identity != expected_identity or path_identity != expected_identity:
+                raise HooksConflict(
+                    "受管事务目录 identity 已变化，保留证据: "
+                    f"{path}; expected={expected_identity}, handle={identity}, "
+                    f"path={path_identity}"
+                )
             entries = self._enumerate(handle, path)
             names = set(entries)
             self._validate_member_names(path, names, expected_members, require_exact_members)

--- a/codex-instruct.py
+++ b/codex-instruct.py
@@ -1241,13 +1241,14 @@ class _PosixFilesystemBackend:
             os.close(descriptor)
 
 
-class _WindowsFilesystemBackend(_PosixFilesystemBackend):
+class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
     """Native Windows handles, ACLs, sharing, identity, and persistence."""
 
     _GENERIC_READ = 0x80000000
     _GENERIC_WRITE = 0x40000000
     _DELETE = 0x00010000
     _READ_CONTROL = 0x00020000
+    _WRITE_DAC = 0x00040000
     _FILE_LIST_DIRECTORY = 0x0001
     _FILE_READ_ATTRIBUTES = 0x0080
     _FILE_WRITE_ATTRIBUTES = 0x0100
@@ -1695,6 +1696,7 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):
             | self._GENERIC_WRITE
             | self._DELETE
             | self._READ_CONTROL
+            | self._WRITE_DAC
             | self._FILE_READ_ATTRIBUTES
             | self._FILE_WRITE_ATTRIBUTES,
             creation=self._CREATE_NEW,
@@ -1712,8 +1714,7 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):
         handle = self.msvcrt.get_osfhandle(descriptor)
         if not self.advapi32.SetKernelObjectSecurity(
             handle,
-            self._DACL_SECURITY_INFORMATION
-            | self._PROTECTED_DACL_SECURITY_INFORMATION,
+            self._DACL_SECURITY_INFORMATION,
             self._security_descriptor,
         ):
             self._raise_last_error("cannot apply private ACL")
@@ -1763,9 +1764,12 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):
             finally:
                 self.kernel32.LocalFree(sddl_pointer)
             if not sddl.startswith("D:P"):
-                raise HooksConflict(f"private ACL is not protected: {path}")
+                raise HooksConflict(f"private ACL is not protected: {path}: {sddl}")
             if self._current_sid not in sddl:
-                raise HooksConflict(f"private ACL does not grant the current user: {path}")
+                raise HooksConflict(
+                    f"private ACL does not grant the current user: {path}: "
+                    f"sid={self._current_sid}; acl={sddl}"
+                )
             if "SY" not in sddl and "S-1-5-18" not in sddl:
                 raise HooksConflict(f"private ACL does not grant SYSTEM: {path}")
         finally:

--- a/codex-instruct.py
+++ b/codex-instruct.py
@@ -37,6 +37,7 @@ import subprocess
 import sys
 import tempfile
 import uuid
+from ctypes import wintypes
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -190,6 +191,7 @@ _ACTIVE_DEPLOYMENT_STATES: Optional[List["DeploymentState"]] = None
 _OWNED_DIRECTORY_RECORDS: Dict[str, Tuple["FileIdentity", Any]] = {}
 _LOADED_JOURNAL_PENDING: Dict[str, Tuple["FileFingerprint", bool]] = {}
 _LOADED_COMPANION_PENDING: Dict[str, Tuple["FileFingerprint", bool]] = {}
+_FILESYSTEM_CHECKPOINT_HOOK: Optional[Callable[[str], None]] = None
 _EN_REPLACEMENTS = (
     ("未找到 codex-keysmith 部署清单；无需卸载。", "No codex-keysmith deployment manifest was found; nothing to uninstall."),
     ("卸载预检发现", "Uninstall preflight found"),
@@ -433,6 +435,12 @@ def _print(*values, **kwargs) -> None:
     )
 
 
+def _filesystem_checkpoint(name: str) -> None:
+    hook = _FILESYSTEM_CHECKPOINT_HOOK
+    if hook is not None:
+        hook(name)
+
+
 def _transaction_temp_prefix(kind: str) -> str:
     transaction_id = _ACTIVE_DEPLOYMENT_TRANSACTION_ID
     suffix = f"-{transaction_id}" if transaction_id else ""
@@ -509,15 +517,25 @@ def _make_registered_transaction_dir(
     kind: str,
     allowed_members: Any,
 ) -> Tuple[Path, "FileIdentity"]:
-    transaction_dir = Path(
-        tempfile.mkdtemp(prefix=_transaction_temp_prefix(kind), dir=str(parent))
-    )
-    os.chmod(transaction_dir, 0o700)
+    prefix = _transaction_temp_prefix(kind)
+    while True:
+        transaction_dir = parent / f"{prefix}{uuid.uuid4().hex}"
+        try:
+            _FILESYSTEM.create_private_directory(transaction_dir)
+        except FileExistsError:
+            continue
+        break
     try:
         identity = _register_active_residue(transaction_dir, allowed_members)
     except BaseException:
-        identity = _directory_identity(transaction_dir)
-        _safe_remove_owned_directory(transaction_dir, identity, set())
+        try:
+            identity = _directory_identity(transaction_dir)
+            _safe_remove_owned_directory(transaction_dir, identity, set())
+        except BaseException as cleanup_exc:
+            _print(
+                f"[事务警告] 临时事务目录清理失败，已保留证据: {cleanup_exc}",
+                file=sys.stderr,
+            )
         raise
     _OWNED_DIRECTORY_RECORDS[str(transaction_dir)] = (identity, allowed_members)
     return transaction_dir, identity
@@ -592,7 +610,7 @@ def atomic_write_text(
                 on_published=on_published,
             )
         else:
-            os.replace(str(tmp_path), str(path))
+            _FILESYSTEM.replace_atomic(tmp_path, path)
             if on_published:
                 on_published(_fingerprint_regular_file(path))
         tmp_path = None
@@ -801,15 +819,7 @@ def find_recovery_dirs() -> List[str]:
 
 def _open_exclusive_private_file(path: Path) -> int:
     """Create a private regular file without following links or replacing nodes."""
-    flags = (
-        os.O_WRONLY
-        | os.O_CREAT
-        | os.O_EXCL
-        | getattr(os, "O_BINARY", 0)
-        | getattr(os, "O_CLOEXEC", 0)
-    )
-    flags |= getattr(os, "O_NOFOLLOW", 0)
-    return os.open(path, flags, 0o600)
+    return _FILESYSTEM.create_private_file(path)
 
 
 def _timestamped_backup_candidate(path: Path, timestamp: str, attempt: int) -> Path:
@@ -845,9 +855,9 @@ def backup_file(
                     shutil.copyfileobj(source, destination)
                     destination.flush()
                     os.fsync(destination.fileno())
-                    os.fchmod(
+                    _FILESYSTEM.clone_file_security(
                         destination.fileno(),
-                        stat.S_IMODE(source_stat.st_mode),
+                        source_stat,
                     )
                 source_after = _fingerprint_descriptor(
                     source_descriptor,
@@ -862,10 +872,10 @@ def backup_file(
                     source_after,
                 ):
                     raise HooksConflict(f"备份内容校验失败: {backup}")
-                os.utime(
+                _FILESYSTEM.set_file_times(
                     backup,
-                    ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns),
-                    follow_symlinks=False,
+                    source_stat.st_atime_ns,
+                    source_stat.st_mtime_ns,
                 )
             except BaseException:
                 try:
@@ -923,6 +933,1181 @@ class FileFingerprint:
     size: int
     modified_ns: int
     sha256: str
+
+
+@dataclass(frozen=True)
+class _DirectoryEntry:
+    name: str
+    identity: FileIdentity
+    is_directory: bool
+    is_reparse: bool = False
+
+
+@dataclass
+class _OwnedDirectoryAccess:
+    path: Path
+    identity: FileIdentity
+    names: set
+    descriptor: Optional[int] = None
+    handle: Optional[int] = None
+    entries: Optional[Dict[str, _DirectoryEntry]] = None
+
+
+class _PosixFilesystemBackend:
+    """Security-sensitive filesystem primitives used by every platform."""
+
+    def create_private_directory(self, path: Path) -> None:
+        os.mkdir(path, 0o700)
+        os.chmod(path, 0o700)
+
+    def create_private_file(self, path: Path) -> int:
+        flags = (
+            os.O_RDWR
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_BINARY", 0)
+            | getattr(os, "O_CLOEXEC", 0)
+        )
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        return os.open(path, flags, 0o600)
+
+    def apply_private_file_security(self, descriptor: int) -> None:
+        os.fchmod(descriptor, 0o600)
+
+    def clone_file_security(self, descriptor: int, source_stat: os.stat_result) -> None:
+        os.fchmod(descriptor, stat.S_IMODE(source_stat.st_mode))
+
+    def verify_private_security(self, path: Path, is_directory: bool) -> None:
+        mode = stat.S_IMODE(os.lstat(path).st_mode)
+        expected = 0o700 if is_directory else 0o600
+        if mode & 0o077:
+            raise HooksConflict(f"private filesystem node has broad mode {oct(mode)}: {path}")
+        if mode & expected != expected:
+            raise HooksConflict(f"private filesystem node lacks owner access: {path}")
+
+    def set_file_times(self, path: Path, atime_ns: int, mtime_ns: int) -> None:
+        os.utime(
+            path,
+            ns=(atime_ns, mtime_ns),
+            follow_symlinks=False,
+        )
+
+    def flush_directory(self, path: Path) -> None:
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_DIRECTORY", 0)
+        descriptor = os.open(path, flags)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+    def open_verified_owned_directory(
+        self,
+        path: Path,
+        expected_identity: FileIdentity,
+        expected_members: Dict[str, Any],
+        require_exact_members: bool,
+    ) -> _OwnedDirectoryAccess:
+        if _directory_identity(path) != expected_identity:
+            raise HooksConflict(f"受管事务目录 identity 已变化，保留证据: {path}")
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, flags)
+        try:
+            descriptor_stat = os.fstat(descriptor)
+            if (
+                not stat.S_ISDIR(descriptor_stat.st_mode)
+                or _identity_from_stat(descriptor_stat) != expected_identity
+            ):
+                raise HooksConflict(f"事务目录在打开前被替换，保留证据: {path}")
+            names = set(os.listdir(descriptor))
+            self._validate_member_names(path, names, expected_members, require_exact_members)
+            for name in sorted(names):
+                item_stat = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+                if not stat.S_ISREG(item_stat.st_mode):
+                    raise HooksConflict(
+                        f"事务目录成员不是普通文件，保留证据: {path / name}"
+                    )
+                expected = expected_members[name]
+                if expected is None:
+                    continue
+                member_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+                member_flags |= getattr(os, "O_NOFOLLOW", 0)
+                member_descriptor = os.open(name, member_flags, dir_fd=descriptor)
+                try:
+                    opened_stat = os.fstat(member_descriptor)
+                    if (
+                        not stat.S_ISREG(opened_stat.st_mode)
+                        or _identity_from_stat(opened_stat)
+                        != _identity_from_stat(item_stat)
+                    ):
+                        raise HooksConflict(
+                            f"事务目录成员在打开期间变化: {path / name}"
+                        )
+                    actual = _fingerprint_descriptor(
+                        member_descriptor,
+                        opened_stat,
+                        path / name,
+                    )
+                finally:
+                    os.close(member_descriptor)
+                self._validate_expected_fingerprint(path / name, actual, expected)
+            return _OwnedDirectoryAccess(
+                path=path,
+                identity=expected_identity,
+                names=names,
+                descriptor=descriptor,
+            )
+        except BaseException:
+            os.close(descriptor)
+            raise
+
+    @staticmethod
+    def _validate_member_names(
+        path: Path,
+        names: set,
+        expected_members: Dict[str, Any],
+        require_exact_members: bool,
+    ) -> None:
+        unexpected = names - set(expected_members)
+        if unexpected:
+            raise HooksConflict(
+                f"事务目录包含未授权成员，保留证据: {path}: "
+                + ", ".join(sorted(unexpected))
+            )
+        if require_exact_members and names != set(expected_members):
+            missing = set(expected_members) - names
+            raise HooksConflict(
+                f"事务目录缺少受管成员，保留证据: {path}: "
+                + ", ".join(sorted(missing))
+            )
+
+    @staticmethod
+    def _validate_expected_fingerprint(
+        path: Path,
+        actual: FileFingerprint,
+        expected: Any,
+    ) -> None:
+        if isinstance(expected, FileFingerprint):
+            expected = _portable_fingerprint(expected)
+        if not (
+            actual.size == expected["size"]
+            and actual.modified_ns == expected["mtime_ns"]
+            and actual.sha256 == expected["sha256"]
+        ):
+            raise HooksConflict(f"事务目录成员指纹不匹配，保留证据: {path}")
+
+    def remove_verified_member(
+        self,
+        access: _OwnedDirectoryAccess,
+        name: str,
+        expected: Any,
+    ) -> None:
+        if access.descriptor is None:
+            raise HooksConflict("owned directory descriptor is unavailable")
+        if expected is not None:
+            item_stat = os.stat(name, dir_fd=access.descriptor, follow_symlinks=False)
+            member_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+            member_flags |= getattr(os, "O_NOFOLLOW", 0)
+            descriptor = os.open(name, member_flags, dir_fd=access.descriptor)
+            try:
+                opened_stat = os.fstat(descriptor)
+                if _identity_from_stat(opened_stat) != _identity_from_stat(item_stat):
+                    raise HooksConflict(f"事务目录成员在删除前变化: {access.path / name}")
+                actual = _fingerprint_descriptor(
+                    descriptor,
+                    opened_stat,
+                    access.path / name,
+                )
+            finally:
+                os.close(descriptor)
+            self._validate_expected_fingerprint(access.path / name, actual, expected)
+        os.unlink(name, dir_fd=access.descriptor)
+        access.names.discard(name)
+
+    def flush_owned_directory(self, access: _OwnedDirectoryAccess) -> None:
+        if access.descriptor is None:
+            raise HooksConflict("owned directory descriptor is unavailable")
+        os.fsync(access.descriptor)
+
+    def close_owned_directory(self, access: _OwnedDirectoryAccess) -> None:
+        if access.descriptor is not None:
+            os.close(access.descriptor)
+            access.descriptor = None
+
+    def remove_verified_directory(self, access: _OwnedDirectoryAccess) -> None:
+        if _directory_identity(access.path) != access.identity:
+            raise HooksConflict(f"清理前事务目录 identity 已变化: {access.path}")
+        os.rmdir(access.path)
+
+    def list_directory_names(self, path: Path) -> set:
+        return set(os.listdir(path))
+
+    def atomic_rename_no_replace(self, source: Path, destination: Path) -> bool:
+        libc = ctypes.CDLL(None, use_errno=True)
+        source_bytes = os.fsencode(source)
+        destination_bytes = os.fsencode(destination)
+
+        if sys.platform == "darwin":
+            if not hasattr(libc, "renamex_np"):
+                raise AtomicRenameUnavailable(errno.ENOTSUP, "renamex_np is unavailable")
+            rename_no_replace = libc.renamex_np
+            rename_no_replace.argtypes = [
+                ctypes.c_char_p,
+                ctypes.c_char_p,
+                ctypes.c_uint,
+            ]
+            rename_no_replace.restype = ctypes.c_int
+            result = rename_no_replace(source_bytes, destination_bytes, 0x00000004)
+        elif sys.platform.startswith("linux") and hasattr(libc, "renameat2"):
+            rename_no_replace = libc.renameat2
+            rename_no_replace.argtypes = [
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_uint,
+            ]
+            rename_no_replace.restype = ctypes.c_int
+            result = rename_no_replace(-100, source_bytes, -100, destination_bytes, 0x00000001)
+        else:
+            raise AtomicRenameUnavailable(
+                errno.ENOTSUP,
+                "atomic no-replace rename is unavailable",
+            )
+
+        if result == 0:
+            return True
+        error_number = ctypes.get_errno()
+        if error_number == errno.EEXIST:
+            return False
+        message = f"{os.strerror(error_number)}: {source} -> {destination}"
+        if error_number in {
+            errno.ENOSYS,
+            errno.ENOTSUP,
+            errno.EOPNOTSUPP,
+            errno.EINVAL,
+        }:
+            raise AtomicRenameUnavailable(error_number, message)
+        raise OSError(error_number, message)
+
+    def replace_atomic(self, source: Path, destination: Path) -> None:
+        os.replace(str(source), str(destination))
+
+    def directory_lock_key(self, path: Path) -> Tuple[Tuple[Any, ...], Path]:
+        canonical = path.resolve()
+        identity = _directory_identity(canonical)
+        return (identity.device, identity.inode, str(canonical)), canonical
+
+    def acquire_directory_lock(self, key: Tuple[Any, ...]) -> Tuple[int, Path]:
+        import fcntl
+
+        owner = getattr(os, "getuid", lambda: 0)()
+        lock_root = Path(tempfile.gettempdir()) / f"codex-keysmith-locks-{owner}"
+        lock_root.mkdir(mode=0o700, exist_ok=True)
+        os.chmod(lock_root, 0o700)
+        digest = hashlib.sha256(repr(key).encode("utf-8")).hexdigest()
+        lock_path = lock_root / f"{digest}.lock"
+        descriptor = os.open(
+            lock_path,
+            os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0),
+            0o600,
+        )
+        try:
+            os.fchmod(descriptor, 0o600)
+            _filesystem_checkpoint("directory-lock-wait")
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+            _filesystem_checkpoint("directory-lock-acquired")
+        except BaseException:
+            os.close(descriptor)
+            raise
+        return descriptor, lock_path
+
+    def release_directory_lock(self, token: Tuple[int, Path]) -> None:
+        import fcntl
+
+        descriptor, _path = token
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(descriptor)
+
+
+class _WindowsFilesystemBackend(_PosixFilesystemBackend):
+    """Native Windows handles, ACLs, sharing, identity, and persistence."""
+
+    _GENERIC_READ = 0x80000000
+    _GENERIC_WRITE = 0x40000000
+    _DELETE = 0x00010000
+    _READ_CONTROL = 0x00020000
+    _FILE_LIST_DIRECTORY = 0x0001
+    _FILE_READ_ATTRIBUTES = 0x0080
+    _FILE_WRITE_ATTRIBUTES = 0x0100
+    _SYNCHRONIZE = 0x00100000
+    _FILE_SHARE_READ = 0x00000001
+    _FILE_SHARE_WRITE = 0x00000002
+    _FILE_SHARE_DELETE = 0x00000004
+    _OPEN_EXISTING = 3
+    _CREATE_NEW = 1
+    _FILE_ATTRIBUTE_NORMAL = 0x00000080
+    _FILE_ATTRIBUTE_DIRECTORY = 0x00000010
+    _FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
+    _FILE_FLAG_BACKUP_SEMANTICS = 0x02000000
+    _FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000
+    _FILE_ID_BOTH_DIRECTORY_INFO = 10
+    _FILE_ID_BOTH_DIRECTORY_RESTART_INFO = 11
+    _FILE_ATTRIBUTE_TAG_INFO = 9
+    _FILE_DISPOSITION_INFO = 4
+    _FILE_DISPOSITION_INFO_EX = 21
+    _FILE_DISPOSITION_FLAG_DELETE = 0x00000001
+    _FILE_DISPOSITION_FLAG_POSIX_SEMANTICS = 0x00000002
+    _FILE_DISPOSITION_FLAG_IGNORE_READONLY_ATTRIBUTE = 0x00000010
+    _DACL_SECURITY_INFORMATION = 0x00000004
+    _PROTECTED_DACL_SECURITY_INFORMATION = 0x80000000
+    _TOKEN_QUERY = 0x0008
+    _TOKEN_USER = 1
+    _SDDL_REVISION_1 = 1
+    _ERROR_FILE_EXISTS = 80
+    _ERROR_ALREADY_EXISTS = 183
+    _ERROR_NO_MORE_FILES = 18
+    _WAIT_OBJECT_0 = 0
+    _WAIT_ABANDONED = 0x00000080
+    _INFINITE = 0xFFFFFFFF
+    _INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
+
+    class _BY_HANDLE_FILE_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ("dwFileAttributes", wintypes.DWORD),
+            ("ftCreationTime", wintypes.FILETIME),
+            ("ftLastAccessTime", wintypes.FILETIME),
+            ("ftLastWriteTime", wintypes.FILETIME),
+            ("dwVolumeSerialNumber", wintypes.DWORD),
+            ("nFileSizeHigh", wintypes.DWORD),
+            ("nFileSizeLow", wintypes.DWORD),
+            ("nNumberOfLinks", wintypes.DWORD),
+            ("nFileIndexHigh", wintypes.DWORD),
+            ("nFileIndexLow", wintypes.DWORD),
+        ]
+
+    class _FILE_ATTRIBUTE_TAG_INFO_STRUCT(ctypes.Structure):
+        _fields_ = [
+            ("FileAttributes", wintypes.DWORD),
+            ("ReparseTag", wintypes.DWORD),
+        ]
+
+    class _FILE_ID_BOTH_DIR_INFO_STRUCT(ctypes.Structure):
+        _fields_ = [
+            ("NextEntryOffset", wintypes.DWORD),
+            ("FileIndex", wintypes.DWORD),
+            ("CreationTime", ctypes.c_longlong),
+            ("LastAccessTime", ctypes.c_longlong),
+            ("LastWriteTime", ctypes.c_longlong),
+            ("ChangeTime", ctypes.c_longlong),
+            ("EndOfFile", ctypes.c_longlong),
+            ("AllocationSize", ctypes.c_longlong),
+            ("FileAttributes", wintypes.DWORD),
+            ("FileNameLength", wintypes.DWORD),
+            ("EaSize", wintypes.DWORD),
+            ("ShortNameLength", ctypes.c_byte),
+            ("ShortName", wintypes.WCHAR * 12),
+            ("FileId", ctypes.c_longlong),
+            ("FileName", wintypes.WCHAR * 1),
+        ]
+
+    class _FILE_DISPOSITION_INFO_STRUCT(ctypes.Structure):
+        _fields_ = [("DeleteFile", wintypes.BOOL)]
+
+    class _FILE_DISPOSITION_INFO_EX_STRUCT(ctypes.Structure):
+        _fields_ = [("Flags", wintypes.DWORD)]
+
+    class _SECURITY_ATTRIBUTES(ctypes.Structure):
+        _fields_ = [
+            ("nLength", wintypes.DWORD),
+            ("lpSecurityDescriptor", wintypes.LPVOID),
+            ("bInheritHandle", wintypes.BOOL),
+        ]
+
+    def __init__(self) -> None:
+        self.kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        self.advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+        self.msvcrt = __import__("msvcrt")
+        self._configure_prototypes()
+        self._current_sid = self._current_user_sid_string()
+        self._security_descriptor = self._build_private_security_descriptor()
+        self._security_attributes = self._SECURITY_ATTRIBUTES(
+            ctypes.sizeof(self._SECURITY_ATTRIBUTES),
+            self._security_descriptor,
+            False,
+        )
+
+    def _configure_prototypes(self) -> None:
+        self.kernel32.CreateFileW.argtypes = [
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            ctypes.POINTER(self._SECURITY_ATTRIBUTES),
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.HANDLE,
+        ]
+        self.kernel32.CreateFileW.restype = wintypes.HANDLE
+        self.kernel32.CreateDirectoryW.argtypes = [
+            wintypes.LPCWSTR,
+            ctypes.POINTER(self._SECURITY_ATTRIBUTES),
+        ]
+        self.kernel32.CreateDirectoryW.restype = wintypes.BOOL
+        self.kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        self.kernel32.CloseHandle.restype = wintypes.BOOL
+        self.kernel32.GetFileInformationByHandle.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(self._BY_HANDLE_FILE_INFORMATION),
+        ]
+        self.kernel32.GetFileInformationByHandle.restype = wintypes.BOOL
+        self.kernel32.GetFileInformationByHandleEx.argtypes = [
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+        ]
+        self.kernel32.GetFileInformationByHandleEx.restype = wintypes.BOOL
+        self.kernel32.SetFileInformationByHandle.argtypes = [
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+        ]
+        self.kernel32.SetFileInformationByHandle.restype = wintypes.BOOL
+        self.kernel32.FlushFileBuffers.argtypes = [wintypes.HANDLE]
+        self.kernel32.FlushFileBuffers.restype = wintypes.BOOL
+        self.kernel32.SetFileTime.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(wintypes.FILETIME),
+            ctypes.POINTER(wintypes.FILETIME),
+            ctypes.POINTER(wintypes.FILETIME),
+        ]
+        self.kernel32.SetFileTime.restype = wintypes.BOOL
+        self.kernel32.GetFinalPathNameByHandleW.argtypes = [
+            wintypes.HANDLE,
+            wintypes.LPWSTR,
+            wintypes.DWORD,
+            wintypes.DWORD,
+        ]
+        self.kernel32.GetFinalPathNameByHandleW.restype = wintypes.DWORD
+        self.kernel32.GetVolumeInformationByHandleW.argtypes = [
+            wintypes.HANDLE,
+            wintypes.LPWSTR,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+            ctypes.POINTER(wintypes.DWORD),
+            ctypes.POINTER(wintypes.DWORD),
+            wintypes.LPWSTR,
+            wintypes.DWORD,
+        ]
+        self.kernel32.GetVolumeInformationByHandleW.restype = wintypes.BOOL
+        self.kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+        self.kernel32.LocalFree.argtypes = [wintypes.HLOCAL]
+        self.kernel32.LocalFree.restype = wintypes.HLOCAL
+        self.kernel32.MoveFileExW.argtypes = [
+            wintypes.LPCWSTR,
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+        ]
+        self.kernel32.MoveFileExW.restype = wintypes.BOOL
+        self.kernel32.CreateMutexW.argtypes = [
+            ctypes.POINTER(self._SECURITY_ATTRIBUTES),
+            wintypes.BOOL,
+            wintypes.LPCWSTR,
+        ]
+        self.kernel32.CreateMutexW.restype = wintypes.HANDLE
+        self.kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+        self.kernel32.WaitForSingleObject.restype = wintypes.DWORD
+        self.kernel32.ReleaseMutex.argtypes = [wintypes.HANDLE]
+        self.kernel32.ReleaseMutex.restype = wintypes.BOOL
+        self.advapi32.OpenProcessToken.argtypes = [
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.HANDLE),
+        ]
+        self.advapi32.OpenProcessToken.restype = wintypes.BOOL
+        self.advapi32.GetTokenInformation.argtypes = [
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        self.advapi32.GetTokenInformation.restype = wintypes.BOOL
+        self.advapi32.ConvertSidToStringSidW.argtypes = [
+            wintypes.LPVOID,
+            ctypes.POINTER(wintypes.LPWSTR),
+        ]
+        self.advapi32.ConvertSidToStringSidW.restype = wintypes.BOOL
+        self.advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW.argtypes = [
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        self.advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW.restype = (
+            wintypes.BOOL
+        )
+        self.advapi32.SetKernelObjectSecurity.argtypes = [
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+        ]
+        self.advapi32.SetKernelObjectSecurity.restype = wintypes.BOOL
+        self.advapi32.GetKernelObjectSecurity.argtypes = [
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        self.advapi32.GetKernelObjectSecurity.restype = wintypes.BOOL
+        self.advapi32.ConvertSecurityDescriptorToStringSecurityDescriptorW.argtypes = [
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.LPWSTR),
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        self.advapi32.ConvertSecurityDescriptorToStringSecurityDescriptorW.restype = (
+            wintypes.BOOL
+        )
+
+    @staticmethod
+    def _path(path: Path) -> str:
+        absolute = os.path.abspath(str(path))
+        if absolute.startswith("\\\\"):
+            return "\\\\?\\UNC\\" + absolute[2:]
+        if not absolute.startswith("\\\\?\\"):
+            return "\\\\?\\" + absolute
+        return absolute
+
+    @staticmethod
+    def _raise_last_error(label: str, path: Optional[Path] = None) -> None:
+        error = ctypes.get_last_error()
+        message = ctypes.FormatError(error).strip()
+        target = f": {path}" if path is not None else ""
+        raise OSError(error, f"{label}{target}: {message}")
+
+    def _open_handle(
+        self,
+        path: Path,
+        access: int,
+        creation: int = _OPEN_EXISTING,
+        security: bool = False,
+    ) -> int:
+        attributes = self._FILE_FLAG_OPEN_REPARSE_POINT
+        if path.is_dir() or creation == self._OPEN_EXISTING:
+            attributes |= self._FILE_FLAG_BACKUP_SEMANTICS
+        security_attributes = (
+            ctypes.byref(self._security_attributes) if security else None
+        )
+        handle = self.kernel32.CreateFileW(
+            self._path(path),
+            access,
+            self._FILE_SHARE_READ | self._FILE_SHARE_WRITE | self._FILE_SHARE_DELETE,
+            security_attributes,
+            creation,
+            attributes | self._FILE_ATTRIBUTE_NORMAL,
+            None,
+        )
+        if handle == self._INVALID_HANDLE_VALUE:
+            self._raise_last_error("cannot open filesystem handle", path)
+        return int(handle)
+
+    def _handle_info(self, handle: int) -> _BY_HANDLE_FILE_INFORMATION:
+        info = self._BY_HANDLE_FILE_INFORMATION()
+        if not self.kernel32.GetFileInformationByHandle(handle, ctypes.byref(info)):
+            self._raise_last_error("cannot read filesystem identity")
+        return info
+
+    def _handle_identity(self, handle: int) -> FileIdentity:
+        info = self._handle_info(handle)
+        inode = (int(info.nFileIndexHigh) << 32) | int(info.nFileIndexLow)
+        return FileIdentity(int(info.dwVolumeSerialNumber), inode)
+
+    def _handle_attributes(self, handle: int) -> _FILE_ATTRIBUTE_TAG_INFO_STRUCT:
+        info = self._FILE_ATTRIBUTE_TAG_INFO_STRUCT()
+        if not self.kernel32.GetFileInformationByHandleEx(
+            handle,
+            self._FILE_ATTRIBUTE_TAG_INFO,
+            ctypes.byref(info),
+            ctypes.sizeof(info),
+        ):
+            self._raise_last_error("cannot read reparse attributes")
+        return info
+
+    def _validate_ntfs(self, handle: int, path: Path) -> None:
+        filesystem = ctypes.create_unicode_buffer(64)
+        if not self.kernel32.GetVolumeInformationByHandleW(
+            handle,
+            None,
+            0,
+            None,
+            None,
+            None,
+            filesystem,
+            len(filesystem),
+        ):
+            self._raise_last_error("cannot verify filesystem type", path)
+        if filesystem.value.upper() != "NTFS":
+            raise OSError(f"Windows filesystem is unsupported (requires NTFS): {path}")
+
+    def _validate_handle_type(
+        self,
+        handle: int,
+        path: Path,
+        is_directory: bool,
+    ) -> None:
+        attributes = self._handle_attributes(handle)
+        if attributes.FileAttributes & self._FILE_ATTRIBUTE_REPARSE_POINT:
+            raise HooksConflict(f"reparse point is not allowed: {path}")
+        actual_directory = bool(
+            attributes.FileAttributes & self._FILE_ATTRIBUTE_DIRECTORY
+        )
+        if actual_directory != is_directory:
+            expected = "directory" if is_directory else "regular file"
+            raise HooksConflict(f"filesystem node is not a {expected}: {path}")
+
+    def _enumerate(self, handle: int, path: Path) -> Dict[str, _DirectoryEntry]:
+        entries: Dict[str, _DirectoryEntry] = {}
+        buffer = ctypes.create_string_buffer(65536)
+        info_class = self._FILE_ID_BOTH_DIRECTORY_RESTART_INFO
+        while True:
+            ctypes.set_last_error(0)
+            ok = self.kernel32.GetFileInformationByHandleEx(
+                handle,
+                info_class,
+                buffer,
+                len(buffer),
+            )
+            if not ok:
+                error = ctypes.get_last_error()
+                if error == self._ERROR_NO_MORE_FILES:
+                    break
+                self._raise_last_error("cannot enumerate owned directory", path)
+            offset = 0
+            while True:
+                item = self._FILE_ID_BOTH_DIR_INFO_STRUCT.from_buffer(buffer, offset)
+                name = ctypes.wstring_at(
+                    ctypes.addressof(buffer)
+                    + offset
+                    + self._FILE_ID_BOTH_DIR_INFO_STRUCT.FileName.offset,
+                    int(item.FileNameLength) // ctypes.sizeof(wintypes.WCHAR),
+                )
+                if name not in {".", ".."}:
+                    identity = FileIdentity(
+                        self._handle_identity(handle).device,
+                        int(item.FileId) & ((1 << 64) - 1),
+                    )
+                    entries[name] = _DirectoryEntry(
+                        name=name,
+                        identity=identity,
+                        is_directory=bool(
+                            item.FileAttributes & self._FILE_ATTRIBUTE_DIRECTORY
+                        ),
+                        is_reparse=bool(
+                            item.FileAttributes & self._FILE_ATTRIBUTE_REPARSE_POINT
+                        ),
+                    )
+                if item.NextEntryOffset == 0:
+                    break
+                offset += int(item.NextEntryOffset)
+            info_class = self._FILE_ID_BOTH_DIRECTORY_INFO
+        return entries
+
+    def _current_user_sid_string(self) -> str:
+        token = wintypes.HANDLE()
+        if not self.advapi32.OpenProcessToken(
+            self.kernel32.GetCurrentProcess(),
+            self._TOKEN_QUERY,
+            ctypes.byref(token),
+        ):
+            self._raise_last_error("cannot open process token")
+        try:
+            size = wintypes.DWORD()
+            self.advapi32.GetTokenInformation(
+                token,
+                self._TOKEN_USER,
+                None,
+                0,
+                ctypes.byref(size),
+            )
+            buffer = ctypes.create_string_buffer(size.value)
+            if not self.advapi32.GetTokenInformation(
+                token,
+                self._TOKEN_USER,
+                buffer,
+                size,
+                ctypes.byref(size),
+            ):
+                self._raise_last_error("cannot read process token user")
+            sid_pointer = ctypes.cast(buffer, ctypes.POINTER(wintypes.LPVOID))[0]
+            sid_string = wintypes.LPWSTR()
+            if not self.advapi32.ConvertSidToStringSidW(
+                sid_pointer,
+                ctypes.byref(sid_string),
+            ):
+                self._raise_last_error("cannot convert process SID")
+            try:
+                return sid_string.value
+            finally:
+                self.kernel32.LocalFree(sid_string)
+        finally:
+            self.kernel32.CloseHandle(token)
+
+    def _build_private_security_descriptor(self) -> int:
+        descriptor = wintypes.LPVOID()
+        size = wintypes.DWORD()
+        sddl = f"D:P(A;;FA;;;{self._current_sid})(A;;FA;;;SY)"
+        if not self.advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl,
+            self._SDDL_REVISION_1,
+            ctypes.byref(descriptor),
+            ctypes.byref(size),
+        ):
+            self._raise_last_error("cannot build private ACL")
+        return int(descriptor.value)
+
+    def create_private_directory(self, path: Path) -> None:
+        if not self.kernel32.CreateDirectoryW(
+            self._path(path),
+            ctypes.byref(self._security_attributes),
+        ):
+            self._raise_last_error("cannot create private directory", path)
+        self.verify_private_security(path, is_directory=True)
+
+    def create_private_file(self, path: Path) -> int:
+        handle = self._open_handle(
+            path,
+            self._GENERIC_READ
+            | self._GENERIC_WRITE
+            | self._DELETE
+            | self._READ_CONTROL
+            | self._FILE_READ_ATTRIBUTES
+            | self._FILE_WRITE_ATTRIBUTES,
+            creation=self._CREATE_NEW,
+            security=True,
+        )
+        self._validate_handle_type(handle, path, is_directory=False)
+        self._validate_ntfs(handle, path)
+        descriptor = self.msvcrt.open_osfhandle(
+            handle,
+            os.O_RDWR | getattr(os, "O_BINARY", 0),
+        )
+        return descriptor
+
+    def apply_private_file_security(self, descriptor: int) -> None:
+        handle = self.msvcrt.get_osfhandle(descriptor)
+        if not self.advapi32.SetKernelObjectSecurity(
+            handle,
+            self._DACL_SECURITY_INFORMATION
+            | self._PROTECTED_DACL_SECURITY_INFORMATION,
+            self._security_descriptor,
+        ):
+            self._raise_last_error("cannot apply private ACL")
+
+    def clone_file_security(self, descriptor: int, source_stat: os.stat_result) -> None:
+        del source_stat
+        self.apply_private_file_security(descriptor)
+
+    def verify_private_security(self, path: Path, is_directory: bool) -> None:
+        handle = self._open_handle(
+            path,
+            self._READ_CONTROL | self._FILE_READ_ATTRIBUTES,
+        )
+        try:
+            self._validate_handle_type(handle, path, is_directory=is_directory)
+            needed = wintypes.DWORD()
+            self.advapi32.GetKernelObjectSecurity(
+                handle,
+                self._DACL_SECURITY_INFORMATION,
+                None,
+                0,
+                ctypes.byref(needed),
+            )
+            if not needed.value:
+                self._raise_last_error("cannot size private ACL", path)
+            descriptor = ctypes.create_string_buffer(needed.value)
+            if not self.advapi32.GetKernelObjectSecurity(
+                handle,
+                self._DACL_SECURITY_INFORMATION,
+                descriptor,
+                len(descriptor),
+                ctypes.byref(needed),
+            ):
+                self._raise_last_error("cannot read private ACL", path)
+            sddl_pointer = wintypes.LPWSTR()
+            sddl_length = wintypes.DWORD()
+            if not self.advapi32.ConvertSecurityDescriptorToStringSecurityDescriptorW(
+                descriptor,
+                self._SDDL_REVISION_1,
+                self._DACL_SECURITY_INFORMATION,
+                ctypes.byref(sddl_pointer),
+                ctypes.byref(sddl_length),
+            ):
+                self._raise_last_error("cannot describe private ACL", path)
+            try:
+                sddl = sddl_pointer.value or ""
+            finally:
+                self.kernel32.LocalFree(sddl_pointer)
+            if not sddl.startswith("D:P"):
+                raise HooksConflict(f"private ACL is not protected: {path}")
+            if self._current_sid not in sddl:
+                raise HooksConflict(f"private ACL does not grant the current user: {path}")
+            if "SY" not in sddl and "S-1-5-18" not in sddl:
+                raise HooksConflict(f"private ACL does not grant SYSTEM: {path}")
+        finally:
+            self.kernel32.CloseHandle(handle)
+
+    @staticmethod
+    def _filetime(value_ns: int) -> wintypes.FILETIME:
+        value = value_ns // 100 + 116444736000000000
+        return wintypes.FILETIME(value & 0xFFFFFFFF, value >> 32)
+
+    def set_file_times(self, path: Path, atime_ns: int, mtime_ns: int) -> None:
+        handle = self._open_handle(
+            path,
+            self._FILE_READ_ATTRIBUTES | self._FILE_WRITE_ATTRIBUTES,
+        )
+        try:
+            self._validate_handle_type(handle, path, is_directory=False)
+            access = self._filetime(atime_ns)
+            modified = self._filetime(mtime_ns)
+            if not self.kernel32.SetFileTime(
+                handle,
+                None,
+                ctypes.byref(access),
+                ctypes.byref(modified),
+            ):
+                self._raise_last_error("cannot set file times", path)
+            if not self.kernel32.FlushFileBuffers(handle):
+                self._raise_last_error("cannot persist file times", path)
+        finally:
+            self.kernel32.CloseHandle(handle)
+
+    def flush_directory(self, path: Path) -> None:
+        handle = self._open_handle(
+            path,
+            self._GENERIC_READ
+            | self._GENERIC_WRITE
+            | self._FILE_LIST_DIRECTORY
+            | self._FILE_READ_ATTRIBUTES
+            | self._SYNCHRONIZE,
+        )
+        try:
+            self._validate_handle_type(handle, path, is_directory=True)
+            self._validate_ntfs(handle, path)
+            if not self.kernel32.FlushFileBuffers(handle):
+                self._raise_last_error("cannot persist directory metadata", path)
+        finally:
+            self.kernel32.CloseHandle(handle)
+
+    def open_verified_owned_directory(
+        self,
+        path: Path,
+        expected_identity: FileIdentity,
+        expected_members: Dict[str, Any],
+        require_exact_members: bool,
+    ) -> _OwnedDirectoryAccess:
+        handle = self._open_handle(
+            path,
+            self._GENERIC_READ
+            | self._GENERIC_WRITE
+            | self._DELETE
+            | self._READ_CONTROL
+            | self._FILE_LIST_DIRECTORY
+            | self._FILE_READ_ATTRIBUTES
+            | self._SYNCHRONIZE,
+        )
+        try:
+            self._validate_handle_type(handle, path, is_directory=True)
+            self._validate_ntfs(handle, path)
+            identity = self._handle_identity(handle)
+            if identity != expected_identity or _directory_identity(path) != expected_identity:
+                raise HooksConflict(f"受管事务目录 identity 已变化，保留证据: {path}")
+            entries = self._enumerate(handle, path)
+            names = set(entries)
+            self._validate_member_names(path, names, expected_members, require_exact_members)
+            for name in sorted(names):
+                entry = entries[name]
+                if entry.is_directory or entry.is_reparse:
+                    raise HooksConflict(
+                        f"事务目录成员不是普通文件，保留证据: {path / name}"
+                    )
+                if expected_members[name] is not None:
+                    actual = self._fingerprint_member(path, entry, delete_access=False)
+                    self._validate_expected_fingerprint(
+                        path / name,
+                        actual,
+                        expected_members[name],
+                    )
+            return _OwnedDirectoryAccess(
+                path=path,
+                identity=identity,
+                names=names,
+                handle=handle,
+                entries=entries,
+            )
+        except BaseException:
+            self.kernel32.CloseHandle(handle)
+            raise
+
+    def _fingerprint_member(
+        self,
+        parent: Path,
+        entry: _DirectoryEntry,
+        delete_access: bool,
+    ) -> FileFingerprint:
+        access = self._GENERIC_READ | self._FILE_READ_ATTRIBUTES
+        if delete_access:
+            access |= self._DELETE
+        handle = self._open_handle(parent / entry.name, access)
+        descriptor = None
+        try:
+            self._validate_handle_type(handle, parent / entry.name, is_directory=False)
+            if self._handle_identity(handle) != entry.identity:
+                raise HooksConflict(f"事务目录成员在打开期间变化: {parent / entry.name}")
+            descriptor = self.msvcrt.open_osfhandle(
+                handle,
+                os.O_RDONLY | getattr(os, "O_BINARY", 0),
+            )
+            handle = 0
+            before = os.fstat(descriptor)
+            return _fingerprint_descriptor(descriptor, before, parent / entry.name)
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+            elif handle:
+                self.kernel32.CloseHandle(handle)
+
+    def _mark_delete(self, handle: int, path: Path) -> None:
+        extended = self._FILE_DISPOSITION_INFO_EX_STRUCT(
+            self._FILE_DISPOSITION_FLAG_DELETE
+            | self._FILE_DISPOSITION_FLAG_POSIX_SEMANTICS
+            | self._FILE_DISPOSITION_FLAG_IGNORE_READONLY_ATTRIBUTE
+        )
+        if self.kernel32.SetFileInformationByHandle(
+            handle,
+            self._FILE_DISPOSITION_INFO_EX,
+            ctypes.byref(extended),
+            ctypes.sizeof(extended),
+        ):
+            return
+        basic = self._FILE_DISPOSITION_INFO_STRUCT(True)
+        if not self.kernel32.SetFileInformationByHandle(
+            handle,
+            self._FILE_DISPOSITION_INFO,
+            ctypes.byref(basic),
+            ctypes.sizeof(basic),
+        ):
+            self._raise_last_error("cannot delete verified filesystem node", path)
+
+    def remove_verified_member(
+        self,
+        access: _OwnedDirectoryAccess,
+        name: str,
+        expected: Any,
+    ) -> None:
+        if access.handle is None or access.entries is None:
+            raise HooksConflict("owned directory handle is unavailable")
+        entry = access.entries.get(name)
+        if entry is None or entry.is_directory or entry.is_reparse:
+            raise HooksConflict(f"事务目录成员在删除前变化: {access.path / name}")
+        handle = self._open_handle(
+            access.path / name,
+            self._GENERIC_READ | self._FILE_READ_ATTRIBUTES | self._DELETE,
+        )
+        descriptor = None
+        try:
+            self._validate_handle_type(handle, access.path / name, is_directory=False)
+            if self._handle_identity(handle) != entry.identity:
+                raise HooksConflict(f"事务目录成员在删除前变化: {access.path / name}")
+            descriptor = self.msvcrt.open_osfhandle(
+                handle,
+                os.O_RDONLY | getattr(os, "O_BINARY", 0),
+            )
+            handle = 0
+            if expected is not None:
+                before = os.fstat(descriptor)
+                actual = _fingerprint_descriptor(
+                    descriptor,
+                    before,
+                    access.path / name,
+                )
+                self._validate_expected_fingerprint(access.path / name, actual, expected)
+            raw_handle = self.msvcrt.get_osfhandle(descriptor)
+            self._mark_delete(raw_handle, access.path / name)
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+            elif handle:
+                self.kernel32.CloseHandle(handle)
+        entries = self._enumerate(access.handle, access.path)
+        if name in entries:
+            raise HooksConflict(f"事务目录成员删除后仍存在: {access.path / name}")
+        access.entries = entries
+        access.names = set(entries)
+
+    def flush_owned_directory(self, access: _OwnedDirectoryAccess) -> None:
+        if access.handle is None:
+            raise HooksConflict("owned directory handle is unavailable")
+        if not self.kernel32.FlushFileBuffers(access.handle):
+            self._raise_last_error("cannot persist owned directory", access.path)
+
+    def close_owned_directory(self, access: _OwnedDirectoryAccess) -> None:
+        if access.handle is not None:
+            self.kernel32.CloseHandle(access.handle)
+            access.handle = None
+
+    def remove_verified_directory(self, access: _OwnedDirectoryAccess) -> None:
+        if access.handle is None:
+            raise HooksConflict("owned directory handle is unavailable")
+        entries = self._enumerate(access.handle, access.path)
+        if entries:
+            raise HooksConflict(f"清理前事务目录不是空目录: {access.path}")
+        if self._handle_identity(access.handle) != access.identity:
+            raise HooksConflict(f"清理前事务目录 identity 已变化: {access.path}")
+        self._mark_delete(access.handle, access.path)
+        self.close_owned_directory(access)
+        if _path_entry_exists(access.path):
+            raise HooksConflict(f"事务目录删除后仍存在: {access.path}")
+
+    def list_directory_names(self, path: Path) -> set:
+        handle = self._open_handle(
+            path,
+            self._FILE_LIST_DIRECTORY | self._FILE_READ_ATTRIBUTES,
+        )
+        try:
+            self._validate_handle_type(handle, path, is_directory=True)
+            return set(self._enumerate(handle, path))
+        finally:
+            self.kernel32.CloseHandle(handle)
+
+    def atomic_rename_no_replace(self, source: Path, destination: Path) -> bool:
+        if self.kernel32.MoveFileExW(self._path(source), self._path(destination), 0):
+            return True
+        error = ctypes.get_last_error()
+        if error in {self._ERROR_FILE_EXISTS, self._ERROR_ALREADY_EXISTS}:
+            return False
+        self._raise_last_error("atomic no-replace rename failed", source)
+        return False
+
+    def replace_atomic(self, source: Path, destination: Path) -> None:
+        flags = 0x00000001 | 0x00000008
+        if not self.kernel32.MoveFileExW(
+            self._path(source),
+            self._path(destination),
+            flags,
+        ):
+            self._raise_last_error("atomic replace failed", destination)
+
+    def _canonical_path(self, handle: int, fallback: Path) -> Path:
+        length = self.kernel32.GetFinalPathNameByHandleW(handle, None, 0, 0)
+        if not length:
+            self._raise_last_error("cannot resolve canonical directory", fallback)
+        buffer = ctypes.create_unicode_buffer(length + 1)
+        if not self.kernel32.GetFinalPathNameByHandleW(handle, buffer, len(buffer), 0):
+            self._raise_last_error("cannot resolve canonical directory", fallback)
+        value = buffer.value
+        if value.startswith("\\\\?\\UNC\\"):
+            value = "\\\\" + value[8:]
+        elif value.startswith("\\\\?\\"):
+            value = value[4:]
+        return Path(value)
+
+    def directory_lock_key(self, path: Path) -> Tuple[Tuple[Any, ...], Path]:
+        handle = self._open_handle(
+            path,
+            self._FILE_LIST_DIRECTORY | self._FILE_READ_ATTRIBUTES,
+        )
+        try:
+            self._validate_handle_type(handle, path, is_directory=True)
+            self._validate_ntfs(handle, path)
+            identity = self._handle_identity(handle)
+            canonical = self._canonical_path(handle, path)
+            key = (
+                identity.device,
+                identity.inode,
+                os.path.normcase(str(canonical)),
+            )
+            return key, canonical
+        finally:
+            self.kernel32.CloseHandle(handle)
+
+    def acquire_directory_lock(self, key: Tuple[Any, ...]) -> int:
+        digest = hashlib.sha256(repr(key).encode("utf-8")).hexdigest()
+        name = f"Global\\JiaEthan.CodexKeysmith.{digest}"
+        handle = self.kernel32.CreateMutexW(
+            ctypes.byref(self._security_attributes),
+            False,
+            name,
+        )
+        if not handle:
+            self._raise_last_error("cannot create directory mutex")
+        _filesystem_checkpoint("directory-lock-wait")
+        result = self.kernel32.WaitForSingleObject(handle, self._INFINITE)
+        if result not in {self._WAIT_OBJECT_0, self._WAIT_ABANDONED}:
+            self.kernel32.CloseHandle(handle)
+            raise OSError(f"cannot acquire directory mutex: wait result {result}")
+        _filesystem_checkpoint("directory-lock-acquired")
+        return int(handle)
+
+    def release_directory_lock(self, token: int) -> None:
+        try:
+            if not self.kernel32.ReleaseMutex(token):
+                self._raise_last_error("cannot release directory mutex")
+        finally:
+            self.kernel32.CloseHandle(token)
+
+
+_FILESYSTEM = (
+    _WindowsFilesystemBackend() if os.name == "nt" else _PosixFilesystemBackend()
+)
+
+
+@dataclass(frozen=True)
+class _OperationDirectory:
+    path: Path
+    lock_key: Tuple[Any, ...]
+
+
+def _normalize_operation_directories(paths: List[str]) -> List[_OperationDirectory]:
+    unique: Dict[Tuple[Any, ...], _OperationDirectory] = {}
+    for value in paths:
+        key, canonical = _FILESYSTEM.directory_lock_key(Path(value))
+        if key not in unique:
+            unique[key] = _OperationDirectory(canonical, key)
+    return sorted(unique.values(), key=lambda item: item.lock_key)
+
+
+class _DirectoryLockSet:
+    def __init__(self, paths: List[str]) -> None:
+        self.directories = _normalize_operation_directories(paths)
+        self.tokens: List[Any] = []
+
+    def __enter__(self) -> "_DirectoryLockSet":
+        try:
+            for directory in self.directories:
+                self.tokens.append(
+                    _FILESYSTEM.acquire_directory_lock(directory.lock_key)
+                )
+        except BaseException:
+            self._release()
+            raise
+        return self
+
+    def _release(self) -> None:
+        while self.tokens:
+            token = self.tokens.pop()
+            _FILESYSTEM.release_directory_lock(token)
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        del exc_type, exc, traceback
+        self._release()
 
 
 @dataclass(frozen=True)
@@ -1020,23 +2205,8 @@ def _path_entry_exists(path: Path) -> bool:
 
 
 def _fsync_directory(path: Path) -> None:
-    """Persist directory entry changes when the platform supports it."""
-    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
-    flags |= getattr(os, "O_DIRECTORY", 0)
-    try:
-        descriptor = os.open(path, flags)
-    except OSError:
-        # Directory fsync support varies on Windows, which is currently unsupported.
-        if os.name == "nt":
-            return
-        raise
-    try:
-        os.fsync(descriptor)
-    except OSError:
-        if os.name != "nt":
-            raise
-    finally:
-        os.close(descriptor)
+    """Persist directory entry changes through the platform backend."""
+    _FILESYSTEM.flush_directory(path)
 
 
 def _deployment_journal_dirs(codex_dir: Path) -> List[Path]:
@@ -1092,74 +2262,14 @@ def _open_verified_owned_directory(
     expected_identity: FileIdentity,
     expected_members: Dict[str, Any],
     require_exact_members: bool,
-) -> Tuple[int, set]:
-    if _directory_identity(path) != expected_identity:
-        raise HooksConflict(f"受管事务目录 identity 已变化，保留证据: {path}")
-    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
-    flags |= getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
-    descriptor = os.open(path, flags)
-    try:
-        descriptor_stat = os.fstat(descriptor)
-        if (
-            not stat.S_ISDIR(descriptor_stat.st_mode)
-            or _identity_from_stat(descriptor_stat) != expected_identity
-        ):
-            raise HooksConflict(f"事务目录在打开前被替换，保留证据: {path}")
-        names = set(os.listdir(descriptor))
-        unexpected = names - set(expected_members)
-        if unexpected:
-            raise HooksConflict(
-                f"事务目录包含未授权成员，保留证据: {path}: "
-                + ", ".join(sorted(unexpected))
-            )
-        if require_exact_members and names != set(expected_members):
-            missing = set(expected_members) - names
-            raise HooksConflict(
-                f"事务目录缺少受管成员，保留证据: {path}: "
-                + ", ".join(sorted(missing))
-            )
-        for name in sorted(names):
-            item_stat = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
-            if not stat.S_ISREG(item_stat.st_mode):
-                raise HooksConflict(
-                    f"事务目录成员不是普通文件，保留证据: {path / name}"
-                )
-            expected = expected_members[name]
-            if expected is not None:
-                member_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
-                member_flags |= getattr(os, "O_NOFOLLOW", 0)
-                member_descriptor = os.open(name, member_flags, dir_fd=descriptor)
-                try:
-                    opened_stat = os.fstat(member_descriptor)
-                    if (
-                        not stat.S_ISREG(opened_stat.st_mode)
-                        or _identity_from_stat(opened_stat)
-                        != _identity_from_stat(item_stat)
-                    ):
-                        raise HooksConflict(
-                            f"事务目录成员在打开期间变化: {path / name}"
-                        )
-                    actual = _fingerprint_descriptor(
-                        member_descriptor,
-                        opened_stat,
-                        path / name,
-                    )
-                finally:
-                    os.close(member_descriptor)
-                if isinstance(expected, FileFingerprint):
-                    expected = _portable_fingerprint(expected)
-                if not (
-                    actual.size == expected["size"]
-                    and actual.modified_ns == expected["mtime_ns"]
-                    and actual.sha256 == expected["sha256"]
-                ):
-                    raise HooksConflict(
-                        f"事务目录成员指纹不匹配，保留证据: {path / name}"
-                    )
-        return descriptor, names
-    except BaseException:
-        os.close(descriptor)
-        raise
+) -> Tuple[_OwnedDirectoryAccess, set]:
+    access = _FILESYSTEM.open_verified_owned_directory(
+        path,
+        expected_identity,
+        expected_members,
+        require_exact_members,
+    )
+    return access, set(access.names)
 
 
 def _safe_remove_owned_directory(
@@ -1175,13 +2285,13 @@ def _safe_remove_owned_directory(
     if not isinstance(expected_members, dict):
         raise HooksConflict("事务目录成员所有权定义无效")
 
-    descriptor, _names = _open_verified_owned_directory(
+    access, _names = _open_verified_owned_directory(
         path,
         expected_identity,
         expected_members,
         require_exact_members,
     )
-    os.close(descriptor)
+    _FILESYSTEM.close_owned_directory(access)
 
     claimed_path = path
     if _cleanup_claim_base(path.name) is None:
@@ -1194,7 +2304,7 @@ def _safe_remove_owned_directory(
             raise HooksConflict(f"无法原子认领事务目录: {path}")
         _fsync_directory(path.parent)
     path = claimed_path
-    descriptor, names = _open_verified_owned_directory(
+    access, names = _open_verified_owned_directory(
         path,
         expected_identity,
         expected_members,
@@ -1222,27 +2332,51 @@ def _safe_remove_owned_directory(
                 MANIFEST_INTENT_FILENAME,
             }
             for name in sorted(names - retained):
-                os.unlink(name, dir_fd=descriptor)
-            os.fsync(descriptor)
+                _FILESYSTEM.remove_verified_member(
+                    access,
+                    name,
+                    expected_members[name],
+                )
+            _FILESYSTEM.flush_owned_directory(access)
             if JOURNAL_FILENAME in names:
-                os.unlink(JOURNAL_FILENAME, dir_fd=descriptor)
-                os.fsync(descriptor)
+                _FILESYSTEM.remove_verified_member(
+                    access,
+                    JOURNAL_FILENAME,
+                    expected_members[JOURNAL_FILENAME],
+                )
+                _FILESYSTEM.flush_owned_directory(access)
             if MANIFEST_INTENT_FILENAME in names:
-                os.unlink(MANIFEST_INTENT_FILENAME, dir_fd=descriptor)
-                os.fsync(descriptor)
+                _FILESYSTEM.remove_verified_member(
+                    access,
+                    MANIFEST_INTENT_FILENAME,
+                    expected_members[MANIFEST_INTENT_FILENAME],
+                )
+                _FILESYSTEM.flush_owned_directory(access)
+            expected_intent = expected_members[INTENT_FILENAME]
+            portable_intent = (
+                _portable_fingerprint(expected_intent)
+                if isinstance(expected_intent, FileFingerprint)
+                else expected_intent
+            )
+            if not _portable_matches(path / INTENT_FILENAME, portable_intent):
+                raise HooksConflict(
+                    f"事务 journal intent 在 cleanup 发布前变化: {path / INTENT_FILENAME}"
+                )
             if not _atomic_rename_no_replace(path / INTENT_FILENAME, marker):
                 raise HooksConflict(f"无法发布事务 journal cleanup marker: {marker}")
-            os.fsync(descriptor)
+            _FILESYSTEM.flush_owned_directory(access)
             cleanup_marker = (marker, expected_members[INTENT_FILENAME])
         else:
             for name in sorted(names):
-                os.unlink(name, dir_fd=descriptor)
-            os.fsync(descriptor)
+                _FILESYSTEM.remove_verified_member(
+                    access,
+                    name,
+                    expected_members[name],
+                )
+            _FILESYSTEM.flush_owned_directory(access)
+        _FILESYSTEM.remove_verified_directory(access)
     finally:
-        os.close(descriptor)
-    if _directory_identity(path) != expected_identity:
-        raise HooksConflict(f"清理前事务目录 identity 已变化: {path}")
-    os.rmdir(path)
+        _FILESYSTEM.close_owned_directory(access)
     _fsync_directory(path.parent)
     if cleanup_marker is not None:
         marker, expected = cleanup_marker
@@ -1641,7 +2775,7 @@ def _atomic_write_private_json(path: Path, data: Dict[str, Any]) -> None:
         ):
             raise HooksConflict(f"事务日志 pending 文件不属于已验证恢复状态: {temporary}")
         if pending_record[1]:
-            os.replace(str(temporary), str(path))
+            _FILESYSTEM.replace_atomic(temporary, path)
         else:
             temporary.unlink()
         _fsync_directory(path.parent)
@@ -1651,9 +2785,8 @@ def _atomic_write_private_json(path: Path, data: Dict[str, Any]) -> None:
             stream.write(content.encode("utf-8"))
             stream.flush()
             os.fsync(stream.fileno())
-            if hasattr(os, "fchmod"):
-                os.fchmod(stream.fileno(), 0o600)
-        os.replace(str(temporary), str(path))
+            _FILESYSTEM.apply_private_file_security(stream.fileno())
+        _FILESYSTEM.replace_atomic(temporary, path)
         _fsync_directory(path.parent)
     finally:
         if _path_entry_exists(temporary):
@@ -1671,8 +2804,7 @@ def _write_exclusive_private_json(path: Path, data: Dict[str, Any]) -> None:
             stream.write(content.encode("utf-8"))
             stream.flush()
             os.fsync(stream.fileno())
-            if hasattr(os, "fchmod"):
-                os.fchmod(stream.fileno(), 0o600)
+            _FILESYSTEM.apply_private_file_security(stream.fileno())
         _fsync_directory(path.parent)
     except BaseException:
         try:
@@ -1695,7 +2827,7 @@ def _publish_exclusive_private_json(
         raise HooksConflict(f"事务 JSON pending 文件已存在: {pending}")
     try:
         _write_exclusive_private_json(pending, data)
-        os.replace(str(pending), str(path))
+        _FILESYSTEM.replace_atomic(pending, path)
         _fsync_directory(path.parent)
     finally:
         if _path_entry_exists(pending):
@@ -1715,7 +2847,7 @@ def _reconcile_loaded_companion_pending(path: Path) -> None:
     if record[1]:
         if _path_entry_exists(path):
             raise HooksConflict(f"manifest intent 与 pending 同时存在: {path}")
-        os.replace(str(pending), str(path))
+        _FILESYSTEM.replace_atomic(pending, path)
     else:
         pending.unlink()
     _fsync_directory(path.parent)
@@ -1865,9 +2997,7 @@ def _create_deployment_journals(
         # discard a missing snapshot only while its live path still matches before.
         for state in states:
             journal_dir = state.codex_dir / f"{JOURNAL_PREFIX}{transaction_id}"
-            os.mkdir(journal_dir, 0o700)
-            if hasattr(os, "chmod"):
-                os.chmod(journal_dir, 0o700)
+            _FILESYSTEM.create_private_directory(journal_dir)
             state.journal_dir = journal_dir
             state.journal_identity = _directory_identity(journal_dir)
             directories[str(state.codex_dir.resolve())]["journal_identity"] = (
@@ -1907,24 +3037,30 @@ def _create_deployment_journals(
         # Ordinary failures occur before deployment mutation and may clean up.
         # Hard termination leaves the published initializing journal recoverable.
         for state in reversed(states):
-            if state.journal_dir and _path_entry_exists(state.journal_dir):
-                if state.journal_identity is None or state.journal_data is None:
-                    raise HooksConflict(
-                        f"初始化失败的 journal 缺少所有权记录: {state.journal_dir}"
-                    ) from None
-                _safe_remove_owned_directory(
-                    state.journal_dir,
-                    state.journal_identity,
-                    _journal_expected_members(
-                        state.journal_data,
-                        str(state.codex_dir.resolve()),
+            try:
+                if state.journal_dir and _path_entry_exists(state.journal_dir):
+                    if state.journal_identity is None or state.journal_data is None:
+                        raise HooksConflict(
+                            f"初始化失败的 journal 缺少所有权记录: {state.journal_dir}"
+                        )
+                    _safe_remove_owned_directory(
                         state.journal_dir,
-                        require_all_snapshots=False,
-                    ),
-                    require_exact_members=True,
+                        state.journal_identity,
+                        _journal_expected_members(
+                            state.journal_data,
+                            str(state.codex_dir.resolve()),
+                            state.journal_dir,
+                            require_all_snapshots=False,
+                        ),
+                        require_exact_members=True,
+                    )
+                    _fsync_directory(state.codex_dir)
+                    state.journal_dir = None
+            except BaseException as cleanup_exc:
+                _print(
+                    f"[事务警告] 初始化 journal 清理失败，已保留证据: {cleanup_exc}",
+                    file=sys.stderr,
                 )
-                _fsync_directory(state.codex_dir)
-                state.journal_dir = None
         raise
 
 def _update_deployment_journals(
@@ -2285,55 +3421,7 @@ def _validate_hooks_for_isolation(codex_dir: Path) -> Optional[dict]:
 
 def _atomic_rename_no_replace(source: Path, destination: Path) -> bool:
     """Atomically rename source while preserving an existing destination."""
-    if os.name == "nt":
-        try:
-            os.rename(str(source), str(destination))
-        except FileExistsError:
-            return False
-        except OSError as exc:
-            if exc.errno in {errno.ENOSYS, errno.ENOTSUP, errno.EOPNOTSUPP, errno.EINVAL}:
-                raise AtomicRenameUnavailable(exc.errno, str(exc)) from exc
-            raise
-        return True
-
-    libc = ctypes.CDLL(None, use_errno=True)
-    source_bytes = os.fsencode(source)
-    destination_bytes = os.fsencode(destination)
-
-    if sys.platform == "darwin":
-        if not hasattr(libc, "renamex_np"):
-            raise AtomicRenameUnavailable(errno.ENOTSUP, "renamex_np is unavailable")
-        rename_no_replace = libc.renamex_np
-        rename_no_replace.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint]
-        rename_no_replace.restype = ctypes.c_int
-        result = rename_no_replace(source_bytes, destination_bytes, 0x00000004)
-    elif sys.platform.startswith("linux") and hasattr(libc, "renameat2"):
-        rename_no_replace = libc.renameat2
-        rename_no_replace.argtypes = [
-            ctypes.c_int,
-            ctypes.c_char_p,
-            ctypes.c_int,
-            ctypes.c_char_p,
-            ctypes.c_uint,
-        ]
-        rename_no_replace.restype = ctypes.c_int
-        result = rename_no_replace(-100, source_bytes, -100, destination_bytes, 0x00000001)
-    else:
-        raise AtomicRenameUnavailable(
-            errno.ENOTSUP,
-            "atomic no-replace rename is unavailable",
-        )
-
-    if result == 0:
-        return True
-
-    error_number = ctypes.get_errno()
-    if error_number == errno.EEXIST:
-        return False
-    message = f"{os.strerror(error_number)}: {source} -> {destination}"
-    if error_number in {errno.ENOSYS, errno.ENOTSUP, errno.EOPNOTSUPP, errno.EINVAL}:
-        raise AtomicRenameUnavailable(error_number, message)
-    raise OSError(error_number, message)
+    return _FILESYSTEM.atomic_rename_no_replace(source, destination)
 
 
 def _verify_atomic_rename_support(codex_dir: Path) -> None:
@@ -2341,22 +3429,21 @@ def _verify_atomic_rename_support(codex_dir: Path) -> None:
     source_path = None
     destination_path = None
     try:
-        with tempfile.NamedTemporaryFile(
-            "wb",
-            dir=str(codex_dir),
-            prefix=".keysmith-rename-source-",
-            delete=False,
-        ) as source_file:
-            source_file.write(b"source")
-            source_path = Path(source_file.name)
-        with tempfile.NamedTemporaryFile(
-            "wb",
-            dir=str(codex_dir),
-            prefix=".keysmith-rename-destination-",
-            delete=False,
-        ) as destination_file:
-            destination_file.write(b"destination")
-            destination_path = Path(destination_file.name)
+        source_path = codex_dir / f".keysmith-rename-source-{uuid.uuid4().hex}"
+        destination_path = codex_dir / (
+            f".keysmith-rename-destination-{uuid.uuid4().hex}"
+        )
+        for path, content in (
+            (source_path, b"source"),
+            (destination_path, b"destination"),
+        ):
+            descriptor = _open_exclusive_private_file(path)
+            with os.fdopen(descriptor, "wb") as stream:
+                stream.write(content)
+                stream.flush()
+                os.fsync(stream.fileno())
+                _FILESYSTEM.apply_private_file_security(stream.fileno())
+        _fsync_directory(codex_dir)
 
         if _atomic_rename_no_replace(source_path, destination_path):
             raise OSError("atomic no-replace rename replaced an existing destination")
@@ -2457,9 +3544,9 @@ def _copy_to_unique_backup(
                 shutil.copyfileobj(source_file, destination)
                 destination.flush()
                 os.fsync(destination.fileno())
-                os.fchmod(
+                _FILESYSTEM.clone_file_security(
                     destination.fileno(),
-                    stat.S_IMODE(source_stat.st_mode),
+                    source_stat,
                 )
             source_after = _fingerprint_descriptor(
                 source_descriptor,
@@ -2474,10 +3561,10 @@ def _copy_to_unique_backup(
                 raise HooksConflict(
                     f"源文件在备份期间发生变化，已拒绝不一致备份: {source}"
                 )
-            os.utime(
+            _FILESYSTEM.set_file_times(
                 backup,
-                ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns),
-                follow_symlinks=False,
+                source_stat.st_atime_ns,
+                source_stat.st_mtime_ns,
             )
         except BaseException:
             try:
@@ -2556,10 +3643,11 @@ def _copy_file_no_replace(
             shutil.copyfileobj(source_file, temporary)
             temporary.flush()
             os.fsync(temporary.fileno())
-            os.fchmod(temporary.fileno(), stat.S_IMODE(source_stat.st_mode))
-        os.utime(
+            _FILESYSTEM.clone_file_security(temporary.fileno(), source_stat)
+        _FILESYSTEM.set_file_times(
             temporary_path,
-            ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns),
+            source_stat.st_atime_ns,
+            source_stat.st_mtime_ns,
         )
         source_after = _fingerprint_descriptor(
             source_descriptor,
@@ -2962,7 +4050,7 @@ def rollback_hooks_isolation(isolation: HooksIsolation) -> None:
         raise
 
 
-def restore_hooks(codex_dir: Path) -> bool:
+def _restore_hooks_locked(codex_dir: Path) -> bool:
     """Atomically claim and restore hooks.json.disabled."""
     hooks_path = codex_dir / "hooks.json"
     disabled_path = codex_dir / "hooks.json.disabled"
@@ -2999,7 +4087,8 @@ def restore_hooks(codex_dir: Path) -> bool:
             raise HooksConflict(
                 f"hooks.json.disabled 在事务登记后发生变化: {disabled_path}"
             )
-        shutil.copy2(disabled_claim, recovery_copy, follow_symlinks=False)
+        _copy_snapshot(disabled_claim, recovery_copy)
+        _filesystem_checkpoint("restore-hooks-recovery-copy-published")
         if (
             _fingerprint_regular_file(disabled_claim) != disabled_fingerprint
             or not _same_file_content(disabled_claim, recovery_copy)
@@ -3065,6 +4154,11 @@ def restore_hooks(codex_dir: Path) -> bool:
         raise
 
 
+def restore_hooks(codex_dir: Path) -> bool:
+    with _DirectoryLockSet([str(codex_dir)]):
+        return _restore_hooks_locked(codex_dir)
+
+
 def write_md_with_backup(md_dest: Path, md_content: str, timestamp: Optional[str] = None) -> Optional[Path]:
     """Write the MD file and back up any existing file first."""
     backup = backup_file(md_dest, timestamp) if _path_entry_exists(md_dest) else None
@@ -3074,26 +4168,28 @@ def write_md_with_backup(md_dest: Path, md_content: str, timestamp: Optional[str
 
 def _restore_file_from_backup(backup: Path, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
+    transaction_dir = None
     temporary_path = None
     try:
-        with backup.open("rb") as source, tempfile.NamedTemporaryFile(
-            "wb",
-            dir=str(destination.parent),
-            delete=False,
-        ) as temporary:
-            shutil.copyfileobj(source, temporary)
-            temporary.flush()
-            os.fsync(temporary.fileno())
-            temporary_path = Path(temporary.name)
-        shutil.copystat(backup, temporary_path)
-        os.replace(temporary_path, destination)
+        transaction_dir, _identity = _make_registered_transaction_dir(
+            destination.parent,
+            "restore-file",
+            {"prepared": None},
+        )
+        temporary_path = transaction_dir / "prepared"
+        _copy_snapshot(backup, temporary_path)
+        _FILESYSTEM.replace_atomic(temporary_path, destination)
         temporary_path = None
+        _remove_transaction_dir(transaction_dir)
+        transaction_dir = None
     finally:
         if temporary_path is not None:
             try:
                 temporary_path.unlink()
             except OSError:
                 pass
+        if transaction_dir is not None:
+            _cleanup_transaction_dir_after_error(transaction_dir)
 
 
 def rollback_deployment_state(state: DeploymentState, md_filename: str) -> List[str]:
@@ -3726,12 +4822,11 @@ def _copy_snapshot(source: Path, destination: Path) -> None:
                 shutil.copyfileobj(source_file, target)
                 target.flush()
                 os.fsync(target.fileno())
-                if hasattr(os, "fchmod"):
-                    os.fchmod(target.fileno(), stat.S_IMODE(source_stat.st_mode))
-            os.utime(
+                _FILESYSTEM.clone_file_security(target.fileno(), source_stat)
+            _FILESYSTEM.set_file_times(
                 destination,
-                ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns),
-                follow_symlinks=False,
+                source_stat.st_atime_ns,
+                source_stat.st_mtime_ns,
             )
         except BaseException:
             try:
@@ -4051,7 +5146,7 @@ def _finish_cleanup_intent_artifact(
     if not marker_mode:
         if cleanup_dir is None or _directory_identity(cleanup_dir) != expected_identity:
             raise HooksConflict(f"cleanup 目录 identity 已变化: {cleanup_dir}")
-        names = set(os.listdir(cleanup_dir))
+        names = _FILESYSTEM.list_directory_names(cleanup_dir)
         allowed = {INTENT_FILENAME, MANIFEST_INTENT_FILENAME}
         if not names <= allowed or INTENT_FILENAME not in names:
             raise HooksConflict(f"cleanup 目录包含未授权成员: {cleanup_dir}")
@@ -4059,22 +5154,44 @@ def _finish_cleanup_intent_artifact(
             raise HooksConflict(f"cleanup marker 已存在: {marker}")
         if not _atomic_rename_no_replace(intent_path, marker):
             raise HooksConflict(f"无法认领 cleanup intent: {intent_path}")
+        expected_remaining: Dict[str, Any] = {}
         if MANIFEST_INTENT_FILENAME in names:
             companion = cleanup_dir / MANIFEST_INTENT_FILENAME
             companion_fingerprint = _fingerprint_regular_file(companion)
             if not _path_has_fingerprint(companion, companion_fingerprint):
                 raise HooksConflict(f"cleanup companion 已漂移: {companion}")
-            companion.unlink()
-        if _directory_identity(cleanup_dir) != expected_identity or os.listdir(cleanup_dir):
-            raise HooksConflict(f"cleanup 目录在 rmdir 前变化: {cleanup_dir}")
-        os.rmdir(cleanup_dir)
+            expected_remaining[MANIFEST_INTENT_FILENAME] = companion_fingerprint
+        access, remaining_names = _open_verified_owned_directory(
+            cleanup_dir,
+            expected_identity,
+            expected_remaining,
+            require_exact_members=True,
+        )
+        try:
+            for name in sorted(remaining_names):
+                _FILESYSTEM.remove_verified_member(
+                    access,
+                    name,
+                    expected_remaining[name],
+                )
+            _FILESYSTEM.flush_owned_directory(access)
+            _FILESYSTEM.remove_verified_directory(access)
+        finally:
+            _FILESYSTEM.close_owned_directory(access)
         _fsync_directory(owner)
         path = marker
 
     if cleanup_dir is not None and _path_entry_exists(cleanup_dir):
-        if _directory_identity(cleanup_dir) != expected_identity or os.listdir(cleanup_dir):
-            raise HooksConflict(f"cleanup marker 对应目录不是空受管目录: {cleanup_dir}")
-        os.rmdir(cleanup_dir)
+        access, _remaining_names = _open_verified_owned_directory(
+            cleanup_dir,
+            expected_identity,
+            {},
+            require_exact_members=True,
+        )
+        try:
+            _FILESYSTEM.remove_verified_directory(access)
+        finally:
+            _FILESYSTEM.close_owned_directory(access)
         _fsync_directory(owner)
     if not _path_has_fingerprint(path, fingerprint):
         raise HooksConflict(f"cleanup marker 已漂移: {path}")
@@ -4176,7 +5293,9 @@ def _recover_cleanup_artifacts(
                 marker = codex_dir / (
                     f"{CLEANUP_MARKER_PREFIX}{transaction_id}{CLEANUP_MARKER_SUFFIX}"
                 )
-                if _path_entry_exists(marker) and not os.listdir(journal):
+                if _path_entry_exists(marker) and not _FILESYSTEM.list_directory_names(
+                    journal
+                ):
                     continue
                 raise HooksConflict(f"cleanup journal 缺少可验证 intent: {journal}")
     if cleanup_intent is not None:
@@ -5067,13 +6186,13 @@ def _late_absent_md_recovery_claim(
             "published": published,
             "previous_in_claim": False,
         }
-    descriptor, names = _open_verified_owned_directory(
+    access, names = _open_verified_owned_directory(
         residue_path,
         _identity_from_portable(record["identity"], "late-MD residue"),
         record["members"],
         require_exact_members=False,
     )
-    os.close(descriptor)
+    _FILESYSTEM.close_owned_directory(access)
     previous_path = residue_path / "previous"
     previous_in_claim = "previous" in names
     published_in_claim = "published" in names
@@ -5295,7 +6414,7 @@ def _uninstall_recovery_preflight(
                 blockers.append(f"{residue}: 不属于卸载事务")
                 continue
             try:
-                descriptor, _names = _open_verified_owned_directory(
+                access, _names = _open_verified_owned_directory(
                     residue,
                     _identity_from_portable(
                         record["identity"],
@@ -5304,7 +6423,7 @@ def _uninstall_recovery_preflight(
                     record["members"],
                     require_exact_members=False,
                 )
-                os.close(descriptor)
+                _FILESYSTEM.close_owned_directory(access)
             except (OSError, ValueError) as exc:
                 blockers.append(str(exc))
         for resource in resources.values():
@@ -5475,13 +6594,13 @@ def _cleanup_initializing_uninstall(
             "initializing uninstall journal identity",
         )
         if not expected_members:
-            descriptor, _names = _open_verified_owned_directory(
+            access, _names = _open_verified_owned_directory(
                 journal_dir,
                 identity,
                 {},
                 require_exact_members=True,
             )
-            os.close(descriptor)
+            _FILESYSTEM.close_owned_directory(access)
             intent_path = journal_dir / INTENT_FILENAME
             _write_exclusive_private_json(intent_path, expected_intent)
             intent_fingerprint = _fingerprint_regular_file(intent_path)
@@ -5598,7 +6717,7 @@ def _recover_uninstall(codex_dirs: List[str], yes: bool) -> None:
             )
             if _directory_identity(expected) != expected_identity:
                 raise HooksConflict(f"初始化 uninstall journal identity 已变化: {expected}")
-            names = set(os.listdir(expected))
+            names = _FILESYSTEM.list_directory_names(expected)
             if not names:
                 partial_journals.append((expected, {}))
                 continue
@@ -5732,7 +6851,7 @@ def _recover_uninstall(codex_dirs: List[str], yes: bool) -> None:
     _print(f"[完成] 已恢复卸载事务 {transaction_id}。")
 
 
-def recover_deployment(codex_dirs: List[str], yes: bool) -> None:
+def _recover_deployment_locked(codex_dirs: List[str], yes: bool) -> None:
     """Preview or safely recover an interrupted durable deployment."""
     global _ACTIVE_DEPLOYMENT_STATES, _ACTIVE_DEPLOYMENT_TRANSACTION_ID
     try:
@@ -5792,7 +6911,7 @@ def recover_deployment(codex_dirs: List[str], yes: bool) -> None:
                     raise HooksConflict(
                         "remaining intent does not match the verified cleanup intent"
                     )
-                names = set(os.listdir(journal))
+                names = _FILESYSTEM.list_directory_names(journal)
                 if names == {INTENT_FILENAME}:
                     continue
                 if (
@@ -6483,9 +7602,7 @@ def _create_uninstall_journals(
     try:
         for state in states:
             journal_dir = state.codex_dir / f"{JOURNAL_PREFIX}{transaction_id}"
-            os.mkdir(journal_dir, 0o700)
-            if hasattr(os, "chmod"):
-                os.chmod(journal_dir, 0o700)
+            _FILESYSTEM.create_private_directory(journal_dir)
             state.journal_dir = journal_dir
             state.journal_identity = _directory_identity(journal_dir)
             directories[str(state.codex_dir.resolve())]["journal_identity"] = (
@@ -6525,23 +7642,31 @@ def _create_uninstall_journals(
         _update_deployment_journals(states, "prepared")
     except BaseException:
         for state in reversed(states):
-            if state.journal_dir and _path_entry_exists(state.journal_dir):
-                if state.journal_identity is None or state.journal_data is None:
-                    raise HooksConflict(
-                        f"初始化失败的 uninstall journal 缺少所有权: {state.journal_dir}"
-                    ) from None
-                _safe_remove_owned_directory(
-                    state.journal_dir,
-                    state.journal_identity,
-                    _journal_expected_members(
-                        state.journal_data,
-                        str(state.codex_dir.resolve()),
+            try:
+                if state.journal_dir and _path_entry_exists(state.journal_dir):
+                    if state.journal_identity is None or state.journal_data is None:
+                        raise HooksConflict(
+                            "初始化失败的 uninstall journal 缺少所有权: "
+                            f"{state.journal_dir}"
+                        )
+                    _safe_remove_owned_directory(
                         state.journal_dir,
-                        require_all_snapshots=False,
-                    ),
-                    require_exact_members=True,
+                        state.journal_identity,
+                        _journal_expected_members(
+                            state.journal_data,
+                            str(state.codex_dir.resolve()),
+                            state.journal_dir,
+                            require_all_snapshots=False,
+                        ),
+                        require_exact_members=True,
+                    )
+                    state.journal_dir = None
+            except BaseException as cleanup_exc:
+                _print(
+                    "[事务警告] 初始化 uninstall journal 清理失败，已保留证据: "
+                    f"{cleanup_exc}",
+                    file=sys.stderr,
                 )
-                state.journal_dir = None
         raise
 
 
@@ -6615,7 +7740,7 @@ def _replace_owned_from_backup(
             shutil.copyfileobj(source, temporary)
             temporary.flush()
             os.fsync(temporary.fileno())
-            os.fchmod(temporary.fileno(), stat.S_IMODE(source_stat.st_mode))
+            _FILESYSTEM.clone_file_security(temporary.fileno(), source_stat)
         source_after = _fingerprint_descriptor(
             source_descriptor,
             source_stat,
@@ -6623,10 +7748,10 @@ def _replace_owned_from_backup(
         )
         if expected_backup and source_after != expected_backup:
             raise HooksConflict(f"卸载备份在预检后发生变化: {backup}")
-        os.utime(
+        _FILESYSTEM.set_file_times(
             temporary_path,
-            ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns),
-            follow_symlinks=False,
+            source_stat.st_atime_ns,
+            source_stat.st_mtime_ns,
         )
         _transactional_replace_existing(
             destination,
@@ -6904,7 +8029,7 @@ def _verify_uninstall_final_state(states: List[UninstallState]) -> None:
                 )
 
 
-def uninstall(codex_dirs: List[str], yes: bool) -> None:
+def _uninstall_locked(codex_dirs: List[str], yes: bool) -> None:
     global _ACTIVE_DEPLOYMENT_STATES, _ACTIVE_DEPLOYMENT_TRANSACTION_ID
     if not codex_dirs:
         _print("[完成] 未找到 codex-keysmith 部署清单；无需卸载。")
@@ -7016,6 +8141,14 @@ def uninstall(codex_dirs: List[str], yes: bool) -> None:
         if state.manifest_archive:
             _print(f"  [清单归档] {state.manifest_archive}")
     _print(f"[完成] 已卸载 {len(states)} 个受管理部署。")
+
+
+def uninstall(codex_dirs: List[str], yes: bool) -> None:
+    if not yes or not codex_dirs:
+        _uninstall_locked(codex_dirs, yes)
+        return
+    with _DirectoryLockSet(codex_dirs) as locks:
+        _uninstall_locked([str(item.path) for item in locks.directories], yes)
 
 
 @dataclass(frozen=True)
@@ -7784,7 +8917,7 @@ def show_status(codex_dirs: List[str]) -> None:
     )
 
 
-def deploy(args) -> None:
+def _deploy_locked(args, codex_dirs: Optional[List[str]] = None) -> None:
     """主部署逻辑"""
     global _ACTIVE_DEPLOYMENT_STATES, _ACTIVE_DEPLOYMENT_TRANSACTION_ID
     try:
@@ -7794,7 +8927,8 @@ def deploy(args) -> None:
         _print(f"[错误] {exc}")
         sys.exit(1)
 
-    codex_dirs = find_codex_dirs()
+    if codex_dirs is None:
+        codex_dirs = find_codex_dirs()
     if not codex_dirs:
         _print(
             _localized(
@@ -8289,6 +9423,81 @@ def deploy(args) -> None:
     _print(f"\n[完成] 已部署到 {len(codex_dirs)} 个 Codex 配置目录。")
     if skip_hooks_isolation:
         _print("[警告] hooks.json 未被隔离，仍保持活跃。")
+
+
+def _discover_recovery_lock_directories(codex_dirs: List[str]) -> List[str]:
+    discovered = list(codex_dirs)
+    queue = list(codex_dirs)
+    seen = set()
+    while queue:
+        directory = queue.pop(0)
+        canonical = str(Path(directory).resolve())
+        if canonical in seen:
+            continue
+        seen.add(canonical)
+        root = Path(directory)
+        candidates = list(_deployment_cleanup_markers(root))
+        candidates.extend(_deployment_journal_dirs(root))
+        for candidate in candidates:
+            payload_path = candidate
+            if candidate.is_dir():
+                if _is_regular_path(candidate / JOURNAL_FILENAME):
+                    payload_path = candidate / JOURNAL_FILENAME
+                elif _is_regular_path(candidate / INTENT_FILENAME):
+                    payload_path = candidate / INTENT_FILENAME
+                else:
+                    continue
+            try:
+                content, _fingerprint = _read_regular_bytes_with_fingerprint(
+                    payload_path,
+                    "recovery lock discovery",
+                )
+                payload = json.loads(content.decode("utf-8"))
+            except (OSError, UnicodeDecodeError, ValueError, TypeError):
+                continue
+            participants = payload.get("participants")
+            if not isinstance(participants, list):
+                continue
+            for participant in participants:
+                if isinstance(participant, str) and participant not in discovered:
+                    discovered.append(participant)
+                    queue.append(participant)
+    return discovered
+
+
+def recover_deployment(codex_dirs: List[str], yes: bool) -> None:
+    if not yes or not codex_dirs:
+        _recover_deployment_locked(codex_dirs, yes)
+        return
+    candidates = _discover_recovery_lock_directories(codex_dirs)
+    for _attempt in range(3):
+        locks = _DirectoryLockSet(candidates)
+        locks.__enter__()
+        try:
+            expanded = _discover_recovery_lock_directories(codex_dirs)
+            expanded_keys = {
+                item.lock_key for item in _normalize_operation_directories(expanded)
+            }
+            locked_keys = {item.lock_key for item in locks.directories}
+            if expanded_keys <= locked_keys:
+                _recover_deployment_locked(codex_dirs, yes)
+                return
+            candidates = expanded
+        finally:
+            locks.__exit__(None, None, None)
+    raise HooksConflict("recovery participant set did not stabilize while acquiring locks")
+
+def deploy(args) -> None:
+    preview_only = args.dry_run or not args.yes
+    if preview_only:
+        _deploy_locked(args)
+        return
+    codex_dirs = find_codex_dirs()
+    if not codex_dirs:
+        _deploy_locked(args, codex_dirs)
+        return
+    with _DirectoryLockSet(codex_dirs) as locks:
+        _deploy_locked(args, [str(item.path) for item in locks.directories])
 
 
 def main() -> None:

--- a/codex-instruct.py
+++ b/codex-instruct.py
@@ -1764,12 +1764,12 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
             finally:
                 self.kernel32.LocalFree(sddl_pointer)
             if not sddl.startswith("D:P"):
-                raise HooksConflict(f"private ACL is not protected: {path}: {sddl}")
-            if self._current_sid not in sddl:
-                raise HooksConflict(
-                    f"private ACL does not grant the current user: {path}: "
-                    f"sid={self._current_sid}; acl={sddl}"
-                )
+                raise HooksConflict(f"private ACL is not protected: {path}")
+            current_user_present = self._current_sid in sddl or (
+                self._current_sid.endswith("-500") and ";;;LA)" in sddl
+            )
+            if not current_user_present:
+                raise HooksConflict(f"private ACL does not grant the current user: {path}")
             if "SY" not in sddl and "S-1-5-18" not in sddl:
                 raise HooksConflict(f"private ACL does not grant SYSTEM: {path}")
         finally:

--- a/codex-instruct.py
+++ b/codex-instruct.py
@@ -968,7 +968,8 @@ class _PosixFilesystemBackend:
         os.mkdir(path, 0o700)
         os.chmod(path, 0o700)
 
-    def create_private_file(self, path: Path) -> int:
+    def create_private_file(self, path: Path, deny_delete: bool = False) -> int:
+        del deny_delete
         flags = (
             os.O_RDWR
             | os.O_CREAT
@@ -1133,6 +1134,49 @@ class _PosixFilesystemBackend:
         os.unlink(name, dir_fd=access.descriptor)
         access.names.discard(name)
 
+    def remove_verified_file(
+        self,
+        path: Path,
+        expected_identity: FileIdentity,
+        expected: Any,
+    ) -> None:
+        parent_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+        parent_flags |= getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        parent_descriptor = os.open(path.parent, parent_flags)
+        descriptor = None
+        try:
+            item_stat = os.stat(
+                path.name,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
+            if (
+                not stat.S_ISREG(item_stat.st_mode)
+                or _identity_from_stat(item_stat) != expected_identity
+            ):
+                raise HooksConflict(f"待删除文件 identity 已变化，保留证据: {path}")
+            flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+            flags |= getattr(os, "O_NOFOLLOW", 0)
+            descriptor = os.open(path.name, flags, dir_fd=parent_descriptor)
+            opened_stat = os.fstat(descriptor)
+            if _identity_from_stat(opened_stat) != expected_identity:
+                raise HooksConflict(f"待删除文件在打开期间变化，保留证据: {path}")
+            actual = _fingerprint_descriptor(descriptor, opened_stat, path)
+            self._validate_expected_fingerprint(path, actual, expected)
+            current_stat = os.stat(
+                path.name,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
+            if _identity_from_stat(current_stat) != expected_identity:
+                raise HooksConflict(f"待删除文件在删除前变化，保留证据: {path}")
+            os.unlink(path.name, dir_fd=parent_descriptor)
+            os.fsync(parent_descriptor)
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+            os.close(parent_descriptor)
+
     def flush_owned_directory(self, access: _OwnedDirectoryAccess) -> None:
         if access.descriptor is None:
             raise HooksConflict("owned directory descriptor is unavailable")
@@ -1207,6 +1251,26 @@ class _PosixFilesystemBackend:
         identity = _directory_identity(canonical)
         return (identity.device, identity.inode, str(canonical)), canonical
 
+    def pin_directory_for_lock(self, path: Path, key: Tuple[Any, ...]) -> int:
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, flags)
+        try:
+            opened = os.fstat(descriptor)
+            expected = FileIdentity(int(key[0]), int(key[1]))
+            if (
+                not stat.S_ISDIR(opened.st_mode)
+                or _identity_from_stat(opened) != expected
+            ):
+                raise HooksConflict(f"锁定目录在加锁期间被替换: {path}")
+            return descriptor
+        except BaseException:
+            os.close(descriptor)
+            raise
+
+    def release_pinned_directory(self, token: int) -> None:
+        os.close(token)
+
     def acquire_directory_lock(self, key: Tuple[Any, ...]) -> Tuple[int, Path]:
         import fcntl
 
@@ -1272,7 +1336,9 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
     _FILE_DISPOSITION_FLAG_POSIX_SEMANTICS = 0x00000002
     _FILE_DISPOSITION_FLAG_IGNORE_READONLY_ATTRIBUTE = 0x00000010
     _DACL_SECURITY_INFORMATION = 0x00000004
-    _PROTECTED_DACL_SECURITY_INFORMATION = 0x80000000
+    _ACCESS_ALLOWED_ACE_TYPE = 0
+    _FILE_ALL_ACCESS = 0x001F01FF
+    _SE_DACL_PROTECTED = 0x1000
     _TOKEN_QUERY = 0x0008
     _TOKEN_USER = 1
     _SDDL_REVISION_1 = 1
@@ -1334,6 +1400,22 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
             ("nLength", wintypes.DWORD),
             ("lpSecurityDescriptor", wintypes.LPVOID),
             ("bInheritHandle", wintypes.BOOL),
+        ]
+
+    class _ACL_HEADER(ctypes.Structure):
+        _fields_ = [
+            ("AclRevision", ctypes.c_ubyte),
+            ("Sbz1", ctypes.c_ubyte),
+            ("AclSize", wintypes.WORD),
+            ("AceCount", wintypes.WORD),
+            ("Sbz2", wintypes.WORD),
+        ]
+
+    class _ACE_HEADER(ctypes.Structure):
+        _fields_ = [
+            ("AceType", ctypes.c_ubyte),
+            ("AceFlags", ctypes.c_ubyte),
+            ("AceSize", wintypes.WORD),
         ]
 
     def __init__(self) -> None:
@@ -1474,16 +1556,25 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
             ctypes.POINTER(wintypes.DWORD),
         ]
         self.advapi32.GetKernelObjectSecurity.restype = wintypes.BOOL
-        self.advapi32.ConvertSecurityDescriptorToStringSecurityDescriptorW.argtypes = [
+        self.advapi32.GetSecurityDescriptorControl.argtypes = [
             wintypes.LPVOID,
-            wintypes.DWORD,
-            wintypes.DWORD,
-            ctypes.POINTER(wintypes.LPWSTR),
+            ctypes.POINTER(wintypes.WORD),
             ctypes.POINTER(wintypes.DWORD),
         ]
-        self.advapi32.ConvertSecurityDescriptorToStringSecurityDescriptorW.restype = (
-            wintypes.BOOL
-        )
+        self.advapi32.GetSecurityDescriptorControl.restype = wintypes.BOOL
+        self.advapi32.GetSecurityDescriptorDacl.argtypes = [
+            wintypes.LPVOID,
+            ctypes.POINTER(wintypes.BOOL),
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.BOOL),
+        ]
+        self.advapi32.GetSecurityDescriptorDacl.restype = wintypes.BOOL
+        self.advapi32.GetAce.argtypes = [
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.LPVOID),
+        ]
+        self.advapi32.GetAce.restype = wintypes.BOOL
 
     @staticmethod
     def _path(path: Path) -> str:
@@ -1507,6 +1598,7 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
         access: int,
         creation: int = _OPEN_EXISTING,
         security: bool = False,
+        share_mode: Optional[int] = None,
     ) -> int:
         attributes = self._FILE_FLAG_OPEN_REPARSE_POINT
         if path.is_dir() or creation == self._OPEN_EXISTING:
@@ -1517,13 +1609,25 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
         handle = self.kernel32.CreateFileW(
             self._path(path),
             access,
-            self._FILE_SHARE_READ | self._FILE_SHARE_WRITE | self._FILE_SHARE_DELETE,
+            (
+                self._FILE_SHARE_READ
+                | self._FILE_SHARE_WRITE
+                | self._FILE_SHARE_DELETE
+                if share_mode is None
+                else share_mode
+            ),
             security_attributes,
             creation,
             attributes | self._FILE_ATTRIBUTE_NORMAL,
             None,
         )
         if handle == self._INVALID_HANDLE_VALUE:
+            error = ctypes.get_last_error()
+            if creation == self._CREATE_NEW and error in {
+                self._ERROR_FILE_EXISTS,
+                self._ERROR_ALREADY_EXISTS,
+            }:
+                raise FileExistsError(error, ctypes.FormatError(error).strip(), str(path))
             self._raise_last_error("cannot open filesystem handle", path)
         return int(handle)
 
@@ -1689,7 +1793,7 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
             self._raise_last_error("cannot create private directory", path)
         self.verify_private_security(path, is_directory=True)
 
-    def create_private_file(self, path: Path) -> int:
+    def create_private_file(self, path: Path, deny_delete: bool = False) -> int:
         handle = self._open_handle(
             path,
             self._GENERIC_READ
@@ -1701,6 +1805,11 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
             | self._FILE_WRITE_ATTRIBUTES,
             creation=self._CREATE_NEW,
             security=True,
+            share_mode=(
+                self._FILE_SHARE_READ | self._FILE_SHARE_WRITE
+                if deny_delete
+                else None
+            ),
         )
         self._validate_handle_type(handle, path, is_directory=False)
         self._validate_ntfs(handle, path)
@@ -1749,29 +1858,74 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
                 ctypes.byref(needed),
             ):
                 self._raise_last_error("cannot read private ACL", path)
-            sddl_pointer = wintypes.LPWSTR()
-            sddl_length = wintypes.DWORD()
-            if not self.advapi32.ConvertSecurityDescriptorToStringSecurityDescriptorW(
+            control = wintypes.WORD()
+            revision = wintypes.DWORD()
+            if not self.advapi32.GetSecurityDescriptorControl(
                 descriptor,
-                self._SDDL_REVISION_1,
-                self._DACL_SECURITY_INFORMATION,
-                ctypes.byref(sddl_pointer),
-                ctypes.byref(sddl_length),
+                ctypes.byref(control),
+                ctypes.byref(revision),
             ):
-                self._raise_last_error("cannot describe private ACL", path)
-            try:
-                sddl = sddl_pointer.value or ""
-            finally:
-                self.kernel32.LocalFree(sddl_pointer)
-            if not sddl.startswith("D:P"):
+                self._raise_last_error("cannot inspect private ACL control", path)
+            if not control.value & self._SE_DACL_PROTECTED:
                 raise HooksConflict(f"private ACL is not protected: {path}")
-            current_user_present = self._current_sid in sddl or (
-                self._current_sid.endswith("-500") and ";;;LA)" in sddl
-            )
-            if not current_user_present:
-                raise HooksConflict(f"private ACL does not grant the current user: {path}")
-            if "SY" not in sddl and "S-1-5-18" not in sddl:
-                raise HooksConflict(f"private ACL does not grant SYSTEM: {path}")
+            dacl_present = wintypes.BOOL()
+            dacl_defaulted = wintypes.BOOL()
+            dacl = wintypes.LPVOID()
+            if not self.advapi32.GetSecurityDescriptorDacl(
+                descriptor,
+                ctypes.byref(dacl_present),
+                ctypes.byref(dacl),
+                ctypes.byref(dacl_defaulted),
+            ):
+                self._raise_last_error("cannot inspect private DACL", path)
+            if not dacl_present.value or not dacl.value:
+                raise HooksConflict(f"private ACL has no DACL: {path}")
+            acl_header = ctypes.cast(
+                dacl,
+                ctypes.POINTER(self._ACL_HEADER),
+            ).contents
+            principals: Dict[str, int] = {}
+            for index in range(int(acl_header.AceCount)):
+                ace_pointer = wintypes.LPVOID()
+                if not self.advapi32.GetAce(dacl, index, ctypes.byref(ace_pointer)):
+                    self._raise_last_error("cannot inspect private ACL entry", path)
+                ace_address = int(ace_pointer.value)
+                header = ctypes.cast(
+                    ace_address,
+                    ctypes.POINTER(self._ACE_HEADER),
+                ).contents
+                if (
+                    header.AceType != self._ACCESS_ALLOWED_ACE_TYPE
+                    or header.AceFlags != 0
+                ):
+                    raise HooksConflict(f"private ACL has a non-canonical ACE: {path}")
+                mask = ctypes.cast(
+                    ace_address + ctypes.sizeof(self._ACE_HEADER),
+                    ctypes.POINTER(wintypes.DWORD),
+                ).contents.value
+                sid_pointer = wintypes.LPVOID(
+                    ace_address
+                    + ctypes.sizeof(self._ACE_HEADER)
+                    + ctypes.sizeof(wintypes.DWORD)
+                )
+                sid_string = wintypes.LPWSTR()
+                if not self.advapi32.ConvertSidToStringSidW(
+                    sid_pointer,
+                    ctypes.byref(sid_string),
+                ):
+                    self._raise_last_error("cannot describe private ACL principal", path)
+                try:
+                    sid = sid_string.value
+                finally:
+                    self.kernel32.LocalFree(sid_string)
+                if sid in principals:
+                    raise HooksConflict(f"private ACL repeats a principal: {path}")
+                principals[sid] = int(mask)
+            expected = {self._current_sid, "S-1-5-18"}
+            if set(principals) != expected or any(
+                mask != self._FILE_ALL_ACCESS for mask in principals.values()
+            ):
+                raise HooksConflict(f"private ACL grants unexpected access: {path}")
         finally:
             self.kernel32.CloseHandle(handle)
 
@@ -1836,6 +1990,7 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
             | self._FILE_LIST_DIRECTORY
             | self._FILE_READ_ATTRIBUTES
             | self._SYNCHRONIZE,
+            share_mode=self._FILE_SHARE_READ | self._FILE_SHARE_WRITE,
         )
         try:
             self._validate_handle_type(handle, path, is_directory=True)
@@ -1966,6 +2121,40 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
         access.entries = entries
         access.names = set(entries)
 
+    def remove_verified_file(
+        self,
+        path: Path,
+        expected_identity: FileIdentity,
+        expected: Any,
+    ) -> None:
+        handle = self._open_handle(
+            path,
+            self._GENERIC_READ | self._FILE_READ_ATTRIBUTES | self._DELETE,
+            share_mode=self._FILE_SHARE_READ | self._FILE_SHARE_WRITE,
+        )
+        descriptor = None
+        try:
+            self._validate_handle_type(handle, path, is_directory=False)
+            if self._handle_identity(handle) != expected_identity:
+                raise HooksConflict(f"待删除文件 identity 已变化，保留证据: {path}")
+            descriptor = self.msvcrt.open_osfhandle(
+                handle,
+                os.O_RDONLY | getattr(os, "O_BINARY", 0),
+            )
+            handle = 0
+            opened = os.fstat(descriptor)
+            actual = _fingerprint_descriptor(descriptor, opened, path)
+            self._validate_expected_fingerprint(path, actual, expected)
+            raw_handle = self.msvcrt.get_osfhandle(descriptor)
+            self._mark_delete(raw_handle, path)
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+            elif handle:
+                self.kernel32.CloseHandle(handle)
+        if _path_entry_exists(path):
+            raise HooksConflict(f"待删除文件删除后仍存在，保留证据: {path}")
+
     def flush_owned_directory(self, access: _OwnedDirectoryAccess) -> None:
         if access.handle is None:
             raise HooksConflict("owned directory handle is unavailable")
@@ -2052,6 +2241,34 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
         finally:
             self.kernel32.CloseHandle(handle)
 
+    def pin_directory_for_lock(self, path: Path, key: Tuple[Any, ...]) -> int:
+        handle = self._open_handle(
+            path,
+            self._FILE_LIST_DIRECTORY
+            | self._FILE_READ_ATTRIBUTES
+            | self._SYNCHRONIZE,
+            share_mode=self._FILE_SHARE_READ | self._FILE_SHARE_WRITE,
+        )
+        try:
+            self._validate_handle_type(handle, path, is_directory=True)
+            self._validate_ntfs(handle, path)
+            identity = self._handle_identity(handle)
+            canonical = self._canonical_path(handle, path)
+            current_key = (
+                identity.device,
+                identity.inode,
+                os.path.normcase(str(canonical)),
+            )
+            if current_key != key:
+                raise HooksConflict(f"锁定目录在加锁期间被替换: {path}")
+            return handle
+        except BaseException:
+            self.kernel32.CloseHandle(handle)
+            raise
+
+    def release_pinned_directory(self, token: int) -> None:
+        self.kernel32.CloseHandle(token)
+
     def acquire_directory_lock(self, key: Tuple[Any, ...]) -> int:
         digest = hashlib.sha256(repr(key).encode("utf-8")).hexdigest()
         name = f"Global\\JiaEthan.CodexKeysmith.{digest}"
@@ -2101,14 +2318,21 @@ def _normalize_operation_directories(paths: List[str]) -> List[_OperationDirecto
 class _DirectoryLockSet:
     def __init__(self, paths: List[str]) -> None:
         self.directories = _normalize_operation_directories(paths)
-        self.tokens: List[Any] = []
+        self.tokens: List[Tuple[Any, Any]] = []
 
     def __enter__(self) -> "_DirectoryLockSet":
         try:
             for directory in self.directories:
-                self.tokens.append(
-                    _FILESYSTEM.acquire_directory_lock(directory.lock_key)
-                )
+                lock_token = _FILESYSTEM.acquire_directory_lock(directory.lock_key)
+                try:
+                    pin_token = _FILESYSTEM.pin_directory_for_lock(
+                        directory.path,
+                        directory.lock_key,
+                    )
+                except BaseException:
+                    _FILESYSTEM.release_directory_lock(lock_token)
+                    raise
+                self.tokens.append((lock_token, pin_token))
         except BaseException:
             self._release()
             raise
@@ -2116,8 +2340,11 @@ class _DirectoryLockSet:
 
     def _release(self) -> None:
         while self.tokens:
-            token = self.tokens.pop()
-            _FILESYSTEM.release_directory_lock(token)
+            lock_token, pin_token = self.tokens.pop()
+            try:
+                _FILESYSTEM.release_pinned_directory(pin_token)
+            finally:
+                _FILESYSTEM.release_directory_lock(lock_token)
 
     def __exit__(self, exc_type, exc, traceback) -> None:
         del exc_type, exc, traceback
@@ -2351,6 +2578,7 @@ def _safe_remove_owned_directory(
                     name,
                     expected_members[name],
                 )
+                _filesystem_checkpoint("owned-directory-member-removed")
             _FILESYSTEM.flush_owned_directory(access)
             if JOURNAL_FILENAME in names:
                 _FILESYSTEM.remove_verified_member(
@@ -2358,6 +2586,7 @@ def _safe_remove_owned_directory(
                     JOURNAL_FILENAME,
                     expected_members[JOURNAL_FILENAME],
                 )
+                _filesystem_checkpoint("owned-directory-member-removed")
                 _FILESYSTEM.flush_owned_directory(access)
             if MANIFEST_INTENT_FILENAME in names:
                 _FILESYSTEM.remove_verified_member(
@@ -2365,6 +2594,7 @@ def _safe_remove_owned_directory(
                     MANIFEST_INTENT_FILENAME,
                     expected_members[MANIFEST_INTENT_FILENAME],
                 )
+                _filesystem_checkpoint("owned-directory-member-removed")
                 _FILESYSTEM.flush_owned_directory(access)
             expected_intent = expected_members[INTENT_FILENAME]
             portable_intent = (
@@ -2378,6 +2608,7 @@ def _safe_remove_owned_directory(
                 )
             if not _atomic_rename_no_replace(path / INTENT_FILENAME, marker):
                 raise HooksConflict(f"无法发布事务 journal cleanup marker: {marker}")
+            _filesystem_checkpoint("cleanup-marker-published")
             _FILESYSTEM.flush_owned_directory(access)
             cleanup_marker = (marker, expected_members[INTENT_FILENAME])
         else:
@@ -2387,8 +2618,12 @@ def _safe_remove_owned_directory(
                     name,
                     expected_members[name],
                 )
+                _filesystem_checkpoint("owned-directory-member-removed")
             _FILESYSTEM.flush_owned_directory(access)
         _FILESYSTEM.remove_verified_directory(access)
+        _filesystem_checkpoint("owned-directory-removed")
+        if journal_cleanup:
+            _filesystem_checkpoint("journal-directory-removed")
     finally:
         _FILESYSTEM.close_owned_directory(access)
     _fsync_directory(path.parent)
@@ -2403,7 +2638,12 @@ def _safe_remove_owned_directory(
                 marker,
                 "retained transaction cleanup marker",
             )
-        marker.unlink()
+        marker_identity = _require_regular_file(
+            marker,
+            "transaction cleanup marker",
+        )
+        _FILESYSTEM.remove_verified_file(marker, marker_identity, expected)
+        _filesystem_checkpoint("cleanup-marker-removed")
         _fsync_directory(path.parent)
     return None
 
@@ -2800,7 +3040,9 @@ def _atomic_write_private_json(path: Path, data: Dict[str, Any]) -> None:
             stream.flush()
             os.fsync(stream.fileno())
             _FILESYSTEM.apply_private_file_security(stream.fileno())
+        _filesystem_checkpoint("journal-pending-published")
         _FILESYSTEM.replace_atomic(temporary, path)
+        _filesystem_checkpoint("journal-file-published")
         _fsync_directory(path.parent)
     finally:
         if _path_entry_exists(temporary):
@@ -3029,6 +3271,7 @@ def _create_deployment_journals(
                 journal_dir / INTENT_FILENAME,
                 _immutable_journal_intent(journal_data),
             )
+            _filesystem_checkpoint("journal-intent-published")
             _atomic_write_private_json(journal_dir / JOURNAL_FILENAME, persisted)
             _fsync_directory(state.codex_dir)
 
@@ -3125,6 +3368,7 @@ def _update_deployment_journals(
         persisted = dict(data)
         persisted["owner_directory"] = str(state.codex_dir.resolve())
         _atomic_write_private_json(state.journal_dir / JOURNAL_FILENAME, persisted)
+        _filesystem_checkpoint("deployment-journal-phase-published")
 
 
 def _journal_expected_members(
@@ -5227,7 +5471,9 @@ def _finish_cleanup_intent_artifact(
             _portable_fingerprint(fingerprint),
             _require_regular_file(path, "retained cleanup marker"),
         )
-    path.unlink()
+    marker_identity = _require_regular_file(path, "cleanup marker")
+    _FILESYSTEM.remove_verified_file(path, marker_identity, fingerprint)
+    _filesystem_checkpoint("cleanup-marker-removed")
     _fsync_directory(owner)
     return None
 
@@ -5483,9 +5729,10 @@ def _remove_retained_cleanup_markers(
         require_claimed_identity(marker, identity)
         if not _portable_matches(marker, expected):
             raise HooksConflict(f"retained cleanup marker content changed: {marker}")
-    for marker, _expected, identity in markers:
+    for marker, expected, identity in markers:
         require_claimed_identity(marker, identity)
-        marker.unlink()
+        _FILESYSTEM.remove_verified_file(marker, identity, expected)
+        _filesystem_checkpoint("cleanup-marker-removed")
         _fsync_directory(marker.parent)
 
 
@@ -7633,6 +7880,7 @@ def _create_uninstall_journals(
                 state.journal_dir / INTENT_FILENAME,
                 _immutable_journal_intent(journal_data),
             )
+            _filesystem_checkpoint("journal-intent-published")
             _atomic_write_private_json(
                 state.journal_dir / JOURNAL_FILENAME,
                 persisted,

--- a/codex-instruct.py
+++ b/codex-instruct.py
@@ -1002,8 +1002,12 @@ class _PosixFilesystemBackend:
     def apply_private_file_security(self, descriptor: int) -> None:
         os.fchmod(descriptor, 0o600)
 
-    def apply_private_path_security(self, path: Path) -> None:
-        del path
+    def apply_private_path_security(
+        self,
+        path: Path,
+        expected: FileFingerprint,
+    ) -> None:
+        del path, expected
 
     def clone_file_security(self, descriptor: int, source_stat: os.stat_result) -> None:
         os.fchmod(descriptor, stat.S_IMODE(source_stat.st_mode))
@@ -1981,7 +1985,11 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
         ):
             self._raise_last_error("cannot apply private ACL")
 
-    def apply_private_path_security(self, path: Path) -> None:
+    def apply_private_path_security(
+        self,
+        path: Path,
+        expected: FileFingerprint,
+    ) -> None:
         handle = self._open_handle(
             path,
             self._GENERIC_READ
@@ -1989,20 +1997,46 @@ class _WindowsFilesystemBackend(_PosixFilesystemBackend):  # pragma: no cover
             | self._READ_CONTROL
             | self._WRITE_DAC
             | self._FILE_READ_ATTRIBUTES,
+            share_mode=self._FILE_SHARE_READ,
         )
+        descriptor = None
         try:
             self._validate_handle_type(handle, path, is_directory=False)
             self._validate_ntfs(handle, path)
-            if not self.advapi32.SetKernelObjectSecurity(
+            if not self._handle_matches_portable_identity(
+                self._handle_identity(handle),
+                expected.identity,
+            ):
+                raise HooksConflict(
+                    f"private ACL target identity changed before update: {path}"
+                )
+            descriptor = self.msvcrt.open_osfhandle(
                 handle,
+                os.O_RDWR | getattr(os, "O_BINARY", 0),
+            )
+            handle = 0
+            opened = os.fstat(descriptor)
+            actual = _fingerprint_descriptor(descriptor, opened, path)
+            self._validate_expected_fingerprint(path, actual, expected)
+            raw_handle = self.msvcrt.get_osfhandle(descriptor)
+            if not self.advapi32.SetKernelObjectSecurity(
+                raw_handle,
                 self._DACL_SECURITY_INFORMATION,
                 self._security_descriptor,
             ):
                 self._raise_last_error("cannot apply private ACL", path)
-            if not self.kernel32.FlushFileBuffers(handle):
+            if not self.kernel32.FlushFileBuffers(raw_handle):
                 self._raise_last_error("cannot persist private ACL", path)
+            self._validate_expected_fingerprint(
+                path,
+                _fingerprint_descriptor(descriptor, os.fstat(descriptor), path),
+                expected,
+            )
         finally:
-            self.kernel32.CloseHandle(handle)
+            if descriptor is not None:
+                os.close(descriptor)
+            elif handle:
+                self.kernel32.CloseHandle(handle)
 
     def clone_file_security(self, descriptor: int, source_stat: os.stat_result) -> None:
         del source_stat
@@ -4012,10 +4046,17 @@ def _validate_hooks_for_isolation(codex_dir: Path) -> Optional[dict]:
 
 def _atomic_rename_no_replace(source: Path, destination: Path) -> bool:
     """Atomically rename source while preserving an existing destination."""
-    renamed = _FILESYSTEM.atomic_rename_no_replace(source, destination)
-    if renamed and str(destination.parent) in _OWNED_DIRECTORY_RECORDS:
-        _FILESYSTEM.apply_private_path_security(destination)
-    return renamed
+    return _FILESYSTEM.atomic_rename_no_replace(source, destination)
+
+
+def _secure_verified_transaction_claim(
+    path: Path,
+    fingerprint: FileFingerprint,
+) -> None:
+    # Windows claims intentionally retain a private ACL when restored or published.
+    if str(path.parent) not in _OWNED_DIRECTORY_RECORDS:
+        raise HooksConflict(f"verified claim is outside an owned transaction: {path}")
+    _FILESYSTEM.apply_private_path_security(path, fingerprint)
 
 
 def _verify_atomic_rename_support(codex_dir: Path) -> None:
@@ -4319,6 +4360,7 @@ def _transactional_replace_existing(
         if claimed_fingerprint != expected_fingerprint:
             _rollback_claim(previous_claim, destination, timestamp)
             raise HooksConflict(f"目标文件在写入前发生变化: {destination}")
+        _secure_verified_transaction_claim(previous_claim, claimed_fingerprint)
 
         if not _atomic_rename_no_replace(prepared_file, destination):
             _rollback_claim(previous_claim, destination, timestamp)
@@ -4343,6 +4385,10 @@ def _transactional_replace_existing(
                         published_claim
                     )
                     if published_fingerprint == prepared_fingerprint:
+                        _secure_verified_transaction_claim(
+                            published_claim,
+                            published_fingerprint,
+                        )
                         published_claim.unlink()
                         if not _atomic_rename_no_replace(
                             previous_claim,
@@ -4365,7 +4411,12 @@ def _transactional_replace_existing(
                             timestamp,
                         )
                 else:
-                    _atomic_rename_no_replace(previous_claim, destination)
+                    if not _atomic_rename_no_replace(previous_claim, destination):
+                        _move_to_unique_recovery(
+                            previous_claim,
+                            destination,
+                            timestamp,
+                        )
         except BaseException as cleanup_exc:
             _print(
                 f"[事务警告] 写入回滚未完整完成: {cleanup_exc}",
@@ -4395,6 +4446,7 @@ def _rollback_owned_file(
         claimed_fingerprint = _fingerprint_regular_file(installed_claim)
         if claimed_fingerprint != installed_fingerprint:
             raise HooksConflict(f"待回滚文件已被并发替换: {destination}")
+        _secure_verified_transaction_claim(installed_claim, claimed_fingerprint)
         claim_verified = True
 
         if backup:
@@ -4520,6 +4572,7 @@ def isolate_hooks(
         active_fingerprint = _fingerprint_regular_file(active_claim)
         if active_fingerprint != expected_active:
             raise HooksConflict(f"hooks.json 在事务登记后发生变化: {hooks_path}")
+        _secure_verified_transaction_claim(active_claim, active_fingerprint)
         hooks_backup = _copy_to_unique_backup(
             active_claim,
             hooks_path,
@@ -4540,6 +4593,10 @@ def isolate_hooks(
                 raise HooksConflict(
                     f"hooks.json.disabled 在事务登记后发生变化: {disabled_path}"
                 )
+            _secure_verified_transaction_claim(
+                disabled_claim,
+                disabled_fingerprint,
+            )
             previous_disabled_backup = _move_to_unique_backup(
                 disabled_claim,
                 disabled_path,
@@ -4657,6 +4714,7 @@ def rollback_hooks_isolation(isolation: HooksIsolation) -> None:
             raise HooksConflict(
                 f"回滚时 hooks.json.disabled 已发生变化: {disabled_path}"
             )
+        _secure_verified_transaction_claim(disabled_claim, claimed_fingerprint)
 
         if not _atomic_rename_no_replace(disabled_claim, hooks_path):
             raise HooksConflict(f"回滚时 hooks.json 被并发创建: {hooks_path}")
@@ -4752,6 +4810,7 @@ def _restore_hooks_locked(codex_dir: Path) -> bool:
             raise HooksConflict(
                 f"hooks.json.disabled 在事务登记后发生变化: {disabled_path}"
             )
+        _secure_verified_transaction_claim(disabled_claim, disabled_fingerprint)
         _copy_snapshot(disabled_claim, recovery_copy)
         _filesystem_checkpoint("restore-hooks-recovery-copy-published")
         if (
@@ -4997,6 +5056,7 @@ def archive_legacy_file(
         claimed_fingerprint = _fingerprint_regular_file(legacy_claim)
         if claimed_fingerprint != expected_fingerprint:
             raise HooksConflict(f"旧版文件在预检后发生变化: {legacy_path}")
+        _secure_verified_transaction_claim(legacy_claim, claimed_fingerprint)
         config_path = state.codex_dir / "config.toml"
         if not _path_has_fingerprint(config_path, expected_config_fingerprint):
             raise HooksConflict(f"config.toml 在旧版文件认领后发生变化: {config_path}")
@@ -8543,6 +8603,7 @@ def _remove_owned_file(path: Path, expected: FileFingerprint) -> None:
         claimed = _fingerprint_regular_file(claim)
         if claimed != expected:
             raise HooksConflict(f"待删除文件已漂移: {path}")
+        _secure_verified_transaction_claim(claim, claimed)
         claim.unlink()
         _remove_transaction_dir(transaction_dir)
     except BaseException as primary:

--- a/scripts/run_prompt_bank_regression.py
+++ b/scripts/run_prompt_bank_regression.py
@@ -5,6 +5,7 @@ import argparse
 import ctypes
 import errno
 import hashlib
+import importlib.util
 import io
 import json
 import os
@@ -167,6 +168,26 @@ PASSTHROUGH_ENV_NAMES = (
     "AZURE_OPENAI_ENDPOINT",
     "AZURE_OPENAI_API_VERSION",
 )
+
+_KEYSMITH_FILESYSTEM = None
+
+
+def _keysmith_filesystem():
+    global _KEYSMITH_FILESYSTEM
+    if _KEYSMITH_FILESYSTEM is not None:
+        return _KEYSMITH_FILESYSTEM
+    module_path = REPO_ROOT / "codex-instruct.py"
+    spec = importlib.util.spec_from_file_location(
+        "codex_instruct_prompt_bank_filesystem",
+        module_path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load the keysmith filesystem backend")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    _KEYSMITH_FILESYSTEM = module._FILESYSTEM
+    return _KEYSMITH_FILESYSTEM
 
 
 class BankValidationError(ValueError):
@@ -775,19 +796,14 @@ def _atomic_report_rename_no_replace(source: Path, destination: Path) -> bool:
 
 
 def _fsync_report_directory(path: Path) -> None:
+    if os.name == "nt":
+        _keysmith_filesystem().flush_directory(path)
+        return
     flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
     flags |= getattr(os, "O_DIRECTORY", 0)
-    try:
-        descriptor = os.open(str(path), flags)
-    except OSError:
-        if os.name == "nt":
-            return
-        raise
+    descriptor = os.open(str(path), flags)
     try:
         os.fsync(descriptor)
-    except OSError:
-        if os.name != "nt":
-            raise
     finally:
         os.close(descriptor)
 
@@ -830,18 +846,24 @@ def _open_report(
     temporary_path = report_path.with_name(
         ".{}.keysmith-report-{}.tmp".format(report_path.name, uuid.uuid4().hex)
     )
-    flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
     try:
-        descriptor = os.open(str(temporary_path), flags, 0o600)
+        if os.name == "nt":
+            descriptor = _keysmith_filesystem().create_private_file(
+                temporary_path,
+                deny_delete=True,
+            )
+        else:
+            flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+            descriptor = os.open(str(temporary_path), flags, 0o600)
     except OSError as exc:
         raise RuntimeError("cannot create secure report file: {}".format(exc)) from exc
     try:
-        if hasattr(os, "fchmod"):
+        if os.name == "nt":
+            _keysmith_filesystem().apply_private_file_security(descriptor)
+        elif hasattr(os, "fchmod"):
             os.fchmod(descriptor, 0o600)
-        else:  # pragma: no cover - Windows uses ACLs rather than POSIX modes
-            os.chmod(temporary_path, 0o600)
         report = os.fdopen(descriptor, "w", encoding="utf-8", newline="\n")
     except BaseException:
         os.close(descriptor)

--- a/tests/test_codex_instruct.py
+++ b/tests/test_codex_instruct.py
@@ -49,6 +49,7 @@ def test_codex_dir_expands_user_and_requires_config(tmp_path, monkeypatch):
     codex_dir.mkdir(parents=True)
     (codex_dir / "config.toml").write_text('model = "gpt-5.6"\n', encoding="utf-8")
     monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
 
     assert codex_instruct.resolve_codex_dir("~/.codex") == codex_dir.resolve()
 
@@ -149,7 +150,7 @@ def test_atomic_write_cleans_temp_file_when_replace_fails(tmp_path, monkeypatch)
     def fail_replace(_source, _destination):
         raise OSError("simulated replace failure")
 
-    monkeypatch.setattr(codex_instruct.os, "replace", fail_replace)
+    monkeypatch.setattr(codex_instruct._FILESYSTEM, "replace_atomic", fail_replace)
 
     with pytest.raises(OSError, match="simulated replace failure"):
         codex_instruct.atomic_write_text(target, "new\n")
@@ -352,7 +353,7 @@ def test_restore_file_cleans_temp_file_when_replace_fails(tmp_path, monkeypatch)
     def fail_replace(_source, _destination):
         raise OSError("simulated replace failure")
 
-    monkeypatch.setattr(codex_instruct.os, "replace", fail_replace)
+    monkeypatch.setattr(codex_instruct._FILESYSTEM, "replace_atomic", fail_replace)
 
     with pytest.raises(OSError, match="simulated replace failure"):
         codex_instruct._restore_file_from_backup(backup, destination)
@@ -373,6 +374,47 @@ def test_backup_file_uses_incrementing_suffix_on_name_collision(tmp_path):
     assert second_backup.name == "rules.md.bak_20260628_120000_1"
     assert first_backup.read_text(encoding="utf-8") == "first"
     assert second_backup.read_text(encoding="utf-8") == "second"
+
+
+@pytest.mark.parametrize(
+    "winerror",
+    [
+        codex_instruct._WindowsFilesystemBackend._ERROR_FILE_EXISTS,
+        codex_instruct._WindowsFilesystemBackend._ERROR_ALREADY_EXISTS,
+    ],
+)
+def test_windows_create_new_collision_maps_to_file_exists(
+    tmp_path,
+    monkeypatch,
+    winerror,
+):
+    backend = object.__new__(codex_instruct._WindowsFilesystemBackend)
+    backend.kernel32 = types.SimpleNamespace(
+        CreateFileW=lambda *_args: backend._INVALID_HANDLE_VALUE,
+    )
+    monkeypatch.setattr(
+        codex_instruct.ctypes,
+        "get_last_error",
+        lambda: winerror,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        codex_instruct.ctypes,
+        "FormatError",
+        lambda error: f"Windows error {error}",
+        raising=False,
+    )
+    destination = tmp_path / "existing"
+
+    with pytest.raises(FileExistsError) as caught:
+        backend._open_handle(
+            destination,
+            access=backend._GENERIC_READ,
+            creation=backend._CREATE_NEW,
+        )
+
+    assert caught.value.errno == winerror
+    assert caught.value.filename == str(destination)
 
 
 def test_regular_and_private_file_opens_request_binary_mode(tmp_path, monkeypatch):
@@ -400,22 +442,31 @@ def test_regular_and_private_file_opens_request_binary_mode(tmp_path, monkeypatc
     destination_descriptor = codex_instruct._open_exclusive_private_file(destination)
     os.close(destination_descriptor)
 
-    assert len(observed_flags) == 2
+    expected_open_calls = 1 if os.name == "nt" else 2
+    assert len(observed_flags) == expected_open_calls
     assert all(flags & binary_flag for flags in observed_flags)
+    codex_instruct._FILESYSTEM.verify_private_security(
+        destination,
+        is_directory=False,
+    )
 
 
-def test_backup_creation_starts_private_and_fchmod_failure_is_not_silent(
+def test_backup_creation_starts_private_and_security_failure_is_not_silent(
     tmp_path,
     monkeypatch,
 ):
     target = tmp_path / "rules.md"
     target.write_text("sensitive\n", encoding="utf-8")
     real_open_private = codex_instruct._open_exclusive_private_file
-    observed_modes = []
+    observed_private_paths = []
 
     def observe_private_creation(path):
         descriptor = real_open_private(path)
-        observed_modes.append(os.fstat(descriptor).st_mode & 0o777)
+        codex_instruct._FILESYSTEM.verify_private_security(
+            path,
+            is_directory=False,
+        )
+        observed_private_paths.append(path)
         return descriptor
 
     monkeypatch.setattr(
@@ -423,35 +474,42 @@ def test_backup_creation_starts_private_and_fchmod_failure_is_not_silent(
         "_open_exclusive_private_file",
         observe_private_creation,
     )
-    real_fchmod = codex_instruct.os.fchmod
 
-    def fail_fchmod(descriptor, mode):
-        if observed_modes:
-            raise OSError("simulated fchmod failure")
-        return real_fchmod(descriptor, mode)
+    def fail_security_clone(_descriptor, _source_stat):
+        raise OSError("simulated private security failure")
 
-    monkeypatch.setattr(codex_instruct.os, "fchmod", fail_fchmod)
+    monkeypatch.setattr(
+        codex_instruct._FILESYSTEM,
+        "clone_file_security",
+        fail_security_clone,
+    )
 
-    with pytest.raises(OSError, match="simulated fchmod failure"):
+    with pytest.raises(OSError, match="simulated private security failure"):
         codex_instruct.backup_file(target, "20260716_120000")
 
-    assert observed_modes == [0o600]
+    assert observed_private_paths == [
+        tmp_path / "rules.md.bak_20260716_120000"
+    ]
     assert not list(tmp_path.glob("rules.md.bak_*"))
 
 
-def test_copy_to_unique_backup_does_not_silence_fchmod_failure(
+def test_copy_to_unique_backup_does_not_silence_security_failure(
     tmp_path,
     monkeypatch,
 ):
     source = tmp_path / "claimed"
     source.write_text("hooks\n", encoding="utf-8")
 
-    def fail_fchmod(_descriptor, _mode):
-        raise OSError("simulated fchmod failure")
+    def fail_security_clone(_descriptor, _source_stat):
+        raise OSError("simulated private security failure")
 
-    monkeypatch.setattr(codex_instruct.os, "fchmod", fail_fchmod)
+    monkeypatch.setattr(
+        codex_instruct._FILESYSTEM,
+        "clone_file_security",
+        fail_security_clone,
+    )
 
-    with pytest.raises(OSError, match="simulated fchmod failure"):
+    with pytest.raises(OSError, match="simulated private security failure"):
         codex_instruct._copy_to_unique_backup(
             source,
             tmp_path / "hooks.json",
@@ -1222,6 +1280,9 @@ def test_atomic_rename_probe_cleans_up_when_unsupported(tmp_path, monkeypatch):
 
 
 def test_linux_renameat2_enosys_maps_to_atomic_unavailable(tmp_path, monkeypatch):
+    if os.name == "nt":
+        pytest.skip("Linux renameat2 is not part of the Windows backend contract")
+
     class FakeRename:
         argtypes = None
         restype = None
@@ -2261,9 +2322,10 @@ def test_historical_legacy_hashes_are_detected(final_newline, tmp_path):
     codex_dir.mkdir()
     (codex_dir / "config.toml").write_text('model = "gpt-5.6"\n', encoding="utf-8")
     legacy = codex_dir / codex_instruct.LEGACY_MD_FILENAME
-    legacy.write_text(
-        HISTORICAL_LEGACY_PROMPT + ("\n" if final_newline else ""),
-        encoding="utf-8",
+    legacy.write_bytes(
+        (HISTORICAL_LEGACY_PROMPT + ("\n" if final_newline else "")).encode(
+            "utf-8"
+        )
     )
 
     plan = codex_instruct.inspect_directory(codex_dir)

--- a/tests/test_codex_instruct.py
+++ b/tests/test_codex_instruct.py
@@ -323,6 +323,53 @@ def test_transactional_replace_cleanup_preserves_concurrent_destination(
     assert not list(tmp_path.glob(".keysmith-write-*"))
 
 
+def test_transactional_replace_acl_failure_preserves_claim_on_restore_race(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "target.txt"
+    target.write_text("old\n", encoding="utf-8")
+    expected = codex_instruct._fingerprint_regular_file(target)
+    real_atomic_rename = codex_instruct._atomic_rename_no_replace
+    raced = False
+
+    def fail_claim_security(_path, _fingerprint):
+        raise PermissionError("primary ACL persistence failure")
+
+    def race_restore(source, destination):
+        nonlocal raced
+        source = Path(source)
+        destination = Path(destination)
+        if source.name == "previous" and destination == target and not raced:
+            target.write_text("concurrent\n", encoding="utf-8")
+            raced = True
+        return real_atomic_rename(source, destination)
+
+    monkeypatch.setattr(
+        codex_instruct,
+        "_secure_verified_transaction_claim",
+        fail_claim_security,
+    )
+    monkeypatch.setattr(
+        codex_instruct,
+        "_atomic_rename_no_replace",
+        race_restore,
+    )
+
+    with pytest.raises(PermissionError, match="primary ACL persistence failure"):
+        codex_instruct.atomic_write_text(
+            target,
+            "new\n",
+            expected_fingerprint=expected,
+        )
+
+    assert target.read_text(encoding="utf-8") == "concurrent\n"
+    recovery_files = list(tmp_path.glob("target.txt.recovery_*"))
+    assert len(recovery_files) == 1
+    assert recovery_files[0].read_text(encoding="utf-8") == "old\n"
+    assert not list(tmp_path.glob(".keysmith-write-*"))
+
+
 def test_rollback_owned_file_preserves_same_content_replacement(tmp_path):
     target = tmp_path / "target.txt"
     target.write_text("same content\n", encoding="utf-8")

--- a/tests/test_codex_instruct.py
+++ b/tests/test_codex_instruct.py
@@ -2315,14 +2315,17 @@ def test_restore_hooks_rejects_same_inode_change_during_recovery_copy(
 ):
     disabled_path = tmp_path / "hooks.json.disabled"
     disabled_path.write_text("original disabled\n", encoding="utf-8")
-    real_copy2 = codex_instruct.shutil.copy2
 
-    def copy_then_mutate(source, destination, *args, **kwargs):
-        result = real_copy2(source, destination, *args, **kwargs)
-        Path(source).write_text("mutated disabled\n", encoding="utf-8")
-        return result
+    def mutate_at_checkpoint(name):
+        if name == "restore-hooks-recovery-copy-published":
+            claim = next(tmp_path.glob(".keysmith-hooks-*/disabled"))
+            claim.write_text("mutated disabled\n", encoding="utf-8")
 
-    monkeypatch.setattr(codex_instruct.shutil, "copy2", copy_then_mutate)
+    monkeypatch.setattr(
+        codex_instruct,
+        "_FILESYSTEM_CHECKPOINT_HOOK",
+        mutate_at_checkpoint,
+    )
 
     with pytest.raises(codex_instruct.HooksConflict, match="发生变化"):
         codex_instruct.restore_hooks(tmp_path)

--- a/tests/test_config_boundaries.py
+++ b/tests/test_config_boundaries.py
@@ -21,7 +21,7 @@ def _make_symlink(link, target):
 
 def test_external_markdown_accepts_unicode_path_and_content(tmp_path):
     source = tmp_path / "规则-猫.md"
-    source.write_text("第一行\n🐈 café\n", encoding="utf-8")
+    source.write_bytes("第一行\n🐈 café\n".encode("utf-8"))
 
     assert codex_instruct.load_md_content(str(source)) == "第一行\n🐈 café\n"
 

--- a/tests/test_platform_and_discovery.py
+++ b/tests/test_platform_and_discovery.py
@@ -1,6 +1,6 @@
 import importlib.util
 import os
-import selectors
+import socket
 import subprocess
 import sys
 import textwrap
@@ -197,76 +197,75 @@ def test_atomic_no_replace_has_one_winner_across_processes(tmp_path):
     result_paths = [tmp_path / "result-1", tmp_path / "result-2"]
     sources = [tmp_path / "source-1", tmp_path / "source-2"]
     for index, source in enumerate(sources, start=1):
-        source.write_text(f"worker-{index}\n", encoding="utf-8")
+        source.write_bytes(f"worker-{index}\n".encode("utf-8"))
 
     worker = textwrap.dedent(
         """
         import importlib.util
+        import socket
         import sys
         from pathlib import Path
 
-        module_path, source, destination, result = map(Path, sys.argv[1:])
+        module_path, source, destination, result = map(Path, sys.argv[1:5])
+        barrier_port = int(sys.argv[5])
         spec = importlib.util.spec_from_file_location("keysmith_worker", module_path)
         module = importlib.util.module_from_spec(spec)
         sys.modules[spec.name] = module
         spec.loader.exec_module(module)
-        print("ready", flush=True)
-        if sys.stdin.buffer.read(1) != b"g":
-            raise SystemExit("start barrier closed")
+        with socket.create_connection(("127.0.0.1", barrier_port), timeout=10) as barrier:
+            barrier.sendall(b"r")
+            if barrier.recv(1) != b"g":
+                raise SystemExit("start barrier closed")
         try:
             moved = module._atomic_rename_no_replace(source, destination)
         except module.AtomicRenameUnavailable as exc:
-            result.write_text("unsupported:" + str(exc), encoding="utf-8")
+            result.write_bytes(("unsupported:" + str(exc)).encode("utf-8"))
         else:
-            result.write_text("won" if moved else "lost", encoding="utf-8")
+            result.write_bytes(b"won" if moved else b"lost")
         """
     )
-    processes = [
-        subprocess.Popen(
-            [
-                sys.executable,
-                "-c",
-                worker,
-                str(MODULE_PATH),
-                str(source),
-                str(destination),
-                str(result),
-            ],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        for source, result in zip(sources, result_paths)
-    ]
-    selector = selectors.DefaultSelector()
-    for process in processes:
-        assert process.stdout is not None
-        selector.register(process.stdout, selectors.EVENT_READ, process)
-    ready = set()
-    while len(ready) != len(processes):
-        events = selector.select(timeout=10)
-        if not events:
+    processes = []
+    barriers = []
+    outputs = []
+    with socket.create_server(("127.0.0.1", 0)) as server:
+        server.settimeout(10)
+        barrier_port = server.getsockname()[1]
+        try:
+            processes = [
+                subprocess.Popen(
+                    [
+                        sys.executable,
+                        "-c",
+                        worker,
+                        str(MODULE_PATH),
+                        str(source),
+                        str(destination),
+                        str(result),
+                        str(barrier_port),
+                    ],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+                for source, result in zip(sources, result_paths)
+            ]
+            for _process in processes:
+                barrier, _address = server.accept()
+                barrier.settimeout(5)
+                assert barrier.recv(1) == b"r"
+                barriers.append(barrier)
+            for barrier in barriers:
+                barrier.sendall(b"g")
+                barrier.close()
+            barriers.clear()
+            outputs = [process.communicate(timeout=15) for process in processes]
+        finally:
+            for barrier in barriers:
+                barrier.close()
             for process in processes:
-                process.kill()
-            pytest.fail("workers did not become ready")
-        for key, _mask in events:
-            process = key.data
-            line = key.fileobj.readline()
-            if line != "ready\n":
-                process.kill()
-                _stdout, stderr = process.communicate(timeout=5)
-                pytest.fail(f"worker readiness failed: {line!r}; stderr={stderr!r}")
-            ready.add(process)
-            selector.unregister(key.fileobj)
-    selector.close()
-    for process in processes:
-        assert process.stdin is not None
-        process.stdin.write("g")
-        process.stdin.flush()
-        process.stdin.close()
-        process.stdin = None
-    outputs = [process.communicate(timeout=15) for process in processes]
+                if process.poll() is None:
+                    process.kill()
+                    process.communicate(timeout=5)
     assert all(process.returncode == 0 for process in processes), outputs
 
     results = [path.read_text(encoding="utf-8") for path in result_paths]

--- a/tests/test_prompt_bank_regression.py
+++ b/tests/test_prompt_bank_regression.py
@@ -3,13 +3,34 @@ import json
 import os
 import stat
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RUNNER_PATH = REPO_ROOT / "scripts" / "run_prompt_bank_regression.py"
+KEYSMITH_PATH = REPO_ROOT / "codex-instruct.py"
 CASES_PATH = REPO_ROOT / "tests" / "prompt_bank" / "cases.json"
+
+keysmith_spec = importlib.util.spec_from_file_location(
+    "codex_instruct_prompt_bank_contract",
+    KEYSMITH_PATH,
+)
+keysmith_contract = importlib.util.module_from_spec(keysmith_spec)
+assert keysmith_spec.loader is not None
+sys.modules[keysmith_spec.name] = keysmith_contract
+keysmith_spec.loader.exec_module(keysmith_contract)
+
+
+def _assert_private_report(path):
+    if os.name == "nt":
+        keysmith_contract._FILESYSTEM.verify_private_security(
+            path,
+            is_directory=False,
+        )
+        return
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
 
 
 @pytest.fixture(scope="module")
@@ -290,6 +311,7 @@ def test_report_path_cannot_write_inside_real_codex_home(
     codex_home = home / ".codex"
     codex_home.mkdir(parents=True)
     monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
     report_path = codex_home / "reports" / "prompt-bank.jsonl"
 
     with pytest.raises(RuntimeError, match="outside the real Codex home"):
@@ -316,13 +338,13 @@ def test_report_is_private_and_atomically_published(prompt_bank_runner, tmp_path
     report, publication = prompt_bank_runner._open_report(str(report_path))
     assert publication is not None
     assert not report_path.exists()
-    assert stat.S_IMODE(os.fstat(report.fileno()).st_mode) == 0o600
+    _assert_private_report(publication.temporary_path)
 
     report.write('{"result":"ok"}\n')
     prompt_bank_runner._publish_report(report, publication)
 
     assert report_path.read_text(encoding="utf-8") == '{"result":"ok"}\n'
-    assert stat.S_IMODE(report_path.stat().st_mode) == 0o600
+    _assert_private_report(report_path)
     assert not publication.temporary_path.exists()
 
 
@@ -340,7 +362,7 @@ def test_report_overwrite_requires_explicit_flag(prompt_bank_runner, tmp_path):
     prompt_bank_runner._publish_report(report, publication)
 
     assert report_path.read_text(encoding="utf-8") == "new\n"
-    assert stat.S_IMODE(report_path.stat().st_mode) == 0o600
+    _assert_private_report(report_path)
 
 
 def test_report_overwrite_refuses_concurrent_replacement(
@@ -411,8 +433,16 @@ def test_report_publish_rejects_replaced_temporary_path(
     assert publication is not None
     report.write("owned\n")
     moved = tmp_path / "moved-owned.jsonl"
+    if os.name == "nt":
+        with pytest.raises(OSError) as caught:
+            publication.temporary_path.rename(moved)
+        assert caught.value.winerror == 32
+    report.flush()
+    os.fsync(report.fileno())
+    report.close()
     publication.temporary_path.rename(moved)
     publication.temporary_path.write_text("injected\n", encoding="utf-8")
+    report = moved.open("r+", encoding="utf-8", newline="\n")
 
     with pytest.raises(RuntimeError, match="temporary path changed concurrently"):
         prompt_bank_runner._publish_report(report, publication)

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -2,11 +2,12 @@ import hashlib
 import importlib.util
 import json
 import os
-import selectors
+import queue
 import shutil
 import signal
 import subprocess
 import sys
+import threading
 import types
 import uuid
 from pathlib import Path
@@ -19,12 +20,36 @@ codex_instruct = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = codex_instruct
 spec.loader.exec_module(codex_instruct)
 
+HARD_EXIT = 86
+
 
 def _make_codex_dir(tmp_path, name):
     codex_dir = tmp_path / name
     codex_dir.mkdir()
-    (codex_dir / "config.toml").write_text('model = "gpt-5.6"\n', encoding="utf-8")
+    (codex_dir / "config.toml").write_bytes(b'model = "gpt-5.6"\n')
     return codex_dir
+
+
+def _write_exact_text(path, content):
+    path.write_bytes(content.encode("utf-8"))
+
+
+def _filesystem_exit_hook_source(checkpoint, *, hit=1, exit_code=HARD_EXIT):
+    return f"""
+target_checkpoint = {checkpoint!r}
+target_hit = {hit}
+checkpoint_seen = 0
+
+def interrupt_at_filesystem_checkpoint(name):
+    global checkpoint_seen
+    if name != target_checkpoint:
+        return
+    checkpoint_seen += 1
+    if checkpoint_seen == target_hit:
+        os._exit({exit_code})
+
+m._FILESYSTEM_CHECKPOINT_HOOK = interrupt_at_filesystem_checkpoint
+"""
 
 
 def _run(*args):
@@ -52,19 +77,33 @@ def _prepare_journals(codex_dirs):
     return states, plans
 
 
+def _cleanup_marker_owner_and_remaining_journal(codex_dirs):
+    marker_owners = [
+        directory
+        for directory in codex_dirs
+        if codex_instruct._deployment_cleanup_markers(directory)
+    ]
+    remaining = [
+        journal
+        for directory in codex_dirs
+        for journal in codex_instruct._deployment_journal_dirs(directory)
+        if codex_instruct._cleanup_claim_base(journal.name) is None
+    ]
+    assert len(marker_owners) == 1
+    assert len(remaining) == 1
+    return marker_owners[0], remaining[0]
+
+
 def test_multi_directory_recover_restores_before_state(tmp_path):
     first = _make_codex_dir(tmp_path, "first")
     second = _make_codex_dir(tmp_path, "second")
     states, plans = _prepare_journals([first, second])
     for codex_dir, plan in zip((first, second), plans):
-        (codex_dir / codex_instruct.DEFAULT_MD_FILENAME).write_text(
+        _write_exact_text(
+            codex_dir / codex_instruct.DEFAULT_MD_FILENAME,
             codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD,
-            encoding="utf-8",
         )
-        (codex_dir / "config.toml").write_text(
-            plan.updated_config_content,
-            encoding="utf-8",
-        )
+        _write_exact_text(codex_dir / "config.toml", plan.updated_config_content)
 
     codex_instruct.recover_deployment([str(first)], yes=True)
 
@@ -487,29 +526,25 @@ def test_committed_multi_directory_cleanup_resumes_after_first_journal_removed(
     child = tmp_path / "kill_committed.py"
     child.write_text(
         f"""
-import importlib.util, os, signal, types
+import importlib.util, os, types
 spec = importlib.util.spec_from_file_location('child_keysmith', {str(MODULE_PATH)!r})
 m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
 m.find_codex_dirs = lambda: [{str(first)!r}, {str(second)!r}]
-original = m._remove_deployment_journals
-def kill_after_first(states):
-    original(states[:1])
-    os.kill(os.getpid(), signal.SIGKILL)
-m._remove_deployment_journals = kill_after_first
+{_filesystem_exit_hook_source("cleanup-marker-published")}
 m.deploy(types.SimpleNamespace(file=None, name='gpt-unrestricted', dry_run=False, yes=True, skip_hooks_isolation=False))
 """,
         encoding="utf-8",
     )
     child_result = subprocess.run([sys.executable, str(child)])
-    assert child_result.returncode < 0
-    assert not list(first.glob(f"{codex_instruct.JOURNAL_PREFIX}*"))
-    remaining = list(second.glob(f"{codex_instruct.JOURNAL_PREFIX}*"))
-    assert len(remaining) == 1
+    assert child_result.returncode == HARD_EXIT
+    marker_owner, remaining = _cleanup_marker_owner_and_remaining_journal(
+        (first, second)
+    )
 
-    resumed = _run("--codex-dir", second, "--recover", "--yes")
+    resumed = _run("--codex-dir", marker_owner, "--recover", "--yes")
 
     assert resumed.returncode == 0, resumed.stdout + resumed.stderr
-    assert not remaining[0].exists()
+    assert not remaining.exists()
     assert (first / codex_instruct.MANIFEST_FILENAME).is_file()
     assert (second / codex_instruct.MANIFEST_FILENAME).is_file()
 
@@ -533,19 +568,7 @@ m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
 m.find_codex_dirs = lambda: [{str(first)!r}, {str(second)!r}]
-real = m._atomic_rename_no_replace
-
-def wrapped(source, destination):
-    result = real(source, destination)
-    if (
-        result
-        and Path(source).name == m.INTENT_FILENAME
-        and Path(destination).name.startswith(m.CLEANUP_MARKER_PREFIX)
-    ):
-        os._exit(86)
-    return result
-
-m._atomic_rename_no_replace = wrapped
+{_filesystem_exit_hook_source("cleanup-marker-published")}
 m.deploy(types.SimpleNamespace(
     file=None,
     name="gpt-unrestricted",
@@ -561,8 +584,10 @@ m.deploy(types.SimpleNamespace(
         text=True,
         capture_output=True,
     )
-    assert result.returncode == 86, result.stdout + result.stderr
-    second_journal = next(second.glob(f"{codex_instruct.JOURNAL_PREFIX}*"))
+    assert result.returncode == HARD_EXIT, result.stdout + result.stderr
+    marker_owner, remaining_journal = _cleanup_marker_owner_and_remaining_journal(
+        (first, second)
+    )
 
     race_source = f"""
 import importlib.util
@@ -585,7 +610,7 @@ def wrapped(journals, phase, yes, retained_cleanup_markers):
     return real(journals, phase, yes, retained_cleanup_markers)
 
 m._cleanup_terminal_journals = wrapped
-m.recover_deployment([{str(first)!r}], True)
+m.recover_deployment([{str(marker_owner)!r}], True)
 """
     raced = tmp_path / f"race-deploy-terminal-{race}.py"
     raced.write_text(race_source, encoding="utf-8")
@@ -596,12 +621,17 @@ m.recover_deployment([{str(first)!r}], True)
     )
 
     assert raced_result.returncode == 1, raced_result.stdout + raced_result.stderr
-    assert second_journal.exists()
-    markers = codex_instruct._deployment_cleanup_markers(first)
+    assert remaining_journal.exists()
+    markers = codex_instruct._deployment_cleanup_markers(marker_owner)
     assert markers
     if race == "move":
-        assert not (first / "moved-retained-marker").exists()
-        resumed = _run("--codex-dir", second, "--recover", "--yes")
+        assert not (marker_owner / "moved-retained-marker").exists()
+        resumed = _run(
+            "--codex-dir",
+            remaining_journal.parent,
+            "--recover",
+            "--yes",
+        )
         assert resumed.returncode == 0, resumed.stdout + resumed.stderr
         assert not codex_instruct._hooks_transaction_residue(first)
         assert not codex_instruct._hooks_transaction_residue(second)
@@ -610,9 +640,14 @@ m.recover_deployment([{str(first)!r}], True)
             path.read_bytes() == b"replacement cleanup marker\n"
             for path in markers
         )
-        resumed = _run("--codex-dir", second, "--recover", "--yes")
+        resumed = _run(
+            "--codex-dir",
+            remaining_journal.parent,
+            "--recover",
+            "--yes",
+        )
         assert resumed.returncode == 1
-        assert second_journal.exists()
+        assert remaining_journal.exists()
 
 
 def test_committed_terminal_cleanup_discovers_all_participant_journals(tmp_path):
@@ -653,44 +688,32 @@ def test_recovered_multi_directory_cleanup_resumes_after_first_journal_removed(
     second = _make_codex_dir(tmp_path, "recovered-second")
     _states, plans = _prepare_journals([first, second])
     for codex_dir, plan in zip((first, second), plans):
-        (codex_dir / codex_instruct.DEFAULT_MD_FILENAME).write_text(
+        _write_exact_text(
+            codex_dir / codex_instruct.DEFAULT_MD_FILENAME,
             codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD,
-            encoding="utf-8",
         )
-        (codex_dir / "config.toml").write_text(
-            plan.updated_config_content,
-            encoding="utf-8",
-        )
+        _write_exact_text(codex_dir / "config.toml", plan.updated_config_content)
     child = tmp_path / "kill_recovered.py"
     child.write_text(
         f"""
-import importlib.util, os, signal
+import importlib.util, os
 spec = importlib.util.spec_from_file_location('child_keysmith', {str(MODULE_PATH)!r})
 m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
-original = m._safe_remove_owned_directory
-seen = 0
-def kill_before_second(path, identity, members, require_exact_members=False):
-    global seen
-    if path.name.startswith(m.JOURNAL_PREFIX):
-        seen += 1
-        if seen == 2:
-            os.kill(os.getpid(), signal.SIGKILL)
-    return original(path, identity, members, require_exact_members)
-m._safe_remove_owned_directory = kill_before_second
+{_filesystem_exit_hook_source("cleanup-marker-published")}
 m.recover_deployment([{str(first)!r}], True)
 """,
         encoding="utf-8",
     )
     child_result = subprocess.run([sys.executable, str(child)])
-    assert child_result.returncode < 0
-    assert not list(first.glob(f"{codex_instruct.JOURNAL_PREFIX}*"))
-    remaining = list(second.glob(f"{codex_instruct.JOURNAL_PREFIX}*"))
-    assert len(remaining) == 1
+    assert child_result.returncode == HARD_EXIT
+    marker_owner, remaining = _cleanup_marker_owner_and_remaining_journal(
+        (first, second)
+    )
 
-    resumed = _run("--codex-dir", second, "--recover", "--yes")
+    resumed = _run("--codex-dir", marker_owner, "--recover", "--yes")
 
     assert resumed.returncode == 0, resumed.stdout + resumed.stderr
-    assert not remaining[0].exists()
+    assert not remaining.exists()
     for codex_dir in (first, second):
         assert (codex_dir / "config.toml").read_text(encoding="utf-8") == (
             'model = "gpt-5.6"\n'
@@ -698,31 +721,21 @@ m.recover_deployment([{str(first)!r}], True)
         assert not (codex_dir / codex_instruct.DEFAULT_MD_FILENAME).exists()
 
 
-@pytest.mark.skipif(os.name == "nt", reason="POSIX hard-exit coverage")
 def test_recover_resumes_after_journal_member_cleanup_interruption(tmp_path):
     codex_dir = _make_codex_dir(tmp_path, "journal-cleanup-kill")
     _states, plans = _prepare_journals([codex_dir])
-    (codex_dir / codex_instruct.DEFAULT_MD_FILENAME).write_text(
+    _write_exact_text(
+        codex_dir / codex_instruct.DEFAULT_MD_FILENAME,
         codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD,
-        encoding="utf-8",
     )
-    (codex_dir / "config.toml").write_text(
-        plans[0].updated_config_content,
-        encoding="utf-8",
-    )
+    _write_exact_text(codex_dir / "config.toml", plans[0].updated_config_content)
     child = tmp_path / "kill_journal_cleanup.py"
     child.write_text(
         f"""
 import importlib.util, os, sys
 spec = importlib.util.spec_from_file_location('child_keysmith', {str(MODULE_PATH)!r})
 m = importlib.util.module_from_spec(spec); sys.modules[spec.name] = m; spec.loader.exec_module(m)
-real = m.os.unlink
-def kill_after_journal(name, *args, **kwargs):
-    result = real(name, *args, **kwargs)
-    if str(name) == m.JOURNAL_FILENAME and kwargs.get('dir_fd') is not None:
-        os._exit(91)
-    return result
-m.os.unlink = kill_after_journal
+{_filesystem_exit_hook_source("cleanup-marker-published", exit_code=91)}
 m.recover_deployment([{str(codex_dir)!r}], True)
 """,
         encoding="utf-8",
@@ -747,32 +760,21 @@ m.recover_deployment([{str(codex_dir)!r}], True)
     )
 
 
-@pytest.mark.skipif(os.name == "nt", reason="POSIX hard-exit coverage")
 def test_recover_resumes_after_cleanup_marker_publication(tmp_path):
     codex_dir = _make_codex_dir(tmp_path, "cleanup-marker-kill")
     _states, plans = _prepare_journals([codex_dir])
-    (codex_dir / codex_instruct.DEFAULT_MD_FILENAME).write_text(
+    _write_exact_text(
+        codex_dir / codex_instruct.DEFAULT_MD_FILENAME,
         codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD,
-        encoding="utf-8",
     )
-    (codex_dir / "config.toml").write_text(
-        plans[0].updated_config_content,
-        encoding="utf-8",
-    )
+    _write_exact_text(codex_dir / "config.toml", plans[0].updated_config_content)
     child = tmp_path / "kill_cleanup_marker.py"
     child.write_text(
         f"""
 import importlib.util, os, sys
-from pathlib import Path
 spec = importlib.util.spec_from_file_location('child_keysmith', {str(MODULE_PATH)!r})
 m = importlib.util.module_from_spec(spec); sys.modules[spec.name] = m; spec.loader.exec_module(m)
-real = m._atomic_rename_no_replace
-def kill_after_marker(source, destination):
-    result = real(source, destination)
-    if Path(source).name == m.INTENT_FILENAME and Path(destination).name.startswith(m.CLEANUP_MARKER_PREFIX):
-        os._exit(92)
-    return result
-m._atomic_rename_no_replace = kill_after_marker
+{_filesystem_exit_hook_source("cleanup-marker-published", exit_code=92)}
 m.recover_deployment([{str(codex_dir)!r}], True)
 """,
         encoding="utf-8",
@@ -837,10 +839,7 @@ def test_recover_reenters_after_remove_claim_interruption(tmp_path):
     codex_dir = _make_codex_dir(tmp_path, "recover-reentrant-remove")
     _states, _plans = _prepare_journals([codex_dir])
     prompt = codex_dir / codex_instruct.DEFAULT_MD_FILENAME
-    prompt.write_text(
-        codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD,
-        encoding="utf-8",
-    )
+    _write_exact_text(prompt, codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD)
     child = tmp_path / "kill_recover_remove.py"
     child.write_text(
         f"""
@@ -878,12 +877,9 @@ def test_recover_reenters_after_replace_claim_interruption(tmp_path):
     codex_dir = _make_codex_dir(tmp_path, "recover-reentrant-replace")
     _states, plans = _prepare_journals([codex_dir])
     prompt = codex_dir / codex_instruct.DEFAULT_MD_FILENAME
-    prompt.write_text(
-        codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD,
-        encoding="utf-8",
-    )
+    _write_exact_text(prompt, codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD)
     config = codex_dir / "config.toml"
-    config.write_text(plans[0].updated_config_content, encoding="utf-8")
+    _write_exact_text(config, plans[0].updated_config_content)
     child = tmp_path / "kill_recover_replace.py"
     child.write_text(
         f"""
@@ -966,14 +962,11 @@ def test_recover_uses_early_manifest_companion_before_phase_update(tmp_path):
             "manifest_sha256": {str(codex_dir.resolve()): digest},
         },
     )
-    (codex_dir / codex_instruct.DEFAULT_MD_FILENAME).write_text(
+    _write_exact_text(
+        codex_dir / codex_instruct.DEFAULT_MD_FILENAME,
         codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD,
-        encoding="utf-8",
     )
-    (codex_dir / "config.toml").write_text(
-        plans[0].updated_config_content,
-        encoding="utf-8",
-    )
+    _write_exact_text(codex_dir / "config.toml", plans[0].updated_config_content)
 
     result = _run("--codex-dir", codex_dir, "--recover", "--yes")
 
@@ -1045,14 +1038,11 @@ def test_recover_reconciles_interrupted_manifest_companion_publish(
         )
     else:
         pending.write_text('{"transaction_id":', encoding="utf-8")
-    (codex_dir / codex_instruct.DEFAULT_MD_FILENAME).write_text(
+    _write_exact_text(
+        codex_dir / codex_instruct.DEFAULT_MD_FILENAME,
         codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD,
-        encoding="utf-8",
     )
-    (codex_dir / "config.toml").write_text(
-        plans[0].updated_config_content,
-        encoding="utf-8",
-    )
+    _write_exact_text(codex_dir / "config.toml", plans[0].updated_config_content)
 
     result = _run("--codex-dir", codex_dir, "--recover", "--yes")
 
@@ -1232,12 +1222,12 @@ def test_recover_final_sweep_detects_change_after_recovered_phase(
 ):
     codex_dir = _make_codex_dir(tmp_path, "recover-final-race")
     _states, plans = _prepare_journals([codex_dir])
-    (codex_dir / codex_instruct.DEFAULT_MD_FILENAME).write_text(
+    _write_exact_text(
+        codex_dir / codex_instruct.DEFAULT_MD_FILENAME,
         codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD,
-        encoding="utf-8",
     )
     config = codex_dir / "config.toml"
-    config.write_text(plans[0].updated_config_content, encoding="utf-8")
+    _write_exact_text(config, plans[0].updated_config_content)
     original = codex_instruct._update_deployment_journals
 
     def update_then_race(states, phase, manifest_sha256=None):
@@ -1429,41 +1419,48 @@ def test_reserved_legacy_name_and_unicode_path_translation(tmp_path):
     assert str(spaced_prompt) in spaced.stdout
 
 
-@pytest.mark.skipif(os.name == "nt", reason="POSIX SIGKILL coverage")
 def test_sigkill_deployment_is_recoverable_from_durable_journal(tmp_path):
     codex_dir = _make_codex_dir(tmp_path, "sigkill")
     hooks_bytes = b"checkpointed active hooks\n"
     (codex_dir / "hooks.json").write_bytes(hooks_bytes)
     original_config = (codex_dir / "config.toml").read_bytes()
-    checkpoint_read, checkpoint_write = os.pipe()
     process = None
     child = tmp_path / "sigkill-checkpoint.py"
     child.write_text(
         f"""
 import importlib.util
-import os
-import signal
 import sys
 import types
 from pathlib import Path
 
 module_path = Path({str(MODULE_PATH)!r})
 codex_dir = Path({str(codex_dir)!r})
-checkpoint_fd = {checkpoint_write}
 spec = importlib.util.spec_from_file_location("sigkill_child", module_path)
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
 m.find_codex_dirs = lambda: [str(codex_dir)]
 real_update = m._update_deployment_journals
+current_phase = None
 
-def update_then_pause(states, phase, manifest_sha256=None):
-    real_update(states, phase, manifest_sha256)
-    if phase == "legacy-intent":
-        os.write(checkpoint_fd, b"1")
-        signal.pause()
+def track_phase(states, phase, manifest_sha256=None):
+    global current_phase
+    current_phase = phase
+    try:
+        return real_update(states, phase, manifest_sha256)
+    finally:
+        current_phase = None
 
-m._update_deployment_journals = update_then_pause
+def pause_at_checkpoint(name):
+    if (
+        name == "deployment-journal-phase-published"
+        and current_phase == "legacy-intent"
+    ):
+        print("KEYSMITH_CHECKPOINT", flush=True)
+        sys.stdin.buffer.read(1)
+
+m._update_deployment_journals = track_phase
+m._FILESYSTEM_CHECKPOINT_HOOK = pause_at_checkpoint
 m.deploy(types.SimpleNamespace(
     file=None,
     name="gpt-unrestricted",
@@ -1478,44 +1475,49 @@ raise AssertionError("SIGKILL checkpoint was not reached")
     try:
         process = subprocess.Popen(
             [sys.executable, str(child)],
-            pass_fds=(checkpoint_write,),
+            stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
         )
-        os.close(checkpoint_write)
-        checkpoint_write = None
-        selector = selectors.DefaultSelector()
+        assert process.stdout is not None
+        checkpoint_queue = queue.Queue()
+
+        def read_checkpoint():
+            for line in process.stdout:
+                if line.strip() == "KEYSMITH_CHECKPOINT":
+                    checkpoint_queue.put(True)
+                    return
+            checkpoint_queue.put(False)
+
+        reader = threading.Thread(target=read_checkpoint, daemon=True)
+        reader.start()
         try:
-            selector.register(checkpoint_read, selectors.EVENT_READ)
-            if not selector.select(timeout=10):
-                pytest.fail("SIGKILL deployment checkpoint timed out")
-            checkpoint = os.read(checkpoint_read, 1)
-        finally:
-            selector.close()
-        assert checkpoint == b"1"
+            checkpoint_reached = checkpoint_queue.get(timeout=10)
+        except queue.Empty:
+            pytest.fail("deployment checkpoint timed out")
+        if not checkpoint_reached:
+            stderr = process.stderr.read() if process.stderr is not None else ""
+            pytest.fail(f"deployment exited before checkpoint: {stderr}")
         assert list(codex_dir.glob(f"{codex_instruct.JOURNAL_PREFIX}*"))
         assert not (codex_dir / "hooks.json").exists()
-        os.kill(process.pid, signal.SIGKILL)
-        stdout, stderr = process.communicate(timeout=5)
+        process.kill()
+        process.wait(timeout=5)
         returncode = process.returncode
         process = None
-        assert returncode == -signal.SIGKILL, stdout + stderr
+        if os.name == "nt":
+            assert returncode != 0
+        else:
+            assert returncode == -signal.SIGKILL
     finally:
-        for descriptor in (checkpoint_read, checkpoint_write):
-            if descriptor is not None:
-                try:
-                    os.close(descriptor)
-                except OSError:
-                    pass
         if process is not None:
             if process.poll() is None:
                 process.kill()
             try:
-                process.communicate(timeout=5)
+                process.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 process.kill()
-                process.communicate(timeout=5)
+                process.wait(timeout=5)
 
     status = _run("--codex-dir", codex_dir, "--status")
     assert status.returncode == 1

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -34,6 +34,16 @@ def _write_exact_text(path, content):
     path.write_bytes(content.encode("utf-8"))
 
 
+def _write_private_bytes(path, content):
+    descriptor = codex_instruct._open_exclusive_private_file(path)
+    with os.fdopen(descriptor, "wb") as stream:
+        stream.write(content)
+        stream.flush()
+        os.fsync(stream.fileno())
+        codex_instruct._FILESYSTEM.apply_private_file_security(stream.fileno())
+    codex_instruct._fsync_directory(path.parent)
+
+
 def _filesystem_exit_hook_source(checkpoint, *, hit=1, exit_code=HARD_EXIT):
     return f"""
 target_checkpoint = {checkpoint!r}
@@ -160,7 +170,7 @@ def test_deploy_recovery_rejects_tampered_base_with_valid_pending(tmp_path):
     journal = journal_dir / codex_instruct.JOURNAL_FILENAME
     pending = journal_dir / codex_instruct.JOURNAL_PENDING_FILENAME
     valid_bytes = journal.read_bytes()
-    pending.write_bytes(valid_bytes)
+    _write_private_bytes(pending, valid_bytes)
     data = json.loads(valid_bytes)
     data["directories"] = []
     journal.write_text(json.dumps(data), encoding="utf-8")
@@ -801,9 +811,9 @@ def test_safe_cleanup_preserves_directory_created_after_atomic_claim(
     monkeypatch,
 ):
     owned = tmp_path / "owned"
-    owned.mkdir()
+    codex_instruct._FILESYSTEM.create_private_directory(owned)
     member = owned / "snapshot"
-    member.write_text("owned\n", encoding="utf-8")
+    _write_private_bytes(member, b"owned\n")
     identity = codex_instruct._directory_identity(owned)
     fingerprint = codex_instruct._fingerprint_regular_file(member)
     original_rename = codex_instruct._atomic_rename_no_replace
@@ -919,7 +929,7 @@ def test_recover_merges_residue_record_from_any_participant(tmp_path):
     states, _plans = _prepare_journals([first, second])
     transaction_id = states[0].deployment_id
     residue = first / f".keysmith-write-prepared-{transaction_id}-partial"
-    residue.mkdir()
+    codex_instruct._FILESYSTEM.create_private_directory(residue)
     record = {
         "name": residue.name,
         "identity": codex_instruct._portable_identity(
@@ -992,9 +1002,10 @@ def test_recover_rejects_invalid_manifest_companion(tmp_path, mode):
     codex_instruct._atomic_write_private_json(journal_path, data)
     companion = states[0].journal_dir / codex_instruct.MANIFEST_INTENT_FILENAME
     if mode == "invalid-json":
-        companion.write_text('{"transaction_id":', encoding="utf-8")
+        _write_private_bytes(companion, b'{"transaction_id":')
     else:
-        companion.write_text(
+        _write_private_bytes(
+            companion,
             json.dumps(
                 {
                     "transaction_id": states[0].deployment_id,
@@ -1002,8 +1013,7 @@ def test_recover_rejects_invalid_manifest_companion(tmp_path, mode):
                         str(codex_dir.resolve()): hashlib.sha256(b"companion").hexdigest()
                     },
                 }
-            ),
-            encoding="utf-8",
+            ).encode("utf-8"),
         )
 
     result = _run("--codex-dir", codex_dir, "--recover", "--yes")
@@ -1037,7 +1047,7 @@ def test_recover_reconciles_interrupted_manifest_companion_publish(
             },
         )
     else:
-        pending.write_text('{"transaction_id":', encoding="utf-8")
+        _write_private_bytes(pending, b'{"transaction_id":')
     _write_exact_text(
         codex_dir / codex_instruct.DEFAULT_MD_FILENAME,
         codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD,
@@ -1063,7 +1073,7 @@ def test_recover_reconciles_interrupted_journal_publish(tmp_path, pending_valid)
         data["phase"] = "files-intent"
         codex_instruct._write_exclusive_private_json(pending, data)
     else:
-        pending.write_text('{"phase":', encoding="utf-8")
+        _write_private_bytes(pending, b'{"phase":')
 
     result = _run("--codex-dir", codex_dir, "--recover", "--yes")
 

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -619,7 +619,7 @@ def test_builder_rejects_missing_file_and_incomplete_mit_notice(
         release_builder.build_release(TAG, license_repo, tmp_path / "license-assets")
 
 
-def test_ci_uses_full_tag_checkout_and_only_claims_supported_platforms():
+def test_ci_uses_full_tag_checkout_and_blocking_windows_matrix():
     workflow = (REPO_ROOT / ".github" / "workflows" / "tests.yml").read_text(
         encoding="utf-8"
     )
@@ -633,9 +633,15 @@ def test_ci_uses_full_tag_checkout_and_only_claims_supported_platforms():
     assert '"pytest==8.4.2"' in workflow
     assert 'python-version == \'3.9\'' in workflow
     assert 'python-version == \'3.8\'' not in workflow
-    assert "windows-2025" not in workflow
+    assert "windows-2025" in workflow
+    assert '"3.10"' in workflow
+    assert '"3.14"' in workflow
     assert "continue-on-error" not in workflow
     assert "Windows experimental atomic no-replace probe passed" not in workflow
+    windows_job = workflow.split("\n  windows:", 1)[1].split("\n  quality:", 1)[0]
+    assert "runs-on: windows-2025" in windows_job
+    assert "python -m py_compile codex-instruct.py" in windows_job
+    assert "python -m pytest -p no:cacheprovider -q tests" in windows_job
     quality_job = workflow.split("\n  quality:", 1)[1]
     assert "fetch-depth: 0" in quality_job
     assert "fetch-tags: true" in quality_job

--- a/tests/test_uninstall_recovery.py
+++ b/tests/test_uninstall_recovery.py
@@ -35,17 +35,15 @@ def _run(*args):
 def _make_rich_deployment(tmp_path, name):
     codex_dir = tmp_path / name
     codex_dir.mkdir()
-    (codex_dir / "config.toml").write_text(
-        'model_instructions_file = "./gpt5.5-unrestricted.md"\n'
-        'model = "gpt-5.6"\n',
-        encoding="utf-8",
+    (codex_dir / "config.toml").write_bytes(
+        (
+            'model_instructions_file = "./gpt5.5-unrestricted.md"\n'
+            'model = "gpt-5.6"\n'
+        ).encode("utf-8"),
     )
     (codex_dir / "hooks.json").write_bytes(b"\x00active hooks\xff")
     (codex_dir / "hooks.json.disabled").write_bytes(b"previous disabled\n")
-    (codex_dir / codex_instruct.LEGACY_MD_FILENAME).write_text(
-        "legacy prompt\n",
-        encoding="utf-8",
-    )
+    (codex_dir / codex_instruct.LEGACY_MD_FILENAME).write_bytes(b"legacy prompt\n")
     deployed = _run("--codex-dir", codex_dir, "--yes")
     assert deployed.returncode == 0, deployed.stdout + deployed.stderr
     return codex_dir
@@ -83,6 +81,24 @@ def _write_child(tmp_path, name, source):
         text=True,
         capture_output=True,
     )
+
+
+def _filesystem_exit_hook_source(checkpoint, *, hit=1):
+    return f"""
+target_checkpoint = {checkpoint!r}
+target_hit = {hit}
+checkpoint_seen = 0
+
+def interrupt_at_filesystem_checkpoint(name):
+    global checkpoint_seen
+    if name != target_checkpoint:
+        return
+    checkpoint_seen += 1
+    if checkpoint_seen == target_hit:
+        os._exit({HARD_EXIT})
+
+m._FILESYSTEM_CHECKPOINT_HOOK = interrupt_at_filesystem_checkpoint
+"""
 
 
 def _interrupt_uninstall(tmp_path, codex_dirs, checkpoint, *, hit=1):
@@ -190,41 +206,27 @@ sys.modules[spec.name] = m
 spec.loader.exec_module(m)
 
 checkpoint = {checkpoint!r}
-if checkpoint in {{"first-intent", "second-intent"}}:
-    real = m._write_exclusive_private_json
-    published = 0
-    target = 1 if checkpoint == "first-intent" else 2
-    def wrapped(path, data):
-        global published
-        result = real(path, data)
-        if Path(path).name == m.INTENT_FILENAME:
-            published += 1
-            if published == target:
-                os._exit({HARD_EXIT})
-        return result
-    m._write_exclusive_private_json = wrapped
-elif checkpoint == "first-journal-pending":
-    real = m.os.replace
-    def wrapped(source, destination):
-        if (
-            Path(source).name == m.JOURNAL_PENDING_FILENAME
-            and Path(destination).name == m.JOURNAL_FILENAME
-        ):
+if checkpoint in {{
+    "first-intent",
+    "second-intent",
+    "first-journal-pending",
+    "first-journal",
+}}:
+    checkpoint_name, target = {{
+        "first-intent": ("journal-intent-published", 1),
+        "second-intent": ("journal-intent-published", 2),
+        "first-journal-pending": ("journal-pending-published", 1),
+        "first-journal": ("journal-file-published", 1),
+    }}[checkpoint]
+    seen = 0
+    def interrupt_at_checkpoint(name):
+        global seen
+        if name != checkpoint_name:
+            return
+        seen += 1
+        if seen == target:
             os._exit({HARD_EXIT})
-        return real(source, destination)
-    m.os.replace = wrapped
-elif checkpoint == "first-journal":
-    real = m._atomic_write_private_json
-    published = 0
-    def wrapped(path, data):
-        global published
-        result = real(path, data)
-        if Path(path).name == m.JOURNAL_FILENAME:
-            published += 1
-            if published == 1:
-                os._exit({HARD_EXIT})
-        return result
-    m._atomic_write_private_json = wrapped
+    m._FILESYSTEM_CHECKPOINT_HOOK = interrupt_at_checkpoint
 elif checkpoint == "first-snapshot":
     real = m._copy_snapshot
     copied = 0
@@ -447,19 +449,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-real = m._atomic_rename_no_replace
-
-def wrapped(source, destination):
-    result = real(source, destination)
-    if (
-        result
-        and Path(source).name == m.INTENT_FILENAME
-        and Path(destination).name.startswith(m.CLEANUP_MARKER_PREFIX)
-    ):
-        os._exit({HARD_EXIT})
-    return result
-
-m._atomic_rename_no_replace = wrapped
+{_filesystem_exit_hook_source("cleanup-marker-published")}
 m.recover_deployment([{str(first)!r}], True)
 """
     cleanup_interrupted = _write_child(
@@ -508,16 +498,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-real = m._safe_remove_owned_directory
-second = Path({str(second)!r}).resolve()
-
-def wrapped(path, *args, **kwargs):
-    result = real(path, *args, **kwargs)
-    if result is not None and Path(path).parent.resolve() == second:
-        os._exit({HARD_EXIT})
-    return result
-
-m._safe_remove_owned_directory = wrapped
+{_filesystem_exit_hook_source("owned-directory-removed")}
 m.recover_deployment([{str(first)!r}], True)
 """
     cleanup_interrupted = _write_child(
@@ -697,20 +678,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-real = m._safe_remove_owned_directory
-seen = 0
-
-def wrapped(path, *args, **kwargs):
-    global seen
-    name = m._cleanup_claim_base(Path(path).name) or Path(path).name
-    result = real(path, *args, **kwargs)
-    if name.startswith(m.JOURNAL_PREFIX):
-        seen += 1
-        if seen == 1:
-            os._exit({HARD_EXIT})
-    return result
-
-m._safe_remove_owned_directory = wrapped
+{_filesystem_exit_hook_source("owned-directory-removed")}
 m.recover_deployment([{str(first)!r}], True)
 """
     cleanup_interrupted = _write_child(tmp_path, "interrupt-journal-cleanup.py", source)
@@ -741,19 +709,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-real = m._atomic_rename_no_replace
-
-def wrapped(source, destination):
-    result = real(source, destination)
-    if (
-        result
-        and Path(source).name == m.INTENT_FILENAME
-        and Path(destination).name.startswith(m.CLEANUP_MARKER_PREFIX)
-    ):
-        os._exit({HARD_EXIT})
-    return result
-
-m._atomic_rename_no_replace = wrapped
+{_filesystem_exit_hook_source("cleanup-marker-published")}
 m.recover_deployment([{str(codex_dir)!r}], True)
 """
     cleanup_interrupted = _write_child(tmp_path, "interrupt-cleanup-marker.py", source)
@@ -789,19 +745,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-real = m._atomic_rename_no_replace
-
-def wrapped(source, destination):
-    result = real(source, destination)
-    if (
-        result
-        and Path(source).name == m.INTENT_FILENAME
-        and Path(destination).name.startswith(m.CLEANUP_MARKER_PREFIX)
-    ):
-        os._exit({HARD_EXIT})
-    return result
-
-m._atomic_rename_no_replace = wrapped
+{_filesystem_exit_hook_source("cleanup-marker-published")}
 m.recover_deployment([{str(first)!r}], True)
 """
     cleanup_interrupted = _write_child(
@@ -847,19 +791,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-real = m._atomic_rename_no_replace
-
-def wrapped(source, destination):
-    result = real(source, destination)
-    if (
-        result
-        and Path(source).name == m.INTENT_FILENAME
-        and Path(destination).name.startswith(m.CLEANUP_MARKER_PREFIX)
-    ):
-        os._exit({HARD_EXIT})
-    return result
-
-m._atomic_rename_no_replace = wrapped
+{_filesystem_exit_hook_source("cleanup-marker-published")}
 m.recover_deployment([{str(first)!r}], True)
 """
     cleanup_interrupted = _write_child(
@@ -931,19 +863,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-real = m._atomic_rename_no_replace
-
-def wrapped(source, destination):
-    result = real(source, destination)
-    if (
-        result
-        and Path(source).name == m.INTENT_FILENAME
-        and Path(destination).name.startswith(m.CLEANUP_MARKER_PREFIX)
-    ):
-        os._exit({HARD_EXIT})
-    return result
-
-m._atomic_rename_no_replace = wrapped
+{_filesystem_exit_hook_source("cleanup-marker-published")}
 m.recover_deployment([{str(first)!r}], True)
 """
     cleanup_interrupted = _write_child(
@@ -963,13 +883,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-real = m._remove_retained_cleanup_markers
-
-def wrapped(markers):
-    real(markers)
-    os._exit({HARD_EXIT})
-
-m._remove_retained_cleanup_markers = wrapped
+{_filesystem_exit_hook_source("cleanup-marker-removed")}
 m.recover_deployment([{str(first)!r}], True)
 """
     deleted = _write_child(
@@ -1005,19 +919,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-real = m._atomic_rename_no_replace
-
-def wrapped(source, destination):
-    result = real(source, destination)
-    if (
-        result
-        and Path(source).name == m.INTENT_FILENAME
-        and Path(destination).name.startswith(m.CLEANUP_MARKER_PREFIX)
-    ):
-        os._exit({HARD_EXIT})
-    return result
-
-m._atomic_rename_no_replace = wrapped
+{_filesystem_exit_hook_source("cleanup-marker-published")}
 m.recover_deployment([{str(first)!r}], True)
 """
     cleanup_interrupted = _write_child(
@@ -1054,19 +956,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-real = m._atomic_rename_no_replace
-
-def wrapped(source, destination):
-    result = real(source, destination)
-    if (
-        result
-        and Path(source).name == m.INTENT_FILENAME
-        and Path(destination).name.startswith(m.CLEANUP_MARKER_PREFIX)
-    ):
-        os._exit({HARD_EXIT})
-    return result
-
-m._atomic_rename_no_replace = wrapped
+{_filesystem_exit_hook_source("cleanup-marker-published")}
 m.recover_deployment([{str(first)!r}], True)
 """
     cleanup_interrupted = _write_child(
@@ -1122,19 +1012,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-real = m._atomic_rename_no_replace
-
-def wrapped(source, destination):
-    result = real(source, destination)
-    if (
-        result
-        and Path(source).name == m.INTENT_FILENAME
-        and Path(destination).name.startswith(m.CLEANUP_MARKER_PREFIX)
-    ):
-        os._exit({HARD_EXIT})
-    return result
-
-m._atomic_rename_no_replace = wrapped
+{_filesystem_exit_hook_source("cleanup-marker-published")}
 m.recover_deployment([{str(first)!r}], True)
 """
     cleanup_interrupted = _write_child(
@@ -1200,19 +1078,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-real = m._atomic_rename_no_replace
-
-def wrapped(source, destination):
-    result = real(source, destination)
-    if (
-        result
-        and Path(source).name == m.INTENT_FILENAME
-        and Path(destination).name.startswith(m.CLEANUP_MARKER_PREFIX)
-    ):
-        os._exit({HARD_EXIT})
-    return result
-
-m._atomic_rename_no_replace = wrapped
+{_filesystem_exit_hook_source("cleanup-marker-published")}
 m.recover_deployment([{str(first)!r}], True)
 """
     cleanup_interrupted = _write_child(
@@ -1253,19 +1119,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-real = m._atomic_rename_no_replace
-
-def wrapped(source, destination):
-    result = real(source, destination)
-    if (
-        result
-        and Path(source).name == m.INTENT_FILENAME
-        and Path(destination).name.startswith(m.CLEANUP_MARKER_PREFIX)
-    ):
-        os._exit({HARD_EXIT})
-    return result
-
-m._atomic_rename_no_replace = wrapped
+{_filesystem_exit_hook_source("cleanup-marker-published")}
 m.recover_deployment([{str(first)!r}], True)
 """
     cleanup_interrupted = _write_child(
@@ -1351,19 +1205,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-real = m._atomic_rename_no_replace
-
-def wrapped(source, destination):
-    result = real(source, destination)
-    if (
-        result
-        and Path(source).name == m.INTENT_FILENAME
-        and Path(destination).name.startswith(m.CLEANUP_MARKER_PREFIX)
-    ):
-        os._exit({HARD_EXIT})
-    return result
-
-m._atomic_rename_no_replace = wrapped
+{_filesystem_exit_hook_source("cleanup-marker-published")}
 m.recover_deployment([{str(first)!r}], True)
 """
     cleanup_interrupted = _write_child(
@@ -1400,19 +1242,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-real = m._atomic_rename_no_replace
-
-def wrapped(source, destination):
-    result = real(source, destination)
-    if (
-        result
-        and Path(source).name == m.INTENT_FILENAME
-        and Path(destination).name.startswith(m.CLEANUP_MARKER_PREFIX)
-    ):
-        os._exit({HARD_EXIT})
-    return result
-
-m._atomic_rename_no_replace = wrapped
+{_filesystem_exit_hook_source("cleanup-marker-published")}
 m.recover_deployment([{str(first)!r}], True)
 """
     cleanup_interrupted = _write_child(
@@ -1453,19 +1283,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-real = m._atomic_rename_no_replace
-
-def wrapped(source, destination):
-    result = real(source, destination)
-    if (
-        result
-        and Path(source).name == m.INTENT_FILENAME
-        and Path(destination).name.startswith(m.CLEANUP_MARKER_PREFIX)
-    ):
-        os._exit({HARD_EXIT})
-    return result
-
-m._atomic_rename_no_replace = wrapped
+{_filesystem_exit_hook_source("cleanup-marker-published")}
 m.recover_deployment([{str(first)!r}], True)
 """
     cleanup_interrupted = _write_child(
@@ -1566,20 +1384,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-real = m._safe_remove_owned_directory
-removed = 0
-
-def wrapped(path, *args, **kwargs):
-    global removed
-    base = m._cleanup_claim_base(Path(path).name) or Path(path).name
-    result = real(path, *args, **kwargs)
-    if base.startswith(m.JOURNAL_PREFIX):
-        removed += 1
-        if removed == 1:
-            os._exit({HARD_EXIT})
-    return result
-
-m._safe_remove_owned_directory = wrapped
+{_filesystem_exit_hook_source("owned-directory-removed")}
 m.uninstall([{str(first)!r}, {str(second)!r}], True)
 """
     interrupted = _write_child(tmp_path, "interrupt-committed-cleanup.py", source)

--- a/tests/test_uninstall_recovery.py
+++ b/tests/test_uninstall_recovery.py
@@ -32,6 +32,16 @@ def _run(*args):
     )
 
 
+def _write_private_bytes(path, content):
+    descriptor = codex_instruct._open_exclusive_private_file(path)
+    with os.fdopen(descriptor, "wb") as stream:
+        stream.write(content)
+        stream.flush()
+        os.fsync(stream.fileno())
+        codex_instruct._FILESYSTEM.apply_private_file_security(stream.fileno())
+    codex_instruct._fsync_directory(path.parent)
+
+
 def _make_rich_deployment(tmp_path, name):
     codex_dir = tmp_path / name
     codex_dir.mkdir()
@@ -500,11 +510,12 @@ def test_uninstall_recovery_cleans_partial_initializing_snapshots_and_pending(
     snapshot_journal = _single_journal(snapshot_owner)
     pending = snapshot_journal / codex_instruct.JOURNAL_PENDING_FILENAME
     if pending_valid:
-        pending.write_bytes(
+        _write_private_bytes(
+            pending,
             (snapshot_journal / codex_instruct.JOURNAL_FILENAME).read_bytes()
         )
     else:
-        pending.write_text('{"phase":', encoding="utf-8")
+        _write_private_bytes(pending, b'{"phase":')
 
     recovered = _run("--codex-dir", second, "--recover", "--yes")
 
@@ -1263,7 +1274,7 @@ m.recover_deployment([{str(pending_owner)!r}], True)
         (first, second)
     )
     pending = remaining_journal / codex_instruct.JOURNAL_PENDING_FILENAME
-    pending.write_text("{", encoding="utf-8")
+    pending.write_bytes(b"{")
     first_evidence = _snapshot_tree(first)
     second_evidence = _snapshot_tree(second)
 
@@ -1314,7 +1325,7 @@ def test_uninstall_recovery_rejects_tampered_base_with_valid_pending(tmp_path):
     journal = journal_dir / codex_instruct.JOURNAL_FILENAME
     pending = journal_dir / codex_instruct.JOURNAL_PENDING_FILENAME
     valid_bytes = journal.read_bytes()
-    pending.write_bytes(valid_bytes)
+    _write_private_bytes(pending, valid_bytes)
     data = json.loads(valid_bytes)
     data["directories"] = []
     journal.write_text(json.dumps(data), encoding="utf-8")
@@ -1561,7 +1572,7 @@ m.uninstall([{str(first)!r}, {str(second)!r}], True)
     assert journal_dir.exists()
 
     pending = journal_dir / codex_instruct.JOURNAL_PENDING_FILENAME
-    pending.write_bytes(journal_path.read_bytes())
+    _write_private_bytes(pending, journal_path.read_bytes())
     recovered = _run("--codex-dir", remaining, "--recover", "--yes")
     assert recovered.returncode == 0, recovered.stdout + recovered.stderr
     for codex_dir in (first, second):
@@ -1637,9 +1648,9 @@ def test_uninstall_journal_loader_rejects_structural_evidence_tampering(
             encoding="utf-8",
         )
     else:
-        (journal_dir / codex_instruct.MANIFEST_INTENT_FILENAME).write_text(
-            "{}\n",
-            encoding="utf-8",
+        codex_instruct._write_exclusive_private_json(
+            journal_dir / codex_instruct.MANIFEST_INTENT_FILENAME,
+            {},
         )
 
     if damage not in {"intent-json", "manifest-companion"}:
@@ -1734,12 +1745,15 @@ def test_uninstall_resource_invariants_reject_ambiguous_recovery_state(
 @pytest.mark.parametrize("damage", ["invalid-json", "invalid-operation"])
 def test_journal_operation_rejects_unusable_dispatch_metadata(tmp_path, damage):
     journal_dir = tmp_path / f"operation-{damage}"
-    journal_dir.mkdir()
+    codex_instruct._FILESYSTEM.create_private_directory(journal_dir)
     journal = journal_dir / codex_instruct.JOURNAL_FILENAME
     if damage == "invalid-json":
-        journal.write_text("{", encoding="utf-8")
+        _write_private_bytes(journal, b"{")
     else:
-        journal.write_text(json.dumps({"operation": "unknown"}), encoding="utf-8")
+        codex_instruct._write_exclusive_private_json(
+            journal,
+            {"operation": "unknown"},
+        )
 
     with pytest.raises(ValueError):
         codex_instruct._journal_operation(journal_dir)

--- a/tests/test_uninstall_recovery.py
+++ b/tests/test_uninstall_recovery.py
@@ -293,6 +293,21 @@ def _directory_with_journal_member(codex_dirs, member):
     return matches[0]
 
 
+def _directory_with_journal_snapshot(codex_dirs):
+    matches = [
+        directory
+        for directory in codex_dirs
+        if any(
+            member.name.startswith("snapshot-")
+            for node in directory.glob(f"{codex_instruct.JOURNAL_PREFIX}*")
+            if node.is_dir()
+            for member in node.iterdir()
+        )
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
 def _cleanup_marker_owner_and_remaining_journal(codex_dirs):
     marker_owners = [
         directory
@@ -330,13 +345,21 @@ def test_uninstall_recovery_cleans_partial_multi_directory_journal_publication(t
     )
 
     assert interrupted.returncode == HARD_EXIT, interrupted.stdout + interrupted.stderr
-    assert len(_journal_dirs(first)) == 1
-    second_nodes = list(second.glob(f"{codex_instruct.JOURNAL_PREFIX}*"))
-    assert len(second_nodes) == 1
-    assert second_nodes[0].is_dir()
-    assert not list(second_nodes[0].iterdir())
+    members = _journal_node_members((first, second))
+    assert sorted(members.values(), key=len) == [
+        set(),
+        {
+            codex_instruct.INTENT_FILENAME,
+            codex_instruct.JOURNAL_FILENAME,
+        },
+    ]
+    anchor = next(
+        directory
+        for directory, names in members.items()
+        if codex_instruct.JOURNAL_FILENAME in names
+    )
 
-    preview = _run("--codex-dir", first, "--recover")
+    preview = _run("--codex-dir", anchor, "--recover")
     assert preview.returncode == 0, preview.stdout + preview.stderr
     _assert_no_cjk(preview.stdout + preview.stderr)
     for codex_dir in (first, second):
@@ -346,7 +369,7 @@ def test_uninstall_recovery_cleans_partial_multi_directory_journal_publication(t
             if not key.startswith(codex_instruct.JOURNAL_PREFIX)
         }
 
-    recovered = _run("--codex-dir", first, "--recover", "--yes")
+    recovered = _run("--codex-dir", anchor, "--recover", "--yes")
     assert recovered.returncode == 0, recovered.stdout + recovered.stderr
     _assert_no_cjk(recovered.stdout + recovered.stderr)
     for codex_dir in (first, second):
@@ -473,11 +496,12 @@ def test_uninstall_recovery_cleans_partial_initializing_snapshots_and_pending(
         "first-snapshot",
     )
     assert interrupted.returncode == HARD_EXIT, interrupted.stdout + interrupted.stderr
-    first_journal = _single_journal(first)
-    pending = first_journal / codex_instruct.JOURNAL_PENDING_FILENAME
+    snapshot_owner = _directory_with_journal_snapshot((first, second))
+    snapshot_journal = _single_journal(snapshot_owner)
+    pending = snapshot_journal / codex_instruct.JOURNAL_PENDING_FILENAME
     if pending_valid:
         pending.write_bytes(
-            (first_journal / codex_instruct.JOURNAL_FILENAME).read_bytes()
+            (snapshot_journal / codex_instruct.JOURNAL_FILENAME).read_bytes()
         )
     else:
         pending.write_text('{"phase":', encoding="utf-8")
@@ -531,15 +555,11 @@ m.recover_deployment([{str(journal_owner)!r}], True)
         source,
     )
     assert cleanup_interrupted.returncode == HARD_EXIT
-    assert list(
-        second.glob(
-            f"{codex_instruct.CLEANUP_MARKER_PREFIX}*"
-            f"{codex_instruct.CLEANUP_MARKER_SUFFIX}"
-        )
+    marker_owner, _remaining_journal = _cleanup_marker_owner_and_remaining_journal(
+        (first, second)
     )
-    assert _journal_dirs(first)
 
-    recovered = _run("--codex-dir", first, "--recover", "--yes")
+    recovered = _run("--codex-dir", marker_owner, "--recover", "--yes")
 
     assert recovered.returncode == 0, recovered.stdout + recovered.stderr
     _assert_no_cjk(recovered.stdout + recovered.stderr)
@@ -1063,7 +1083,10 @@ m.recover_deployment([{str(first)!r}], True)
         marker_source,
     )
     assert cleanup_interrupted.returncode == HARD_EXIT
-    first_evidence = _snapshot_tree(first)
+    marker_owner, remaining_journal = _cleanup_marker_owner_and_remaining_journal(
+        (first, second)
+    )
+    marker_evidence = _snapshot_tree(marker_owner)
 
     race_source = f"""
 import importlib.util
@@ -1075,21 +1098,21 @@ m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
 real = m._recover_uninstall
-second = Path({str(second)!r})
+remaining = Path({str(remaining_journal.parent)!r})
 
 def wrapped(codex_dirs, yes):
-    journal = next(second.glob(f"{{m.JOURNAL_PREFIX}}*")) / m.JOURNAL_FILENAME
+    journal = next(remaining.glob(f"{{m.JOURNAL_PREFIX}}*")) / m.JOURNAL_FILENAME
     journal.write_text("{{", encoding="utf-8")
     return real(codex_dirs, yes)
 
 m._recover_uninstall = wrapped
-m.recover_deployment([{str(first)!r}], True)
+m.recover_deployment([{str(marker_owner)!r}], True)
 """
     raced = _write_child(tmp_path, "race-after-cleanup-preflight.py", race_source)
 
     assert raced.returncode == 1
-    assert _snapshot_tree(first) == first_evidence
-    assert (_single_journal(second) / codex_instruct.JOURNAL_FILENAME).read_text(
+    assert _snapshot_tree(marker_owner) == marker_evidence
+    assert (remaining_journal / codex_instruct.JOURNAL_FILENAME).read_text(
         encoding="utf-8"
     ) == "{"
 
@@ -1119,7 +1142,9 @@ m.recover_deployment([{str(first)!r}], True)
         marker_source,
     )
     assert cleanup_interrupted.returncode == HARD_EXIT
-    second_journal = _single_journal(second)
+    marker_owner, remaining_journal = _cleanup_marker_owner_and_remaining_journal(
+        (first, second)
+    )
 
     race_source = f"""
 import importlib.util
@@ -1132,28 +1157,28 @@ sys.modules[spec.name] = m
 spec.loader.exec_module(m)
 real = m._recover_cleanup_artifacts
 calls = 0
-first = Path({str(first)!r})
+marker_owner = Path({str(marker_owner)!r})
 
 def wrapped(*args, **kwargs):
     global calls
     result = real(*args, **kwargs)
     calls += 1
     if calls == 2:
-        marker = next(first.glob(
+        marker = next(marker_owner.glob(
             f"{{m.CLEANUP_MARKER_PREFIX}}*{{m.CLEANUP_MARKER_SUFFIX}}"
         ))
         marker.write_text("{{", encoding="utf-8")
     return result
 
 m._recover_cleanup_artifacts = wrapped
-m.recover_deployment([{str(first)!r}], True)
+m.recover_deployment([{str(marker_owner)!r}], True)
 """
     raced = _write_child(tmp_path, "race-after-inner-cleanup-preflight.py", race_source)
 
     assert raced.returncode == 1
-    assert second_journal.exists()
+    assert remaining_journal.exists()
     assert list(
-        first.glob(
+        marker_owner.glob(
             f"{codex_instruct.CLEANUP_MARKER_PREFIX}*"
             f"{codex_instruct.CLEANUP_MARKER_SUFFIX}"
         )
@@ -1185,15 +1210,19 @@ m.recover_deployment([{str(first)!r}], True)
         source,
     )
     assert cleanup_interrupted.returncode == HARD_EXIT
-    first_evidence = _snapshot_tree(first)
-    moved = second.with_name(second.name + "-moved")
-    second.rename(moved)
+    marker_owner, remaining_journal = _cleanup_marker_owner_and_remaining_journal(
+        (first, second)
+    )
+    anchor_evidence = _snapshot_tree(marker_owner)
+    participant = remaining_journal.parent
+    moved = participant.with_name(participant.name + "-moved")
+    participant.rename(moved)
     moved_evidence = _snapshot_tree(moved)
 
-    recovered = _run("--codex-dir", first, "--recover", "--yes")
+    recovered = _run("--codex-dir", marker_owner, "--recover", "--yes")
 
     assert recovered.returncode == 1
-    assert _snapshot_tree(first) == first_evidence
+    assert _snapshot_tree(marker_owner) == anchor_evidence
     assert _snapshot_tree(moved) == moved_evidence
 
 

--- a/tests/test_uninstall_recovery.py
+++ b/tests/test_uninstall_recovery.py
@@ -1021,12 +1021,17 @@ m.recover_deployment([{str(first)!r}], True)
         source,
     )
     assert cleanup_interrupted.returncode == HARD_EXIT
+    marker_owner, remaining_journal = _cleanup_marker_owner_and_remaining_journal(
+        (first, second)
+    )
+    (remaining_journal / codex_instruct.JOURNAL_FILENAME).write_text(
+        "{",
+        encoding="utf-8",
+    )
     first_evidence = _snapshot_tree(first)
-    second_journal = _single_journal(second) / codex_instruct.JOURNAL_FILENAME
-    second_journal.write_text("{", encoding="utf-8")
     second_evidence = _snapshot_tree(second)
 
-    recovered = _run("--codex-dir", first, "--recover", "--yes")
+    recovered = _run("--codex-dir", marker_owner, "--recover", "--yes")
 
     assert recovered.returncode == 1
     assert _snapshot_tree(first) == first_evidence

--- a/tests/test_uninstall_recovery.py
+++ b/tests/test_uninstall_recovery.py
@@ -498,7 +498,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-{_filesystem_exit_hook_source("owned-directory-removed")}
+    {_filesystem_exit_hook_source("journal-directory-removed")}
 m.recover_deployment([{str(first)!r}], True)
 """
     cleanup_interrupted = _write_child(
@@ -678,7 +678,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-{_filesystem_exit_hook_source("owned-directory-removed")}
+    {_filesystem_exit_hook_source("journal-directory-removed")}
 m.recover_deployment([{str(first)!r}], True)
 """
     cleanup_interrupted = _write_child(tmp_path, "interrupt-journal-cleanup.py", source)
@@ -1384,7 +1384,7 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-{_filesystem_exit_hook_source("owned-directory-removed")}
+{_filesystem_exit_hook_source("journal-directory-removed")}
 m.uninstall([{str(first)!r}, {str(second)!r}], True)
 """
     interrupted = _write_child(tmp_path, "interrupt-committed-cleanup.py", source)
@@ -1399,7 +1399,7 @@ m.uninstall([{str(first)!r}, {str(second)!r}], True)
 
     preview = _run("--codex-dir", remaining, "--recover")
     assert preview.returncode == 0, preview.stdout + preview.stderr
-    assert "committed" in preview.stdout
+    assert "Cleanup residue" in preview.stdout
     assert journal_dir.exists()
 
     pending = journal_dir / codex_instruct.JOURNAL_PENDING_FILENAME

--- a/tests/test_uninstall_recovery.py
+++ b/tests/test_uninstall_recovery.py
@@ -260,6 +260,56 @@ def _single_journal(codex_dir):
     return journals[0]
 
 
+def _single_journal_node(codex_dir):
+    nodes = [
+        path
+        for path in codex_dir.glob(f"{codex_instruct.JOURNAL_PREFIX}*")
+        if path.is_dir() and codex_instruct._cleanup_claim_base(path.name) is None
+    ]
+    assert len(nodes) == 1
+    return nodes[0]
+
+
+def _journal_node_members(codex_dirs):
+    result = {}
+    for directory in codex_dirs:
+        nodes = list(directory.glob(f"{codex_instruct.JOURNAL_PREFIX}*"))
+        assert len(nodes) == 1
+        result[directory] = {path.name for path in nodes[0].iterdir()}
+    return result
+
+
+def _directory_with_journal_member(codex_dirs, member):
+    matches = [
+        directory
+        for directory in codex_dirs
+        if any(
+            (node / member).is_file()
+            for node in directory.glob(f"{codex_instruct.JOURNAL_PREFIX}*")
+            if node.is_dir()
+        )
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _cleanup_marker_owner_and_remaining_journal(codex_dirs):
+    marker_owners = [
+        directory
+        for directory in codex_dirs
+        if codex_instruct._deployment_cleanup_markers(directory)
+    ]
+    remaining = [
+        node
+        for directory in codex_dirs
+        for node in directory.glob(f"{codex_instruct.JOURNAL_PREFIX}*")
+        if node.is_dir() and codex_instruct._cleanup_claim_base(node.name) is None
+    ]
+    assert len(marker_owners) == 1
+    assert len(remaining) == 1
+    return marker_owners[0], remaining[0]
+
+
 def _assert_no_transaction_artifacts(codex_dir):
     assert not codex_instruct._hooks_transaction_residue(codex_dir)
 
@@ -327,27 +377,31 @@ def test_uninstall_recovery_cleans_partial_initial_intent_publication(
     )
 
     assert interrupted.returncode == HARD_EXIT, interrupted.stdout + interrupted.stderr
-    first_nodes = list(first.glob(f"{codex_instruct.JOURNAL_PREFIX}*"))
-    second_nodes = list(second.glob(f"{codex_instruct.JOURNAL_PREFIX}*"))
-    assert len(first_nodes) == len(second_nodes) == 1
+    members = _journal_node_members((first, second))
     if checkpoint == "first-intent":
-        assert {path.name for path in first_nodes[0].iterdir()} == {
-            codex_instruct.INTENT_FILENAME
-        }
-        assert not list(second_nodes[0].iterdir())
+        assert sorted(members.values(), key=len) == [
+            set(),
+            {codex_instruct.INTENT_FILENAME},
+        ]
     elif checkpoint == "second-intent":
-        assert (first_nodes[0] / codex_instruct.JOURNAL_FILENAME).is_file()
-        assert {path.name for path in second_nodes[0].iterdir()} == {
-            codex_instruct.INTENT_FILENAME
-        }
+        assert sorted(members.values(), key=len) == [
+            {codex_instruct.INTENT_FILENAME},
+            {
+                codex_instruct.INTENT_FILENAME,
+                codex_instruct.JOURNAL_FILENAME,
+            },
+        ]
     else:
-        assert {path.name for path in first_nodes[0].iterdir()} == {
-            codex_instruct.INTENT_FILENAME,
-            codex_instruct.JOURNAL_PENDING_FILENAME,
-        }
-        assert not list(second_nodes[0].iterdir())
+        assert sorted(members.values(), key=len) == [
+            set(),
+            {
+                codex_instruct.INTENT_FILENAME,
+                codex_instruct.JOURNAL_PENDING_FILENAME,
+            },
+        ]
+    anchor = next(directory for directory, names in members.items() if names)
 
-    recovered = _run("--codex-dir", first, "--recover", "--yes")
+    recovered = _run("--codex-dir", anchor, "--recover", "--yes")
 
     assert recovered.returncode == 0, recovered.stdout + recovered.stderr
     _assert_no_cjk(recovered.stdout + recovered.stderr)
@@ -373,15 +427,30 @@ def test_initializing_uninstall_recovery_rejects_detached_participant_evidence(
         checkpoint,
     )
     assert interrupted.returncode == HARD_EXIT, interrupted.stdout + interrupted.stderr
-
-    second_journal = next(second.glob(f"{codex_instruct.JOURNAL_PREFIX}*"))
+    members = _journal_node_members((first, second))
+    anchor = next(
+        (
+            directory
+            for directory, names in members.items()
+            if codex_instruct.JOURNAL_FILENAME in names
+        ),
+        next(
+            directory
+            for directory, names in members.items()
+            if codex_instruct.INTENT_FILENAME in names
+        ),
+    )
+    detached_owner = next(directory for directory in (first, second) if directory != anchor)
+    detached_journal = next(
+        detached_owner.glob(f"{codex_instruct.JOURNAL_PREFIX}*")
+    )
     detached = tmp_path / f"detached-evidence-{checkpoint}"
-    second_journal.rename(detached)
+    detached_journal.rename(detached)
     first_evidence = _snapshot_tree(first)
     second_evidence = _snapshot_tree(second)
     detached_evidence = _snapshot_tree(detached)
 
-    recovered = _run("--codex-dir", first, "--recover", "--yes")
+    recovered = _run("--codex-dir", anchor, "--recover", "--yes")
 
     assert recovered.returncode == 1
     assert _snapshot_tree(first) == first_evidence
@@ -438,6 +507,10 @@ def test_uninstall_initializing_cleanup_is_reentrant_after_empty_marker_publicat
         "first-journal",
     )
     assert interrupted.returncode == HARD_EXIT, interrupted.stdout + interrupted.stderr
+    journal_owner = _directory_with_journal_member(
+        (first, second),
+        codex_instruct.JOURNAL_FILENAME,
+    )
 
     source = f"""
 import importlib.util
@@ -450,7 +523,7 @@ m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
 {_filesystem_exit_hook_source("cleanup-marker-published")}
-m.recover_deployment([{str(first)!r}], True)
+m.recover_deployment([{str(journal_owner)!r}], True)
 """
     cleanup_interrupted = _write_child(
         tmp_path,
@@ -487,6 +560,10 @@ def test_uninstall_initializing_cleanup_retains_anchor_after_participant_removal
         "first-journal",
     )
     assert interrupted.returncode == HARD_EXIT, interrupted.stdout + interrupted.stderr
+    journal_owner = _directory_with_journal_member(
+        (first, second),
+        codex_instruct.JOURNAL_FILENAME,
+    )
 
     source = f"""
 import importlib.util
@@ -498,8 +575,8 @@ spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH
 m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
-    {_filesystem_exit_hook_source("journal-directory-removed")}
-m.recover_deployment([{str(first)!r}], True)
+{_filesystem_exit_hook_source("journal-directory-removed")}
+m.recover_deployment([{str(journal_owner)!r}], True)
 """
     cleanup_interrupted = _write_child(
         tmp_path,
@@ -507,15 +584,16 @@ m.recover_deployment([{str(first)!r}], True)
         source,
     )
     assert cleanup_interrupted.returncode == HARD_EXIT
-    assert list(
-        second.glob(
-            f"{codex_instruct.CLEANUP_MARKER_PREFIX}*"
-            f"{codex_instruct.CLEANUP_MARKER_SUFFIX}"
-        )
+    _marker_owner, remaining_journal = _cleanup_marker_owner_and_remaining_journal(
+        (first, second)
     )
-    assert _journal_dirs(first)
 
-    recovered = _run("--codex-dir", first, "--recover", "--yes")
+    recovered = _run(
+        "--codex-dir",
+        remaining_journal.parent,
+        "--recover",
+        "--yes",
+    )
 
     assert recovered.returncode == 0, recovered.stdout + recovered.stderr
     for codex_dir in (first, second):
@@ -754,15 +832,11 @@ m.recover_deployment([{str(first)!r}], True)
         source,
     )
     assert cleanup_interrupted.returncode == HARD_EXIT
-    assert list(
-        first.glob(
-            f"{codex_instruct.CLEANUP_MARKER_PREFIX}*"
-            f"{codex_instruct.CLEANUP_MARKER_SUFFIX}"
-        )
+    marker_owner, _remaining_journal = _cleanup_marker_owner_and_remaining_journal(
+        (first, second)
     )
-    assert _journal_dirs(second)
 
-    resumed = _run("--codex-dir", first, "--recover", "--yes")
+    resumed = _run("--codex-dir", marker_owner, "--recover", "--yes")
 
     assert resumed.returncode == 0, resumed.stdout + resumed.stderr
     _assert_no_cjk(resumed.stdout + resumed.stderr)
@@ -800,7 +874,9 @@ m.recover_deployment([{str(first)!r}], True)
         marker_source,
     )
     assert cleanup_interrupted.returncode == HARD_EXIT
-    second_journal = _single_journal(second)
+    marker_owner, remaining_journal = _cleanup_marker_owner_and_remaining_journal(
+        (first, second)
+    )
 
     race_source = f"""
 import importlib.util
@@ -823,17 +899,22 @@ def wrapped(journals, phase, yes, retained_cleanup_markers):
     return real(journals, phase, yes, retained_cleanup_markers)
 
 m._cleanup_uninstall_terminal_journals = wrapped
-m.recover_deployment([{str(first)!r}], True)
+m.recover_deployment([{str(marker_owner)!r}], True)
 """
     raced = _write_child(tmp_path, f"race-terminal-{race}.py", race_source)
 
     assert raced.returncode == 1, raced.stdout + raced.stderr
-    assert second_journal.exists()
-    markers = codex_instruct._deployment_cleanup_markers(first)
+    assert remaining_journal.exists()
+    markers = codex_instruct._deployment_cleanup_markers(marker_owner)
     assert markers
     if race == "move":
-        assert not (first / "moved-retained-marker").exists()
-        resumed = _run("--codex-dir", second, "--recover", "--yes")
+        assert not (marker_owner / "moved-retained-marker").exists()
+        resumed = _run(
+            "--codex-dir",
+            remaining_journal.parent,
+            "--recover",
+            "--yes",
+        )
         assert resumed.returncode == 0, resumed.stdout + resumed.stderr
         for codex_dir in (first, second):
             _assert_no_transaction_artifacts(codex_dir)
@@ -842,9 +923,14 @@ m.recover_deployment([{str(first)!r}], True)
             path.read_bytes() == b"replacement cleanup marker\n"
             for path in markers
         )
-        resumed = _run("--codex-dir", second, "--recover", "--yes")
+        resumed = _run(
+            "--codex-dir",
+            remaining_journal.parent,
+            "--recover",
+            "--yes",
+        )
         assert resumed.returncode == 1
-        assert second_journal.exists()
+        assert remaining_journal.exists()
 
 
 def test_uninstall_terminal_cleanup_resumes_after_marker_delete_hard_exit(tmp_path):
@@ -872,7 +958,9 @@ m.recover_deployment([{str(first)!r}], True)
         marker_source,
     )
     assert cleanup_interrupted.returncode == HARD_EXIT
-    second_journal = _single_journal(second)
+    marker_owner, remaining_journal = _cleanup_marker_owner_and_remaining_journal(
+        (first, second)
+    )
 
     delete_source = f"""
 import importlib.util
@@ -884,7 +972,7 @@ m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
 {_filesystem_exit_hook_source("cleanup-marker-removed")}
-m.recover_deployment([{str(first)!r}], True)
+m.recover_deployment([{str(marker_owner)!r}], True)
 """
     deleted = _write_child(
         tmp_path,
@@ -893,9 +981,14 @@ m.recover_deployment([{str(first)!r}], True)
     )
 
     assert deleted.returncode == HARD_EXIT
-    assert second_journal.exists()
-    assert not codex_instruct._deployment_cleanup_markers(first)
-    resumed = _run("--codex-dir", second, "--recover", "--yes")
+    assert remaining_journal.exists()
+    assert not codex_instruct._deployment_cleanup_markers(marker_owner)
+    resumed = _run(
+        "--codex-dir",
+        remaining_journal.parent,
+        "--recover",
+        "--yes",
+    )
     assert resumed.returncode == 0, resumed.stdout + resumed.stderr
     for codex_dir in (first, second):
         _assert_no_transaction_artifacts(codex_dir)
@@ -1108,6 +1201,10 @@ def test_cleanup_marker_preflight_validates_remaining_initial_pending(tmp_path):
         "first-journal-pending",
     )
     assert interrupted.returncode == HARD_EXIT, interrupted.stdout + interrupted.stderr
+    pending_owner = _directory_with_journal_member(
+        (first, second),
+        codex_instruct.JOURNAL_PENDING_FILENAME,
+    )
 
     source = f"""
 import importlib.util
@@ -1120,7 +1217,7 @@ m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
 {_filesystem_exit_hook_source("cleanup-marker-published")}
-m.recover_deployment([{str(first)!r}], True)
+m.recover_deployment([{str(pending_owner)!r}], True)
 """
     cleanup_interrupted = _write_child(
         tmp_path,
@@ -1128,13 +1225,15 @@ m.recover_deployment([{str(first)!r}], True)
         source,
     )
     assert cleanup_interrupted.returncode == HARD_EXIT
-    first_node = next(first.glob(f"{codex_instruct.JOURNAL_PREFIX}*"))
-    pending = first_node / codex_instruct.JOURNAL_PENDING_FILENAME
+    marker_owner, remaining_journal = _cleanup_marker_owner_and_remaining_journal(
+        (first, second)
+    )
+    pending = remaining_journal / codex_instruct.JOURNAL_PENDING_FILENAME
     pending.write_text("{", encoding="utf-8")
     first_evidence = _snapshot_tree(first)
     second_evidence = _snapshot_tree(second)
 
-    recovered = _run("--codex-dir", second, "--recover", "--yes")
+    recovered = _run("--codex-dir", marker_owner, "--recover", "--yes")
 
     assert recovered.returncode == 1
     assert _snapshot_tree(first) == first_evidence
@@ -1150,15 +1249,21 @@ def test_initial_pending_structure_tamper_fails_closed_without_traceback(tmp_pat
         "first-journal-pending",
     )
     assert interrupted.returncode == HARD_EXIT, interrupted.stdout + interrupted.stderr
-    first_journal = next(first.glob(f"{codex_instruct.JOURNAL_PREFIX}*"))
-    pending = first_journal / codex_instruct.JOURNAL_PENDING_FILENAME
+    pending_owner = _directory_with_journal_member(
+        (first, second),
+        codex_instruct.JOURNAL_PENDING_FILENAME,
+    )
+    pending = (
+        _single_journal_node(pending_owner)
+        / codex_instruct.JOURNAL_PENDING_FILENAME
+    )
     data = json.loads(pending.read_text(encoding="utf-8"))
     data["directories"] = []
     pending.write_text(json.dumps(data), encoding="utf-8")
     first_evidence = _snapshot_tree(first)
     second_evidence = _snapshot_tree(second)
 
-    recovered = _run("--codex-dir", first, "--recover", "--yes")
+    recovered = _run("--codex-dir", pending_owner, "--recover", "--yes")
 
     assert recovered.returncode == 1
     assert "Traceback" not in recovered.stdout + recovered.stderr
@@ -1214,12 +1319,14 @@ m.recover_deployment([{str(first)!r}], True)
         source,
     )
     assert cleanup_interrupted.returncode == HARD_EXIT
-    second_journal = _single_journal(second)
-    second_journal.rename(second / "moved-evidence")
+    marker_owner, remaining_journal = _cleanup_marker_owner_and_remaining_journal(
+        (first, second)
+    )
+    remaining_journal.rename(remaining_journal.parent / "moved-evidence")
     first_evidence = _snapshot_tree(first)
     second_evidence = _snapshot_tree(second)
 
-    recovered = _run("--codex-dir", first, "--recover", "--yes")
+    recovered = _run("--codex-dir", marker_owner, "--recover", "--yes")
 
     assert recovered.returncode == 1
     assert _snapshot_tree(first) == first_evidence
@@ -1251,12 +1358,14 @@ m.recover_deployment([{str(first)!r}], True)
         source,
     )
     assert cleanup_interrupted.returncode == HARD_EXIT
-    second_journal = _single_journal(second)
-    second_journal.rename(tmp_path / "detached-transaction-evidence")
+    marker_owner, remaining_journal = _cleanup_marker_owner_and_remaining_journal(
+        (first, second)
+    )
+    remaining_journal.rename(tmp_path / "detached-transaction-evidence")
     first_evidence = _snapshot_tree(first)
     second_evidence = _snapshot_tree(second)
 
-    recovered = _run("--codex-dir", first, "--recover", "--yes")
+    recovered = _run("--codex-dir", marker_owner, "--recover", "--yes")
 
     assert recovered.returncode == 1
     assert _snapshot_tree(first) == first_evidence
@@ -1272,6 +1381,10 @@ def test_cleanup_marker_preflight_rejects_replaced_intent_only_directory(tmp_pat
         "first-intent",
     )
     assert interrupted.returncode == HARD_EXIT, interrupted.stdout + interrupted.stderr
+    intent_owner = _directory_with_journal_member(
+        (first, second),
+        codex_instruct.INTENT_FILENAME,
+    )
 
     source = f"""
 import importlib.util
@@ -1284,7 +1397,7 @@ m = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = m
 spec.loader.exec_module(m)
 {_filesystem_exit_hook_source("cleanup-marker-published")}
-m.recover_deployment([{str(first)!r}], True)
+m.recover_deployment([{str(intent_owner)!r}], True)
 """
     cleanup_interrupted = _write_child(
         tmp_path,
@@ -1292,15 +1405,26 @@ m.recover_deployment([{str(first)!r}], True)
         source,
     )
     assert cleanup_interrupted.returncode == HARD_EXIT
-    first_journal = next(first.glob(f"{codex_instruct.JOURNAL_PREFIX}*"))
-    intent_bytes = (first_journal / codex_instruct.INTENT_FILENAME).read_bytes()
-    first_journal.rename(tmp_path / "original-intent-evidence")
-    first_journal.mkdir()
-    (first_journal / codex_instruct.INTENT_FILENAME).write_bytes(intent_bytes)
+    marker_owner = next(
+        directory
+        for directory in (first, second)
+        if codex_instruct._deployment_cleanup_markers(directory)
+    )
+    intent_owner = _directory_with_journal_member(
+        (first, second),
+        codex_instruct.INTENT_FILENAME,
+    )
+    intent_journal = next(
+        intent_owner.glob(f"{codex_instruct.JOURNAL_PREFIX}*")
+    )
+    intent_bytes = (intent_journal / codex_instruct.INTENT_FILENAME).read_bytes()
+    intent_journal.rename(tmp_path / "original-intent-evidence")
+    intent_journal.mkdir()
+    (intent_journal / codex_instruct.INTENT_FILENAME).write_bytes(intent_bytes)
     first_evidence = _snapshot_tree(first)
     second_evidence = _snapshot_tree(second)
 
-    recovered = _run("--codex-dir", second, "--recover", "--yes")
+    recovered = _run("--codex-dir", marker_owner, "--recover", "--yes")
 
     assert recovered.returncode == 1
     assert _snapshot_tree(first) == first_evidence

--- a/tests/test_windows_filesystem.py
+++ b/tests/test_windows_filesystem.py
@@ -262,6 +262,16 @@ def test_operation_directories_are_identity_deduplicated_and_stably_sorted(tmp_p
     assert {item.path for item in normalized} == {first.resolve(), second.resolve()}
 
 
+def test_windows_native_identity_matches_python_portable_device_encoding():
+    native = codex_instruct.FileIdentity(0x428342FD, 123)
+    portable = codex_instruct.FileIdentity(0xFA428383428342FD, 123)
+
+    assert codex_instruct._WindowsFilesystemBackend._handle_matches_portable_identity(
+        native,
+        portable,
+    )
+
+
 @pytest.mark.parametrize(
     "name",
     ["CON", "prn.md", "AUX", "nul.txt", "COM1", "lpt9.md"],

--- a/tests/test_windows_filesystem.py
+++ b/tests/test_windows_filesystem.py
@@ -699,3 +699,12 @@ def test_uninstall_intent_reads_are_bound_to_verified_directory_evidence(
 
     assert len(calls) == expected_calls
     assert all("," in call.split(")", 1)[0] for call in calls)
+
+
+def test_initializing_uninstall_member_set_uses_verified_directory_evidence():
+    source = inspect.getsource(
+        codex_instruct._load_initializing_uninstall_pending
+    )
+
+    assert "MANIFEST_INTENT_FILENAME in evidence" in source
+    assert "_path_entry_exists(journal_dir / MANIFEST_INTENT_FILENAME)" not in source

--- a/tests/test_windows_filesystem.py
+++ b/tests/test_windows_filesystem.py
@@ -46,6 +46,8 @@ def test_platform_filesystem_contract_is_centralized():
     for method in (
         "create_private_directory",
         "create_private_file",
+        "resolve_directory",
+        "verify_recovery_directory_security",
         "open_verified_owned_directory",
         "remove_verified_member",
         "remove_verified_directory",
@@ -129,6 +131,57 @@ def test_uninstall_snapshot_failure_preserves_primary_exception(
     assert "secondary uninstall cleanup failure" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize("operation", ["deploy", "uninstall"])
+def test_journal_directory_flush_failure_removes_empty_node(
+    tmp_path,
+    monkeypatch,
+    operation,
+):
+    codex_dir = _make_codex_dir(tmp_path, f"{operation} flush failure")
+    if operation == "deploy":
+        plan = codex_instruct.inspect_directory(codex_dir)
+        state = codex_instruct.DeploymentState(codex_dir, deployment_id="f" * 32)
+
+        def create():
+            codex_instruct._create_deployment_journals(
+                [state],
+                [plan],
+                codex_instruct.DEFAULT_MD_FILENAME,
+                codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD,
+                False,
+            )
+
+    else:
+        deployed = _run("--codex-dir", codex_dir, "--yes")
+        assert deployed.returncode == 0, deployed.stdout + deployed.stderr
+        plan = codex_instruct.inspect_uninstall_directory(codex_dir)
+        state = codex_instruct.UninstallState(plan=plan, deployment_id="f" * 32)
+
+        def create():
+            codex_instruct._create_uninstall_journals([state], "20260721_120000")
+
+    real_flush = codex_instruct._FILESYSTEM.flush_directory
+    failed = False
+
+    def fail_first_parent_flush(path):
+        nonlocal failed
+        if Path(path) == codex_dir and not failed:
+            failed = True
+            raise OSError("primary create persistence failure")
+        real_flush(path)
+
+    monkeypatch.setattr(
+        codex_instruct._FILESYSTEM,
+        "flush_directory",
+        fail_first_parent_flush,
+    )
+
+    with pytest.raises(OSError, match="primary create persistence failure"):
+        create()
+
+    assert not list(codex_dir.glob(f"{codex_instruct.JOURNAL_PREFIX}*"))
+
+
 def test_issue_1_initializing_intent_and_journal_recover_to_ready(tmp_path):
     codex_dir = _make_codex_dir(tmp_path, "Issue 1 中文")
     before = {path.name: path.read_bytes() for path in codex_dir.iterdir() if path.is_file()}
@@ -172,6 +225,26 @@ def test_issue_1_initializing_intent_and_journal_recover_to_ready(tmp_path):
     ready = _run("--codex-dir", codex_dir, "--status")
     assert ready.returncode == 0, ready.stdout + ready.stderr
     assert "structural health: healthy" in ready.stdout.lower()
+    assert "deployability: ready" in ready.stdout.lower()
+
+
+def test_empty_private_initializing_journal_recovers_to_ready(tmp_path):
+    codex_dir = _make_codex_dir(tmp_path, "empty initializing journal")
+    journal_dir = codex_dir / f"{codex_instruct.JOURNAL_PREFIX}{'a' * 32}"
+    codex_instruct._FILESYSTEM.create_private_directory(journal_dir)
+
+    blocked = _run("--codex-dir", codex_dir, "--status")
+    assert blocked.returncode == 1
+    preview = _run("--codex-dir", codex_dir, "--recover")
+    assert preview.returncode == 0, preview.stdout + preview.stderr
+    assert journal_dir.exists()
+
+    recovered = _run("--codex-dir", codex_dir, "--recover", "--yes")
+
+    assert recovered.returncode == 0, recovered.stdout + recovered.stderr
+    assert not journal_dir.exists()
+    ready = _run("--codex-dir", codex_dir, "--status")
+    assert ready.returncode == 0, ready.stdout + ready.stderr
     assert "deployability: ready" in ready.stdout.lower()
 
 
@@ -290,29 +363,90 @@ def test_windows_lock_key_uses_file_id_across_distinct_alias_paths(monkeypatch):
         102: Path("X:/Codex"),
     }
     backend.kernel32 = types.SimpleNamespace(CloseHandle=lambda _handle: True)
-    monkeypatch.setattr(backend, "_open_handle", lambda *_args, **_kwargs: next(handles))
+
+    def open_components(_path):
+        handle = next(handles)
+        return canonical[handle], [handle]
+
     monkeypatch.setattr(
         backend,
-        "_validate_handle_type",
-        lambda *_args, **_kwargs: None,
+        "_open_directory_components",
+        open_components,
     )
-    monkeypatch.setattr(backend, "_validate_ntfs", lambda *_args: None)
     monkeypatch.setattr(
         backend,
         "_handle_identity",
         lambda _handle: codex_instruct.FileIdentity(17, 23),
     )
-    monkeypatch.setattr(
-        backend,
-        "_canonical_path",
-        lambda handle, _fallback: canonical[handle],
-    )
-
     first_key, first_path = backend.directory_lock_key(Path("C:/alias"))
     second_key, second_path = backend.directory_lock_key(Path("X:/alias"))
 
     assert first_path != second_path
     assert first_key == second_key == (17, 23)
+
+
+def test_windows_directory_resolution_pins_all_path_components(monkeypatch):
+    backend = object.__new__(codex_instruct._WindowsFilesystemBackend)
+    opened = []
+    closed = []
+    share_modes = []
+    backend.kernel32 = types.SimpleNamespace(
+        CloseHandle=lambda handle: closed.append(handle) or True
+    )
+
+    def open_handle(path, _access, **kwargs):
+        handle = len(opened) + 1
+        opened.append((handle, Path(path)))
+        share_modes.append(kwargs.get("share_mode"))
+        return handle
+
+    monkeypatch.setattr(backend, "_open_handle", open_handle)
+    def validate_handle(*_args, **_kwargs):
+        assert closed == []
+
+    monkeypatch.setattr(backend, "_validate_handle_type", validate_handle)
+    monkeypatch.setattr(backend, "_validate_ntfs", lambda *_args: None)
+    monkeypatch.setattr(
+        backend,
+        "_canonical_path",
+        lambda _handle, fallback: fallback,
+    )
+
+    resolved = backend.resolve_directory(Path("nested/path"))
+
+    assert resolved.is_absolute()
+    assert len(opened) >= 3
+    assert closed == [handle for handle, _path in reversed(opened)]
+    assert set(share_modes) == {
+        backend._FILE_SHARE_READ | backend._FILE_SHARE_WRITE
+    }
+
+
+def test_windows_lock_pin_revalidates_reparse_components_after_key_handoff(
+    monkeypatch,
+):
+    backend = object.__new__(codex_instruct._WindowsFilesystemBackend)
+    backend.kernel32 = types.SimpleNamespace(CloseHandle=lambda _handle: True)
+    calls = 0
+
+    def open_components(_path):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return Path("C:/stable/Codex"), [101]
+        raise codex_instruct.HooksConflict("reparse point is not allowed")
+
+    monkeypatch.setattr(backend, "_open_directory_components", open_components)
+    monkeypatch.setattr(
+        backend,
+        "_handle_identity",
+        lambda _handle: codex_instruct.FileIdentity(17, 23),
+    )
+
+    key, canonical = backend.directory_lock_key(Path("C:/alias/Codex"))
+
+    with pytest.raises(codex_instruct.HooksConflict, match="reparse"):
+        backend.pin_directory_for_lock(canonical, key)
 
 
 def test_failure_cleanup_contract_preserves_primary_exception(capsys):
@@ -359,6 +493,35 @@ def test_windows_mutation_backend_declares_durable_metadata_contracts():
         backend.remove_verified_file,
     ):
         assert "flush_directory" in inspect.getsource(method)
+    assert "_fsync_directory(parent)" in inspect.getsource(
+        codex_instruct._make_registered_transaction_dir
+    )
+    for creator in (
+        codex_instruct._create_deployment_journals,
+        codex_instruct._create_uninstall_journals,
+    ):
+        assert "_fsync_directory(state.codex_dir)" in inspect.getsource(creator)
+    for writer in (
+        codex_instruct._write_exclusive_private_json,
+        codex_instruct._atomic_write_private_json,
+    ):
+        assert "_fsync_directory" in inspect.getsource(writer)
+    atomic_text_source = inspect.getsource(codex_instruct.atomic_write_text)
+    assert "os.fsync" in atomic_text_source
+    assert "_atomic_rename_no_replace" in atomic_text_source
+    assert "_transactional_replace_existing" in atomic_text_source
+
+
+def test_recovery_acl_preflight_runs_before_journal_content_is_read():
+    for loader in (
+        codex_instruct._load_deployment_journal,
+        codex_instruct._load_uninstall_journal,
+        codex_instruct._load_initializing_uninstall_pending,
+    ):
+        source = inspect.getsource(loader)
+        assert source.index("read_verified_recovery_directory") < source.index(
+            "_recovery_member_text"
+        )
 
 
 @pytest.mark.parametrize(
@@ -551,18 +714,33 @@ def test_windows_private_acl_rejects_extra_everyone_ace(tmp_path):
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows recovery ACL contract")
+@pytest.mark.parametrize("operation", ["deploy", "uninstall"])
 @pytest.mark.parametrize("target_kind", ["directory", "member"])
-def test_windows_recovery_revalidates_existing_journal_acl(tmp_path, target_kind):
-    codex_dir = _make_codex_dir(tmp_path, f"acl recovery {target_kind}")
-    plan = codex_instruct.inspect_directory(codex_dir)
-    state = codex_instruct.DeploymentState(codex_dir, deployment_id="e" * 32)
-    codex_instruct._create_deployment_journals(
-        [state],
-        [plan],
-        codex_instruct.DEFAULT_MD_FILENAME,
-        codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD,
-        False,
+def test_windows_recovery_revalidates_existing_journal_acl(
+    tmp_path,
+    target_kind,
+    operation,
+):
+    codex_dir = _make_codex_dir(
+        tmp_path,
+        f"{operation} acl recovery {target_kind}",
     )
+    if operation == "deploy":
+        plan = codex_instruct.inspect_directory(codex_dir)
+        state = codex_instruct.DeploymentState(codex_dir, deployment_id="e" * 32)
+        codex_instruct._create_deployment_journals(
+            [state],
+            [plan],
+            codex_instruct.DEFAULT_MD_FILENAME,
+            codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD,
+            False,
+        )
+    else:
+        deployed = _run("--codex-dir", codex_dir, "--yes")
+        assert deployed.returncode == 0, deployed.stdout + deployed.stderr
+        plan = codex_instruct.inspect_uninstall_directory(codex_dir)
+        state = codex_instruct.UninstallState(plan=plan, deployment_id="e" * 32)
+        codex_instruct._create_uninstall_journals([state], "20260721_120000")
     assert state.journal_dir is not None
     target = (
         state.journal_dir
@@ -583,6 +761,37 @@ def test_windows_recovery_revalidates_existing_journal_acl(tmp_path, target_kind
     assert state.journal_dir.exists()
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows intent-only ACL contract")
+def test_windows_intent_only_recovery_revalidates_acl(tmp_path):
+    codex_dir = _make_codex_dir(tmp_path, "intent only acl recovery")
+    plan = codex_instruct.inspect_directory(codex_dir)
+    state = codex_instruct.DeploymentState(codex_dir, deployment_id="9" * 32)
+    codex_instruct._create_deployment_journals(
+        [state],
+        [plan],
+        codex_instruct.DEFAULT_MD_FILENAME,
+        codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD,
+        False,
+    )
+    assert state.journal_dir is not None
+    for member in state.journal_dir.iterdir():
+        if member.name != codex_instruct.INTENT_FILENAME:
+            member.unlink()
+    intent = state.journal_dir / codex_instruct.INTENT_FILENAME
+    changed = subprocess.run(
+        ["icacls", str(intent), "/grant", "*S-1-1-0:(R)"],
+        text=True,
+        capture_output=True,
+    )
+    assert changed.returncode == 0, changed.stdout + changed.stderr
+
+    recovered = _run("--codex-dir", codex_dir, "--recover", "--yes")
+
+    assert recovered.returncode == 1
+    assert "acl" in (recovered.stdout + recovered.stderr).lower()
+    assert intent.exists()
+
+
 @pytest.mark.skipif(os.name != "nt", reason="Windows durable metadata contract")
 def test_windows_mutations_flush_parent_directories(tmp_path, monkeypatch):
     backend = codex_instruct._FILESYSTEM
@@ -596,6 +805,7 @@ def test_windows_mutations_flush_parent_directories(tmp_path, monkeypatch):
     monkeypatch.setattr(backend, "flush_directory", record_flush)
     parent = tmp_path / "durable parent"
     backend.create_private_directory(parent)
+    backend.flush_directory(tmp_path)
 
     source = parent / "source.json"
     descriptor = backend.create_private_file(source)
@@ -603,6 +813,7 @@ def test_windows_mutations_flush_parent_directories(tmp_path, monkeypatch):
         stream.write(b"source\n")
         stream.flush()
         os.fsync(stream.fileno())
+    backend.flush_directory(parent)
     destination = parent / "destination.json"
     assert backend.atomic_rename_no_replace(source, destination)
 
@@ -612,6 +823,7 @@ def test_windows_mutations_flush_parent_directories(tmp_path, monkeypatch):
         stream.write(b"replacement\n")
         stream.flush()
         os.fsync(stream.fileno())
+    backend.flush_directory(parent)
     backend.replace_atomic(replacement, destination)
     identity = codex_instruct._require_regular_file(destination, "destination")
     fingerprint = codex_instruct._fingerprint_regular_file(destination)
@@ -619,6 +831,7 @@ def test_windows_mutations_flush_parent_directories(tmp_path, monkeypatch):
 
     owned = parent / "owned"
     backend.create_private_directory(owned)
+    backend.flush_directory(parent)
     access = backend.open_verified_owned_directory(
         owned,
         codex_instruct._directory_identity(owned),
@@ -629,6 +842,35 @@ def test_windows_mutations_flush_parent_directories(tmp_path, monkeypatch):
 
     assert tmp_path in flushed
     assert flushed.count(parent) >= 6
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows create cleanup contract")
+@pytest.mark.parametrize("node_kind", ["directory", "file"])
+def test_windows_create_flush_failure_removes_unowned_node(
+    tmp_path,
+    monkeypatch,
+    node_kind,
+):
+    target = tmp_path / f"failed {node_kind}"
+    real_flush = codex_instruct._FILESYSTEM.flush_directory
+    failed = False
+
+    def fail_once(path):
+        nonlocal failed
+        if Path(path) == tmp_path and not failed:
+            failed = True
+            raise OSError("create parent flush failure")
+        real_flush(path)
+
+    monkeypatch.setattr(codex_instruct._FILESYSTEM, "flush_directory", fail_once)
+
+    with pytest.raises(OSError, match="create parent flush failure"):
+        if node_kind == "directory":
+            codex_instruct._FILESYSTEM.create_private_directory(target)
+        else:
+            codex_instruct._FILESYSTEM.create_private_file(target)
+
+    assert not target.exists()
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows verified delete contract")

--- a/tests/test_windows_filesystem.py
+++ b/tests/test_windows_filesystem.py
@@ -1,3 +1,4 @@
+import hashlib
 import importlib.util
 import inspect
 import json
@@ -44,6 +45,9 @@ def test_platform_filesystem_contract_is_centralized():
         "replace_atomic",
         "flush_directory",
         "directory_lock_key",
+        "pin_directory_for_lock",
+        "release_pinned_directory",
+        "remove_verified_file",
     ):
         assert callable(getattr(backend, method))
 
@@ -158,6 +162,89 @@ def test_issue_1_initializing_intent_and_journal_recover_to_ready(tmp_path):
     ready = _run("--codex-dir", codex_dir, "--status")
     assert ready.returncode == 0, ready.stdout + ready.stderr
     assert "structural health: healthy" in ready.stdout.lower()
+    assert "deployability: ready" in ready.stdout.lower()
+
+
+def test_issue_1_v010_initializing_fixture_recovers_to_ready(tmp_path):
+    codex_dir = _make_codex_dir(tmp_path, "v0.1.0 Issue 1 中文")
+    transaction_id = "d" * 32
+    journal_dir = codex_dir / f"{codex_instruct.JOURNAL_PREFIX}{transaction_id}"
+    codex_instruct._FILESYSTEM.create_private_directory(journal_dir)
+    plan = codex_instruct.inspect_directory(codex_dir)
+    config_before = codex_instruct._portable_fingerprint(plan.config_fingerprint)
+    directories = {
+        str(codex_dir.resolve()): {
+            "journal_dir": journal_dir.name,
+            "journal_identity": codex_instruct._portable_identity(
+                codex_instruct._directory_identity(journal_dir)
+            ),
+            "resources": {
+                "config": {
+                    "path": "config.toml",
+                    "before": config_before,
+                    "snapshot": "snapshot-config",
+                    "allowed_absent": False,
+                    "allowed_sha256": [
+                        hashlib.sha256(
+                            plan.updated_config_content.encode("utf-8")
+                        ).hexdigest()
+                    ],
+                    "allowed_portable": [],
+                },
+                "md": {
+                    "path": codex_instruct.DEFAULT_MD_FILENAME,
+                    "before": None,
+                    "snapshot": None,
+                    "allowed_absent": False,
+                    "allowed_sha256": [
+                        hashlib.sha256(
+                            codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD.encode("utf-8")
+                        ).hexdigest()
+                    ],
+                    "allowed_portable": [],
+                },
+                "manifest": {
+                    "path": codex_instruct.MANIFEST_FILENAME,
+                    "before": None,
+                    "snapshot": None,
+                    "allowed_absent": False,
+                    "allowed_sha256": [],
+                    "allowed_portable": [],
+                },
+            },
+            "residues": [],
+        }
+    }
+    base = {
+        "schema_version": 1,
+        "operation": "deploy",
+        "transaction_id": transaction_id,
+        "phase": "initializing",
+        "participants": [str(codex_dir.resolve())],
+        "directories": directories,
+    }
+    intent = json.loads(json.dumps(base))
+    intent.pop("phase")
+    intent["directories"][str(codex_dir.resolve())]["resources"]["manifest"][
+        "allowed_sha256"
+    ] = []
+    journal = dict(base)
+    journal["owner_directory"] = str(codex_dir.resolve())
+    codex_instruct._write_exclusive_private_json(
+        journal_dir / codex_instruct.INTENT_FILENAME,
+        intent,
+    )
+    codex_instruct._write_exclusive_private_json(
+        journal_dir / codex_instruct.JOURNAL_FILENAME,
+        journal,
+    )
+
+    recovered = _run("--codex-dir", codex_dir, "--recover", "--yes")
+
+    assert recovered.returncode == 0, recovered.stdout + recovered.stderr
+    assert not journal_dir.exists()
+    ready = _run("--codex-dir", codex_dir, "--status")
+    assert ready.returncode == 0, ready.stdout + ready.stderr
     assert "deployability: ready" in ready.stdout.lower()
 
 
@@ -281,6 +368,24 @@ with module._DirectoryLockSet([target]):
     assert worker.stdout == "acquired\n"
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows lock pin contract")
+def test_windows_directory_lock_pins_the_verified_identity(tmp_path):
+    codex_dir = _make_codex_dir(tmp_path, "pinned identity")
+    moved = codex_dir.with_name("pinned identity moved")
+
+    with codex_instruct._DirectoryLockSet([str(codex_dir)]):
+        try:
+            codex_dir.rename(moved)
+        except OSError as exc:
+            assert exc.winerror == 32
+        else:
+            moved.rename(codex_dir)
+            pytest.fail("locked directory identity was not pinned")
+
+    codex_dir.rename(moved)
+    assert moved.is_dir()
+
+
 @pytest.mark.skipif(os.name != "nt", reason="Windows case-insensitive identity contract")
 def test_windows_case_aliases_are_identity_deduplicated(tmp_path):
     directory = _make_codex_dir(tmp_path, "CaseAlias")
@@ -305,6 +410,54 @@ def test_windows_private_file_and_directory_acl(tmp_path):
         directory / "secret.json",
         is_directory=False,
     )
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows native ACL contract")
+def test_windows_private_acl_rejects_extra_everyone_ace(tmp_path):
+    target = tmp_path / "private-acl.txt"
+    descriptor = codex_instruct._FILESYSTEM.create_private_file(target)
+    os.close(descriptor)
+    changed = subprocess.run(
+        ["icacls", str(target), "/grant", "*S-1-1-0:(R)"],
+        text=True,
+        capture_output=True,
+    )
+    assert changed.returncode == 0, changed.stdout + changed.stderr
+
+    with pytest.raises(codex_instruct.HooksConflict, match="ACL"):
+        codex_instruct._FILESYSTEM.verify_private_security(
+            target,
+            is_directory=False,
+        )
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows verified delete contract")
+def test_windows_verified_delete_preserves_occupied_evidence_then_retries(tmp_path):
+    target = tmp_path / "occupied-marker.json"
+    descriptor = codex_instruct._FILESYSTEM.create_private_file(target)
+    with os.fdopen(descriptor, "wb") as stream:
+        stream.write(b"owned marker\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    identity = codex_instruct._require_regular_file(target, "occupied marker")
+    fingerprint = codex_instruct._fingerprint_regular_file(target)
+
+    with target.open("rb"):
+        with pytest.raises(OSError) as caught:
+            codex_instruct._FILESYSTEM.remove_verified_file(
+                target,
+                identity,
+                fingerprint,
+            )
+        assert caught.value.winerror == 32
+        assert target.read_bytes() == b"owned marker\n"
+
+    codex_instruct._FILESYSTEM.remove_verified_file(
+        target,
+        identity,
+        fingerprint,
+    )
+    assert not target.exists()
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows native handle contract")

--- a/tests/test_windows_filesystem.py
+++ b/tests/test_windows_filesystem.py
@@ -1,0 +1,213 @@
+import importlib.util
+import inspect
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "codex-instruct.py"
+spec = importlib.util.spec_from_file_location("codex_instruct_windows_fs", MODULE_PATH)
+codex_instruct = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = codex_instruct
+spec.loader.exec_module(codex_instruct)
+
+
+def _make_codex_dir(tmp_path, name="codex dir 中文"):
+    codex_dir = tmp_path / name
+    codex_dir.mkdir()
+    (codex_dir / "config.toml").write_text('model = "gpt-5.6"\n', encoding="utf-8")
+    return codex_dir
+
+
+def _run(*args):
+    return subprocess.run(
+        [sys.executable, str(MODULE_PATH), *map(str, args), "--lang", "en"],
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_platform_filesystem_contract_is_centralized():
+    backend = codex_instruct._FILESYSTEM
+    for method in (
+        "create_private_directory",
+        "create_private_file",
+        "open_verified_owned_directory",
+        "remove_verified_member",
+        "remove_verified_directory",
+        "set_file_times",
+        "apply_private_file_security",
+        "atomic_rename_no_replace",
+        "replace_atomic",
+        "flush_directory",
+        "directory_lock_key",
+    ):
+        assert callable(getattr(backend, method))
+
+    cleanup_source = inspect.getsource(codex_instruct._open_verified_owned_directory)
+    assert "os.listdir(descriptor)" not in cleanup_source
+    assert "dir_fd=descriptor" not in cleanup_source
+
+    module_source = MODULE_PATH.read_text(encoding="utf-8")
+    backend_start = module_source.index("class _PosixFilesystemBackend")
+    backend_end = module_source.index("_FILESYSTEM =", backend_start)
+    outside_backend = module_source[:backend_start] + module_source[backend_end:]
+    assert "os.utime(" not in outside_backend
+    assert "os.fchmod(" not in outside_backend
+
+
+def test_deploy_snapshot_failure_preserves_primary_exception(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    codex_dir = _make_codex_dir(tmp_path)
+    plan = codex_instruct.inspect_directory(codex_dir)
+    state = codex_instruct.DeploymentState(codex_dir, deployment_id="a" * 32)
+
+    def fail_snapshot(_source, _destination):
+        raise RuntimeError("primary snapshot failure")
+
+    def fail_cleanup(*_args, **_kwargs):
+        raise PermissionError("secondary cleanup failure")
+
+    monkeypatch.setattr(codex_instruct, "_copy_snapshot", fail_snapshot)
+    monkeypatch.setattr(codex_instruct, "_safe_remove_owned_directory", fail_cleanup)
+
+    with pytest.raises(RuntimeError, match="primary snapshot failure"):
+        codex_instruct._create_deployment_journals(
+            [state],
+            [plan],
+            codex_instruct.DEFAULT_MD_FILENAME,
+            codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD,
+            False,
+        )
+
+    assert "secondary cleanup failure" in capsys.readouterr().err
+
+
+def test_uninstall_snapshot_failure_preserves_primary_exception(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    codex_dir = _make_codex_dir(tmp_path, "uninstall 中文")
+    deployed = _run("--codex-dir", codex_dir, "--yes")
+    assert deployed.returncode == 0, deployed.stdout + deployed.stderr
+    plan = codex_instruct.inspect_uninstall_directory(codex_dir)
+    state = codex_instruct.UninstallState(plan=plan, deployment_id="b" * 32)
+
+    def fail_snapshot(_source, _destination):
+        raise RuntimeError("primary uninstall snapshot failure")
+
+    def fail_cleanup(*_args, **_kwargs):
+        raise PermissionError("secondary uninstall cleanup failure")
+
+    monkeypatch.setattr(codex_instruct, "_copy_snapshot", fail_snapshot)
+    monkeypatch.setattr(codex_instruct, "_safe_remove_owned_directory", fail_cleanup)
+
+    with pytest.raises(RuntimeError, match="primary uninstall snapshot failure"):
+        codex_instruct._create_uninstall_journals([state], "20260721_120000")
+
+    assert "secondary uninstall cleanup failure" in capsys.readouterr().err
+
+
+def test_issue_1_initializing_intent_and_journal_recover_to_ready(tmp_path):
+    codex_dir = _make_codex_dir(tmp_path, "Issue 1 中文")
+    before = {path.name: path.read_bytes() for path in codex_dir.iterdir() if path.is_file()}
+    plan = codex_instruct.inspect_directory(codex_dir)
+    state = codex_instruct.DeploymentState(codex_dir, deployment_id="c" * 32)
+    codex_instruct._create_deployment_journals(
+        [state],
+        [plan],
+        codex_instruct.DEFAULT_MD_FILENAME,
+        codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD,
+        False,
+    )
+    journal_dir = state.journal_dir
+    assert journal_dir is not None
+    for entry in list(journal_dir.iterdir()):
+        if entry.name not in {
+            codex_instruct.INTENT_FILENAME,
+            codex_instruct.JOURNAL_FILENAME,
+        }:
+            entry.unlink()
+    journal_path = journal_dir / codex_instruct.JOURNAL_FILENAME
+    journal = json.loads(journal_path.read_text(encoding="utf-8"))
+    journal["phase"] = "initializing"
+    codex_instruct._atomic_write_private_json(journal_path, journal)
+
+    blocked = _run("--codex-dir", codex_dir, "--status")
+    assert blocked.returncode == 1
+    assert "deployability: blocked" in blocked.stdout.lower()
+
+    preview = _run("--codex-dir", codex_dir, "--recover")
+    assert preview.returncode == 0, preview.stdout + preview.stderr
+    assert journal_dir.exists()
+
+    recovered = _run("--codex-dir", codex_dir, "--recover", "--yes")
+    assert recovered.returncode == 0, recovered.stdout + recovered.stderr
+    assert not journal_dir.exists()
+    assert before == {
+        path.name: path.read_bytes() for path in codex_dir.iterdir() if path.is_file()
+    }
+
+    ready = _run("--codex-dir", codex_dir, "--status")
+    assert ready.returncode == 0, ready.stdout + ready.stderr
+    assert "structural health: healthy" in ready.stdout.lower()
+    assert "deployability: ready" in ready.stdout.lower()
+
+
+def test_operation_directories_are_identity_deduplicated_and_stably_sorted(tmp_path):
+    first = _make_codex_dir(tmp_path, "Z Folder")
+    second = _make_codex_dir(tmp_path, "a folder")
+
+    normalized = codex_instruct._normalize_operation_directories(
+        [str(first), str(second), str(first / ".")]
+    )
+
+    assert len(normalized) == 2
+    keys = [item.lock_key for item in normalized]
+    assert keys == sorted(keys)
+    assert {item.path for item in normalized} == {first.resolve(), second.resolve()}
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows native ACL contract")
+def test_windows_private_file_and_directory_acl(tmp_path):
+    directory = tmp_path / "private 中文"
+    codex_instruct._FILESYSTEM.create_private_directory(directory)
+    descriptor = codex_instruct._FILESYSTEM.create_private_file(directory / "secret.json")
+    os.close(descriptor)
+
+    codex_instruct._FILESYSTEM.verify_private_security(directory, is_directory=True)
+    codex_instruct._FILESYSTEM.verify_private_security(
+        directory / "secret.json",
+        is_directory=False,
+    )
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows native handle contract")
+def test_windows_owned_directory_cleanup_rejects_reparse_members(tmp_path):
+    owned = tmp_path / "owned"
+    codex_instruct._FILESYSTEM.create_private_directory(owned)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside\n", encoding="utf-8")
+    link = owned / "member"
+    try:
+        link.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+
+    identity = codex_instruct._directory_identity(owned)
+    with pytest.raises(codex_instruct.HooksConflict, match="member"):
+        codex_instruct._safe_remove_owned_directory(
+            owned,
+            identity,
+            {"member": None},
+            require_exact_members=True,
+        )
+    assert outside.read_text(encoding="utf-8") == "outside\n"

--- a/tests/test_windows_filesystem.py
+++ b/tests/test_windows_filesystem.py
@@ -176,6 +176,15 @@ def test_operation_directories_are_identity_deduplicated_and_stably_sorted(tmp_p
     assert {item.path for item in normalized} == {first.resolve(), second.resolve()}
 
 
+@pytest.mark.parametrize(
+    "name",
+    ["CON", "prn.md", "AUX", "nul.txt", "COM1", "lpt9.md"],
+)
+def test_windows_reserved_device_names_are_rejected(name):
+    with pytest.raises(ValueError, match="reserved"):
+        codex_instruct.normalize_md_name(name)
+
+
 def test_directory_lock_excludes_second_process_without_sleep(tmp_path):
     codex_dir = _make_codex_dir(tmp_path, "lock target")
     worker = """
@@ -218,6 +227,75 @@ with module._DirectoryLockSet([target]):
     selector.close()
     assert process.returncode == 0, stderr
     assert stdout == "directory-lock-acquired\n"
+
+
+def test_process_termination_releases_directory_lock(tmp_path):
+    codex_dir = _make_codex_dir(tmp_path, "terminated lock")
+    holder = """
+import importlib.util
+import sys
+from pathlib import Path
+
+module_path = Path(sys.argv[1])
+target = sys.argv[2]
+spec = importlib.util.spec_from_file_location("keysmith_lock_holder", module_path)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+def checkpoint(name):
+    if name == "directory-lock-acquired":
+        print(name, flush=True)
+
+module._FILESYSTEM_CHECKPOINT_HOOK = checkpoint
+with module._DirectoryLockSet([target]):
+    sys.stdin.buffer.read(1)
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-c", holder, str(MODULE_PATH), str(codex_dir)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert process.stdout is not None
+    assert process.stdout.readline() == "directory-lock-acquired\n"
+    process.kill()
+    process.communicate(timeout=10)
+
+    worker = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import importlib.util,sys; from pathlib import Path; "
+                "p=Path(sys.argv[1]); s=importlib.util.spec_from_file_location('m',p); "
+                "m=importlib.util.module_from_spec(s); sys.modules[s.name]=m; "
+                "s.loader.exec_module(m); "
+                "lock=m._DirectoryLockSet([sys.argv[2]]); lock.__enter__(); "
+                "print('acquired'); lock.__exit__(None,None,None)"
+            ),
+            str(MODULE_PATH),
+            str(codex_dir),
+        ],
+        text=True,
+        capture_output=True,
+        timeout=10,
+    )
+    assert worker.returncode == 0, worker.stderr
+    assert worker.stdout == "acquired\n"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows case-insensitive identity contract")
+def test_windows_case_aliases_are_identity_deduplicated(tmp_path):
+    directory = _make_codex_dir(tmp_path, "CaseAlias")
+    alias = Path(str(directory).swapcase())
+
+    normalized = codex_instruct._normalize_operation_directories(
+        [str(directory), str(alias)]
+    )
+
+    assert len(normalized) == 1
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows native ACL contract")

--- a/tests/test_windows_filesystem.py
+++ b/tests/test_windows_filesystem.py
@@ -53,6 +53,7 @@ def test_platform_filesystem_contract_is_centralized():
         "remove_verified_directory",
         "set_file_times",
         "apply_private_file_security",
+        "apply_private_path_security",
         "atomic_rename_no_replace",
         "replace_atomic",
         "flush_directory",
@@ -389,14 +390,16 @@ def test_windows_directory_resolution_pins_all_path_components(monkeypatch):
     backend = object.__new__(codex_instruct._WindowsFilesystemBackend)
     opened = []
     closed = []
+    accesses = []
     share_modes = []
     backend.kernel32 = types.SimpleNamespace(
         CloseHandle=lambda handle: closed.append(handle) or True
     )
 
-    def open_handle(path, _access, **kwargs):
+    def open_handle(path, access, **kwargs):
         handle = len(opened) + 1
         opened.append((handle, Path(path)))
+        accesses.append(access)
         share_modes.append(kwargs.get("share_mode"))
         return handle
 
@@ -417,6 +420,12 @@ def test_windows_directory_resolution_pins_all_path_components(monkeypatch):
     assert resolved.is_absolute()
     assert len(opened) >= 3
     assert closed == [handle for handle, _path in reversed(opened)]
+    assert all(
+        access
+        & (backend._FILE_TRAVERSE | backend._FILE_READ_ATTRIBUTES)
+        == (backend._FILE_TRAVERSE | backend._FILE_READ_ATTRIBUTES)
+        for access in accesses
+    )
     assert set(share_modes) == {
         backend._FILE_SHARE_READ | backend._FILE_SHARE_WRITE
     }
@@ -447,6 +456,36 @@ def test_windows_lock_pin_revalidates_reparse_components_after_key_handoff(
 
     with pytest.raises(codex_instruct.HooksConflict, match="reparse"):
         backend.pin_directory_for_lock(canonical, key)
+
+
+def test_file_claim_into_owned_transaction_applies_private_security(
+    tmp_path,
+    monkeypatch,
+):
+    transaction_dir = tmp_path / "owned transaction"
+    destination = transaction_dir / "claimed"
+    secured = []
+    monkeypatch.setitem(
+        codex_instruct._OWNED_DIRECTORY_RECORDS,
+        str(transaction_dir),
+        (codex_instruct.FileIdentity(1, 2), {}),
+    )
+    monkeypatch.setattr(
+        codex_instruct._FILESYSTEM,
+        "atomic_rename_no_replace",
+        lambda _source, _destination: True,
+    )
+    monkeypatch.setattr(
+        codex_instruct._FILESYSTEM,
+        "apply_private_path_security",
+        lambda path: secured.append(path),
+    )
+
+    assert codex_instruct._atomic_rename_no_replace(
+        tmp_path / "source",
+        destination,
+    )
+    assert secured == [destination]
 
 
 def test_failure_cleanup_contract_preserves_primary_exception(capsys):
@@ -631,20 +670,24 @@ with module._DirectoryLockSet([target]):
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows lock pin contract")
-def test_windows_directory_lock_pins_the_verified_identity(tmp_path):
-    codex_dir = _make_codex_dir(tmp_path, "pinned identity")
-    moved = codex_dir.with_name("pinned identity moved")
+@pytest.mark.parametrize("rename_target", ["directory", "parent"])
+def test_windows_directory_lock_pins_the_verified_identity(tmp_path, rename_target):
+    parent = tmp_path / "pinned identity parent"
+    parent.mkdir()
+    codex_dir = _make_codex_dir(parent, "pinned identity")
+    target = codex_dir if rename_target == "directory" else parent
+    moved = target.with_name(f"{target.name} moved")
 
     with codex_instruct._DirectoryLockSet([str(codex_dir)]):
         try:
-            codex_dir.rename(moved)
+            target.rename(moved)
         except OSError as exc:
             assert exc.winerror == 32
         else:
-            moved.rename(codex_dir)
+            moved.rename(target)
             pytest.fail("locked directory identity was not pinned")
 
-    codex_dir.rename(moved)
+    target.rename(moved)
     assert moved.is_dir()
 
 

--- a/tests/test_windows_filesystem.py
+++ b/tests/test_windows_filesystem.py
@@ -2,7 +2,6 @@ import importlib.util
 import inspect
 import json
 import os
-import selectors
 import subprocess
 import sys
 from pathlib import Path
@@ -208,7 +207,6 @@ with module._DirectoryLockSet([target]):
     pass
 """
     process = None
-    selector = selectors.DefaultSelector()
     with codex_instruct._DirectoryLockSet([str(codex_dir)]):
         process = subprocess.Popen(
             [sys.executable, "-c", worker, str(MODULE_PATH), str(codex_dir)],
@@ -217,14 +215,11 @@ with module._DirectoryLockSet([target]):
             text=True,
         )
         assert process.stdout is not None
-        selector.register(process.stdout, selectors.EVENT_READ)
-        events = selector.select(timeout=10)
-        assert events, "lock worker did not reach the wait checkpoint"
         assert process.stdout.readline() == "directory-lock-wait\n"
-        assert not selector.select(timeout=0.2), "worker acquired an already-held lock"
+        with pytest.raises(subprocess.TimeoutExpired):
+            process.wait(timeout=0.2)
     assert process is not None
     stdout, stderr = process.communicate(timeout=10)
-    selector.close()
     assert process.returncode == 0, stderr
     assert stdout == "directory-lock-acquired\n"
 

--- a/tests/test_windows_filesystem.py
+++ b/tests/test_windows_filesystem.py
@@ -449,7 +449,7 @@ def test_windows_verified_delete_preserves_occupied_evidence_then_retries(tmp_pa
                 identity,
                 fingerprint,
             )
-        assert caught.value.winerror == 32
+        assert caught.value.errno == 32
         assert target.read_bytes() == b"owned marker\n"
 
     codex_instruct._FILESYSTEM.remove_verified_file(

--- a/tests/test_windows_filesystem.py
+++ b/tests/test_windows_filesystem.py
@@ -2,12 +2,12 @@ import importlib.util
 import inspect
 import json
 import os
+import selectors
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
-
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "codex-instruct.py"
 spec = importlib.util.spec_from_file_location("codex_instruct_windows_fs", MODULE_PATH)
@@ -174,6 +174,50 @@ def test_operation_directories_are_identity_deduplicated_and_stably_sorted(tmp_p
     keys = [item.lock_key for item in normalized]
     assert keys == sorted(keys)
     assert {item.path for item in normalized} == {first.resolve(), second.resolve()}
+
+
+def test_directory_lock_excludes_second_process_without_sleep(tmp_path):
+    codex_dir = _make_codex_dir(tmp_path, "lock target")
+    worker = """
+import importlib.util
+import sys
+from pathlib import Path
+
+module_path = Path(sys.argv[1])
+target = sys.argv[2]
+spec = importlib.util.spec_from_file_location("keysmith_lock_worker", module_path)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+def checkpoint(name):
+    if name in {"directory-lock-wait", "directory-lock-acquired"}:
+        print(name, flush=True)
+
+module._FILESYSTEM_CHECKPOINT_HOOK = checkpoint
+with module._DirectoryLockSet([target]):
+    pass
+"""
+    process = None
+    selector = selectors.DefaultSelector()
+    with codex_instruct._DirectoryLockSet([str(codex_dir)]):
+        process = subprocess.Popen(
+            [sys.executable, "-c", worker, str(MODULE_PATH), str(codex_dir)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert process.stdout is not None
+        selector.register(process.stdout, selectors.EVENT_READ)
+        events = selector.select(timeout=10)
+        assert events, "lock worker did not reach the wait checkpoint"
+        assert process.stdout.readline() == "directory-lock-wait\n"
+        assert not selector.select(timeout=0.2), "worker acquired an already-held lock"
+    assert process is not None
+    stdout, stderr = process.communicate(timeout=10)
+    selector.close()
+    assert process.returncode == 0, stderr
+    assert stdout == "directory-lock-acquired\n"
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows native ACL contract")

--- a/tests/test_windows_filesystem.py
+++ b/tests/test_windows_filesystem.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -29,6 +30,15 @@ def _run(*args):
         text=True,
         capture_output=True,
     )
+
+
+def _make_windows_junction(link, target):
+    created = subprocess.run(
+        ["cmd", "/d", "/c", "mklink", "/J", str(link), str(target)],
+        text=True,
+        capture_output=True,
+    )
+    assert created.returncode == 0, created.stdout + created.stderr
 
 
 def test_platform_filesystem_contract_is_centralized():
@@ -272,6 +282,85 @@ def test_windows_native_identity_matches_python_portable_device_encoding():
     )
 
 
+def test_windows_lock_key_uses_file_id_across_distinct_alias_paths(monkeypatch):
+    backend = object.__new__(codex_instruct._WindowsFilesystemBackend)
+    handles = iter((101, 102))
+    canonical = {
+        101: Path("C:/Users/example/Codex"),
+        102: Path("X:/Codex"),
+    }
+    backend.kernel32 = types.SimpleNamespace(CloseHandle=lambda _handle: True)
+    monkeypatch.setattr(backend, "_open_handle", lambda *_args, **_kwargs: next(handles))
+    monkeypatch.setattr(
+        backend,
+        "_validate_handle_type",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(backend, "_validate_ntfs", lambda *_args: None)
+    monkeypatch.setattr(
+        backend,
+        "_handle_identity",
+        lambda _handle: codex_instruct.FileIdentity(17, 23),
+    )
+    monkeypatch.setattr(
+        backend,
+        "_canonical_path",
+        lambda handle, _fallback: canonical[handle],
+    )
+
+    first_key, first_path = backend.directory_lock_key(Path("C:/alias"))
+    second_key, second_path = backend.directory_lock_key(Path("X:/alias"))
+
+    assert first_path != second_path
+    assert first_key == second_key == (17, 23)
+
+
+def test_failure_cleanup_contract_preserves_primary_exception(capsys):
+    primary = RuntimeError("primary operation failure")
+
+    def cleanup():
+        raise PermissionError("secondary cleanup failure")
+
+    codex_instruct._run_cleanup_preserving_primary(
+        primary,
+        [("test cleanup", cleanup)],
+    )
+
+    output = capsys.readouterr().err
+    assert "primary operation failure" in output
+    assert "secondary cleanup failure" in output
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        codex_instruct._rollback_owned_file,
+        codex_instruct.isolate_hooks,
+        codex_instruct.rollback_hooks_isolation,
+        codex_instruct.archive_legacy_file,
+        codex_instruct._remove_owned_file,
+    ],
+)
+def test_failure_cleanup_paths_use_primary_preserving_guard(function):
+    assert "_run_cleanup_preserving_primary" in inspect.getsource(function)
+
+
+def test_windows_mutation_backend_declares_durable_metadata_contracts():
+    backend = codex_instruct._WindowsFilesystemBackend
+    rename_source = inspect.getsource(backend.atomic_rename_no_replace)
+    assert "_MOVEFILE_WRITE_THROUGH" in rename_source
+    for method in (
+        backend.create_private_directory,
+        backend.create_private_file,
+        backend.atomic_rename_no_replace,
+        backend.replace_atomic,
+        backend.remove_verified_member,
+        backend.remove_verified_directory,
+        backend.remove_verified_file,
+    ):
+        assert "flush_directory" in inspect.getsource(method)
+
+
 @pytest.mark.parametrize(
     "name",
     ["CON", "prn.md", "AUX", "nul.txt", "COM1", "lpt9.md"],
@@ -408,6 +497,26 @@ def test_windows_case_aliases_are_identity_deduplicated(tmp_path):
     assert len(normalized) == 1
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows reparse path contract")
+@pytest.mark.parametrize("alias_kind", ["root", "parent"])
+def test_windows_codex_directory_rejects_reparse_path_components(tmp_path, alias_kind):
+    real_parent = tmp_path / "real parent"
+    real_parent.mkdir()
+    codex_dir = _make_codex_dir(real_parent, "real codex")
+    if alias_kind == "root":
+        alias = tmp_path / "codex junction"
+        _make_windows_junction(alias, codex_dir)
+    else:
+        alias_parent = tmp_path / "parent junction"
+        _make_windows_junction(alias_parent, real_parent)
+        alias = alias_parent / codex_dir.name
+
+    result = _run("--codex-dir", alias, "--status")
+
+    assert result.returncode == 1
+    assert "reparse" in (result.stdout + result.stderr).lower()
+
+
 @pytest.mark.skipif(os.name != "nt", reason="Windows native ACL contract")
 def test_windows_private_file_and_directory_acl(tmp_path):
     directory = tmp_path / "private 中文"
@@ -439,6 +548,87 @@ def test_windows_private_acl_rejects_extra_everyone_ace(tmp_path):
             target,
             is_directory=False,
         )
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows recovery ACL contract")
+@pytest.mark.parametrize("target_kind", ["directory", "member"])
+def test_windows_recovery_revalidates_existing_journal_acl(tmp_path, target_kind):
+    codex_dir = _make_codex_dir(tmp_path, f"acl recovery {target_kind}")
+    plan = codex_instruct.inspect_directory(codex_dir)
+    state = codex_instruct.DeploymentState(codex_dir, deployment_id="e" * 32)
+    codex_instruct._create_deployment_journals(
+        [state],
+        [plan],
+        codex_instruct.DEFAULT_MD_FILENAME,
+        codex_instruct.BUILTIN_GPT_UNRESTRICTED_MD,
+        False,
+    )
+    assert state.journal_dir is not None
+    target = (
+        state.journal_dir
+        if target_kind == "directory"
+        else state.journal_dir / codex_instruct.JOURNAL_FILENAME
+    )
+    changed = subprocess.run(
+        ["icacls", str(target), "/grant", "*S-1-1-0:(R)"],
+        text=True,
+        capture_output=True,
+    )
+    assert changed.returncode == 0, changed.stdout + changed.stderr
+
+    recovered = _run("--codex-dir", codex_dir, "--recover", "--yes")
+
+    assert recovered.returncode == 1
+    assert "acl" in (recovered.stdout + recovered.stderr).lower()
+    assert state.journal_dir.exists()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows durable metadata contract")
+def test_windows_mutations_flush_parent_directories(tmp_path, monkeypatch):
+    backend = codex_instruct._FILESYSTEM
+    flushed = []
+    real_flush = backend.flush_directory
+
+    def record_flush(path):
+        flushed.append(Path(path))
+        real_flush(path)
+
+    monkeypatch.setattr(backend, "flush_directory", record_flush)
+    parent = tmp_path / "durable parent"
+    backend.create_private_directory(parent)
+
+    source = parent / "source.json"
+    descriptor = backend.create_private_file(source)
+    with os.fdopen(descriptor, "wb") as stream:
+        stream.write(b"source\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    destination = parent / "destination.json"
+    assert backend.atomic_rename_no_replace(source, destination)
+
+    replacement = parent / "replacement.json"
+    descriptor = backend.create_private_file(replacement)
+    with os.fdopen(descriptor, "wb") as stream:
+        stream.write(b"replacement\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    backend.replace_atomic(replacement, destination)
+    identity = codex_instruct._require_regular_file(destination, "destination")
+    fingerprint = codex_instruct._fingerprint_regular_file(destination)
+    backend.remove_verified_file(destination, identity, fingerprint)
+
+    owned = parent / "owned"
+    backend.create_private_directory(owned)
+    access = backend.open_verified_owned_directory(
+        owned,
+        codex_instruct._directory_identity(owned),
+        {},
+        True,
+    )
+    backend.remove_verified_directory(access)
+
+    assert tmp_path in flushed
+    assert flushed.count(parent) >= 6
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows verified delete contract")

--- a/tests/test_windows_filesystem.py
+++ b/tests/test_windows_filesystem.py
@@ -225,9 +225,9 @@ def test_issue_1_v010_initializing_fixture_recovers_to_ready(tmp_path):
     }
     intent = json.loads(json.dumps(base))
     intent.pop("phase")
-    intent["directories"][str(codex_dir.resolve())]["resources"]["manifest"][
-        "allowed_sha256"
-    ] = []
+    intent_directory = intent["directories"][str(codex_dir.resolve())]
+    intent_directory.pop("residues")
+    intent_directory["resources"]["manifest"]["allowed_sha256"] = []
     journal = dict(base)
     journal["owner_directory"] = str(codex_dir.resolve())
     codex_instruct._write_exclusive_private_json(

--- a/tests/test_windows_filesystem.py
+++ b/tests/test_windows_filesystem.py
@@ -458,13 +458,19 @@ def test_windows_lock_pin_revalidates_reparse_components_after_key_handoff(
         backend.pin_directory_for_lock(canonical, key)
 
 
-def test_file_claim_into_owned_transaction_applies_private_security(
+def test_verified_file_claim_applies_identity_bound_private_security(
     tmp_path,
     monkeypatch,
 ):
     transaction_dir = tmp_path / "owned transaction"
     destination = transaction_dir / "claimed"
     secured = []
+    fingerprint = codex_instruct.FileFingerprint(
+        codex_instruct.FileIdentity(3, 4),
+        5,
+        6,
+        "7" * 64,
+    )
     monkeypatch.setitem(
         codex_instruct._OWNED_DIRECTORY_RECORDS,
         str(transaction_dir),
@@ -472,20 +478,60 @@ def test_file_claim_into_owned_transaction_applies_private_security(
     )
     monkeypatch.setattr(
         codex_instruct._FILESYSTEM,
-        "atomic_rename_no_replace",
-        lambda _source, _destination: True,
-    )
-    monkeypatch.setattr(
-        codex_instruct._FILESYSTEM,
         "apply_private_path_security",
-        lambda path: secured.append(path),
+        lambda path, expected: secured.append((path, expected)),
     )
 
-    assert codex_instruct._atomic_rename_no_replace(
-        tmp_path / "source",
+    codex_instruct._secure_verified_transaction_claim(
         destination,
+        fingerprint,
     )
-    assert secured == [destination]
+    assert secured == [(destination, fingerprint)]
+
+
+def test_windows_private_acl_update_rejects_replaced_claim(monkeypatch):
+    backend = object.__new__(codex_instruct._WindowsFilesystemBackend)
+    closed = []
+    open_kwargs = []
+    security_updates = []
+    backend.kernel32 = types.SimpleNamespace(
+        CloseHandle=lambda handle: closed.append(handle) or True,
+        FlushFileBuffers=lambda _handle: True,
+    )
+    backend.advapi32 = types.SimpleNamespace(
+        SetKernelObjectSecurity=lambda *_args: security_updates.append(True) or True,
+    )
+    backend._security_descriptor = object()
+
+    def open_handle(*_args, **kwargs):
+        open_kwargs.append(kwargs)
+        return 101
+
+    monkeypatch.setattr(backend, "_open_handle", open_handle)
+    monkeypatch.setattr(backend, "_validate_handle_type", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(backend, "_validate_ntfs", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        backend,
+        "_handle_identity",
+        lambda _handle: codex_instruct.FileIdentity(5, 6),
+    )
+
+    with pytest.raises(codex_instruct.HooksConflict, match="identity changed"):
+        backend.apply_private_path_security(
+            Path("C:/claimed"),
+            codex_instruct.FileFingerprint(
+                codex_instruct.FileIdentity(7, 8),
+                9,
+                10,
+                "a" * 64,
+            ),
+        )
+
+    assert open_kwargs == [{"share_mode": backend._FILE_SHARE_READ}]
+    assert security_updates == []
+    assert closed == [101]
+    source = inspect.getsource(backend.apply_private_path_security)
+    assert source.count("_fingerprint_descriptor") == 2
 
 
 def test_failure_cleanup_contract_preserves_primary_exception(capsys):

--- a/tests/test_windows_filesystem.py
+++ b/tests/test_windows_filesystem.py
@@ -681,3 +681,21 @@ def test_windows_owned_directory_cleanup_rejects_reparse_members(tmp_path):
             require_exact_members=True,
         )
     assert outside.read_text(encoding="utf-8") == "outside\n"
+
+
+@pytest.mark.parametrize(
+    ("function", "expected_calls"),
+    [
+        (codex_instruct._recover_uninstall, 2),
+        (codex_instruct._load_initializing_uninstall_pending, 1),
+    ],
+)
+def test_uninstall_intent_reads_are_bound_to_verified_directory_evidence(
+    function,
+    expected_calls,
+):
+    source = inspect.getsource(function)
+    calls = source.split("_load_cleanup_intent(")[1:]
+
+    assert len(calls) == expected_calls
+    assert all("," in call.split(")", 1)[0] for call in calls)


### PR DESCRIPTION
## Scope

P0-only Windows filesystem and durable-recovery hardening on top of `codex/fix-durable-recovery`.

- remove Windows directory-FD assumptions with a native handle backend
- reject root/parent reparse components and lock directory aliases by stable File ID
- preserve primary exceptions across rollback/cleanup failures
- revalidate journal directory/member ACL, identity, membership, and fingerprints before recovery
- make create/no-replace/replace/delete metadata durable with write-through and directory flushes
- recover v0.1.0-style initializing intent/journal evidence, empty private journals, and partial multi-directory uninstall publication
- bind claimed-file ACL updates to an exact native identity and full fingerprint under deny-write/delete sharing

## P0 evidence

- Addresses #1 with deterministic fixtures for `intent.json` + `journal.json` and empty initializing journal recovery to `status ready`.
- Windows 3.10: 474 passed, 6 skipped.
- Windows 3.14: 474 passed, 6 skipped.
- macOS 3.9/3.14: 463 passed, 17 skipped each.
- Ubuntu 3.9/3.14: 463 passed, 17 skipped each.
- Quality: Ruff passed; 463 passed, 17 skipped; branch coverage 82%; prompt bank 12 cases; release-conflict refusal passed.
- Blocking run: https://github.com/Jia-Ethan/codex-keysmith/actions/runs/29849531362

## Deferred

P1 hard-kill phase expansion, real SUBST/8.3/volume-alias cross-process coverage, long paths, localized USERPROFILE fixtures, and P2 documentation/release support declarations remain out of scope. No tag or Release is created, and signed `v0.1.0` is unchanged.
