### PR TITLE
fix: preserve external config rewrites on uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ### Fixed
 
+- Schema-1 manifest config ownership is now interpreted as semantic ownership of the top-level `model_instructions_file`, fixing CCSwitch-style rewrites of unrelated `config.toml` fields blocking status, deploy, or uninstall. Uninstall preserves unrelated live content while restoring/removing only the pre-deployment instruction statement, fails closed when that reference is missing/different or the target field is ambiguous/uses unsupported structure, and keeps full-file fingerprints for CAS, durable snapshots, rollback, concurrency, and recovery. Merged config publication uses one immutable SHA-only uninstall after-state without weakening any other resource.
 - Release recovery now keeps an existing immutable signed tag, reruns every blocking job against its exact peeled commit, and stages draft assets through the numeric Release ID and returned upload URL instead of querying an unpublished draft by tag.
 
 ## [0.1.1] - 2026-07-22

--- a/README.en.md
+++ b/README.en.md
@@ -53,7 +53,7 @@ Omitting `--codex-dir` processes every auto-discovered directory; only do this f
 | Path | What happens |
 | --- | --- |
 | `<codex-dir>/gpt-unrestricted.md` (or custom `--name`) | Create, or back up and replace |
-| `<codex-dir>/config.toml` | Only `model_instructions_file` changes; unchanged values stay untouched |
+| `<codex-dir>/config.toml` | Owns and edits only top-level `model_instructions_file`; external rewrites of other fields do not block status/uninstall and survive uninstall |
 | `<codex-dir>/hooks.json` | Isolated to `hooks.json.disabled` by default (backed up first) |
 | `<codex-dir>/.codex-keysmith-manifest.json` | Records what this deployment changed, for later uninstall |
 
@@ -70,7 +70,7 @@ python3 codex-instruct.py --codex-dir ~/.codex --uninstall --lang en        # pr
 python3 codex-instruct.py --codex-dir ~/.codex --uninstall --yes --lang en  # confirm
 ```
 
-Uninstall removes only the newest layer each run; repeat it to peel back earlier deployments.
+Uninstall removes only the newest layer each run; repeat it to peel back earlier deployments. Long-lived config ownership covers only the top-level `model_instructions_file`: rewrites by CCSwitch or similar tools remain compatible while that field still references this layer's Markdown. Uninstall restores or removes only the pre-deployment field statement and preserves all other live content. A missing/different target reference, target-field ambiguity, or unsupported statement structure still fails closed.
 
 ### If something goes wrong
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ python3 codex-instruct-vX.Y.Z.py --codex-dir ~/.codex --yes --lang zh-CN
 | 路径 | 会发生什么 |
 | --- | --- |
 | `<codex-dir>/gpt-unrestricted.md`（或自定义 `--name`） | 新建，或先备份再替换 |
-| `<codex-dir>/config.toml` | 只改 `model_instructions_file` 这一项，值不变就不动 |
+| `<codex-dir>/config.toml` | 只拥有并修改顶层 `model_instructions_file`；外部工具重写其他字段不会阻塞 status/uninstall，卸载会保留这些字段 |
 | `<codex-dir>/hooks.json` | 默认整体隔离为 `hooks.json.disabled`（先备份） |
 | `<codex-dir>/.codex-keysmith-manifest.json` | 记录这次部署改了什么，供后续卸载用 |
 
@@ -83,7 +83,7 @@ python3 codex-instruct.py --codex-dir ~/.codex --uninstall --lang zh-CN        #
 python3 codex-instruct.py --codex-dir ~/.codex --uninstall --yes --lang zh-CN  # 确认卸载
 ```
 
-卸载每次只撤销最新一层部署；部署过多次的话，重复运行逐层撤销。
+卸载每次只撤销最新一层部署；部署过多次的话，重复运行逐层撤销。config 的长期所有权只覆盖顶层 `model_instructions_file`：CCSwitch 等工具重写其他字段时，只要该字段仍引用本层 MD，status 和卸载仍可继续；卸载只恢复/移除部署前的该字段语句并保留其余当前内容。目标字段缺失、改指其他路径、存在歧义或使用扫描器不支持的语句结构仍会 fail closed。
 
 ### 出问题了怎么办
 

--- a/codex-instruct.py
+++ b/codex-instruct.py
@@ -962,6 +962,14 @@ class ConfigConflict(HooksConflict):
     """Raised when config.toml cannot be updated without guessing."""
 
 
+class TransactionResidueCleanupFailure(HooksConflict):
+    """Raised when a published write cannot remove its registered residue."""
+
+    def __init__(self, message: str, transaction_dir: Path):
+        super().__init__(message)
+        self.transaction_dir = transaction_dir
+
+
 _PLANNED_HOOKS_UNSET = object()
 
 
@@ -4309,6 +4317,17 @@ def _cleanup_transaction_dir_after_error(transaction_dir: Path) -> None:
         _print(f"[事务警告] {exc}", file=sys.stderr)
 
 
+def _strict_cleanup_transaction_dir(transaction_dir: Path) -> None:
+    """Remove a successful transaction residue or surface durable cleanup failure."""
+    try:
+        _remove_transaction_dir(transaction_dir)
+    except Exception as exc:
+        raise TransactionResidueCleanupFailure(
+            f"registered transaction residue cleanup failed: {transaction_dir}",
+            transaction_dir,
+        ) from exc
+
+
 def _run_cleanup_preserving_primary(
     primary_exception: BaseException,
     steps: List[Tuple[str, Callable[[], None]]],
@@ -4510,6 +4529,7 @@ def _transactional_replace_existing(
         },
     )
     previous_claim = transaction_dir / "previous"
+    previous_unlinked = False
 
     try:
         if not _atomic_rename_no_replace(destination, previous_claim):
@@ -4529,8 +4549,27 @@ def _transactional_replace_existing(
             on_published(prepared_fingerprint)
 
         previous_claim.unlink()
-        _cleanup_transaction_dir_after_error(transaction_dir)
-    except BaseException:
+        previous_unlinked = True
+        # Success is not durable until this registered residue is gone. If
+        # strict cleanup fails, surface a typed error while the uninstall
+        # journal still authorizes the empty residue. The enclosing uninstall
+        # rolls back from its durable snapshot and retains that journal.
+        _strict_cleanup_transaction_dir(transaction_dir)
+    except BaseException as primary:
+        if previous_unlinked:
+            current = _fingerprint_or_none(destination)
+            if current is None or current != prepared_fingerprint:
+                raise HooksConflict(
+                    f"residue 清理失败后发布文件已漂移: {destination}"
+                ) from primary
+            if not isinstance(primary, TransactionResidueCleanupFailure):
+                primary = TransactionResidueCleanupFailure(
+                    f"registered transaction residue cleanup failed: {transaction_dir}",
+                    transaction_dir,
+                )
+            raise primary
+
+        rollback_incomplete = False
         try:
             if _path_entry_exists(previous_claim):
                 if _path_entry_exists(destination):
@@ -4576,11 +4615,15 @@ def _transactional_replace_existing(
                             timestamp,
                         )
         except BaseException as cleanup_exc:
+            rollback_incomplete = True
             _print(
                 f"[事务警告] 写入回滚未完整完成: {cleanup_exc}",
                 file=sys.stderr,
             )
-        _cleanup_transaction_dir_after_error(transaction_dir)
+        if rollback_incomplete:
+            _cleanup_transaction_dir_after_error(transaction_dir)
+        else:
+            _remove_transaction_dir(transaction_dir)
         raise
 
 
@@ -5487,6 +5530,7 @@ class UninstallPlan:
     manifest: Optional[Dict[str, Any]] = None
     manifest_fingerprint: Optional[FileFingerprint] = None
     current_fingerprints: Optional[Dict[Path, FileFingerprint]] = None
+    merged_config_content: Optional[str] = None
     hooks_state: str = "unchanged"
     blockers: Optional[List[str]] = None
 
@@ -5568,6 +5612,164 @@ def _preflight_manifest_path(
         plan.blockers.append(f"{label} 已漂移，拒绝卸载: {path}")
 
 
+def _fingerprint_matches_portable(
+    fingerprint: FileFingerprint,
+    expected: Optional[Dict[str, Any]],
+) -> bool:
+    return expected is not None and (
+        fingerprint.size == expected["size"]
+        and fingerprint.modified_ns == expected["mtime_ns"]
+        and fingerprint.sha256 == expected["sha256"]
+    )
+
+
+def _merge_uninstall_config_statement(
+    current_content: str,
+    current_analysis: "TomlRootAnalysis",
+    original_content: str,
+    original_analysis: "TomlRootAnalysis",
+) -> str:
+    current_statement = current_analysis.instruction_statement
+    if current_statement is None:
+        raise ConfigConflict(
+            "当前 config.toml 缺少受管的顶层 model_instructions_file"
+        )
+    original_statement = original_analysis.instruction_statement
+    if original_statement is None:
+        merged = (
+            current_content[: current_statement.start]
+            + current_content[current_statement.end :]
+        )
+    else:
+        original_ending = _statement_newline(original_content, original_statement)
+        current_ending = _statement_newline(current_content, current_statement)
+        original_text = original_content[
+            original_statement.start : original_statement.end
+        ]
+        if original_ending:
+            original_text = original_text[: -len(original_ending)]
+        merged = (
+            current_content[: current_statement.start]
+            + original_text
+            + current_ending
+            + current_content[current_statement.end :]
+        )
+
+    merged_analysis = _analyze_toml_root(merged)
+    if (
+        merged_analysis.instruction_reference
+        != original_analysis.instruction_reference
+    ):
+        raise ConfigConflict(
+            "合并后的顶层 model_instructions_file 未恢复到部署前状态"
+        )
+    return merged
+
+
+def _preflight_uninstall_config(
+    plan: UninstallPlan,
+    config: Dict[str, Any],
+    md: Dict[str, Any],
+) -> None:
+    config_path = plan.codex_dir / config["path"]
+    node = _classify_node(config_path)
+    if not node.regular:
+        plan.blockers.append(
+            _localized(
+                "config.toml 应为普通文件，但当前为 "
+                f"{node.kind}: {config_path}",
+                "config.toml must be a regular file, but is a "
+                f"{node.kind}: {config_path}",
+            )
+        )
+        return
+    try:
+        content, fingerprint = _read_regular_text_with_fingerprint(
+            config_path,
+            "config.toml",
+        )
+        analysis = _analyze_toml_root(content)
+    except (OSError, UnicodeDecodeError, ConfigConflict) as exc:
+        plan.blockers.append(
+            _localized(
+                f"config.toml 已漂移且目标字段存在歧义或不支持的结构: {exc}",
+                "config.toml drifted and has target-field ambiguity or "
+                f"unsupported structure ({type(exc).__name__})",
+            )
+        )
+        return
+    plan.current_fingerprints[config_path] = fingerprint
+
+    exact_after_content = (
+        fingerprint.size == config["after"]["size"]
+        and fingerprint.sha256 == config["after"]["sha256"]
+    )
+    owned_reference = f'./{md["path"]}'
+    if analysis.instruction_reference != owned_reference:
+        current_state = (
+            "缺失"
+            if analysis.instruction_statement is None
+            else "指向其他路径"
+        )
+        plan.blockers.append(
+            _localized(
+                "config.toml 顶层 model_instructions_file 所有权冲突: "
+                f"当前字段{current_state}，预期仍引用 {owned_reference}",
+                "top-level config.toml model_instructions_file ownership conflict: "
+                f"the current field is {'missing' if analysis.instruction_statement is None else 'set to another path'}; "
+                f"expected it to still reference {owned_reference}",
+            )
+        )
+        return
+
+    if exact_after_content or not config["changed"]:
+        return
+
+    if config["backup"] is None:
+        plan.blockers.append(
+            _localized(
+                "config.toml manifest 缺少字段恢复备份",
+                "config.toml manifest is missing its field-restoration backup",
+            )
+        )
+        return
+    backup_path = plan.codex_dir / config["backup"]
+    backup_node = _classify_node(backup_path)
+    if not backup_node.regular:
+        plan.blockers.append(
+            _localized(
+                f"config.toml 备份是 {backup_node.kind}: {backup_path}",
+                f"config.toml backup is a {backup_node.kind}: {backup_path}",
+            )
+        )
+        return
+    try:
+        original_content, backup_fingerprint = _read_regular_text_with_fingerprint(
+            backup_path,
+            "config.toml 备份",
+        )
+        if not _fingerprint_matches_portable(backup_fingerprint, config["before"]):
+            raise ConfigConflict("config.toml 备份内容或时间戳不匹配")
+        original_analysis = _analyze_toml_root(original_content)
+        merged = _merge_uninstall_config_statement(
+            content,
+            analysis,
+            original_content,
+            original_analysis,
+        )
+    except (OSError, UnicodeDecodeError, ConfigConflict) as exc:
+        plan.blockers.append(
+            _localized(
+                f"config.toml 备份无法安全用于字段恢复: {exc}",
+                "config.toml backup cannot be used safely for field restoration "
+                f"({type(exc).__name__})",
+            )
+        )
+        return
+    plan.current_fingerprints[backup_path] = backup_fingerprint
+    plan.merged_config_content = merged
+
+
 def _preflight_backup(
     plan: UninstallPlan,
     name: Optional[str],
@@ -5592,7 +5794,7 @@ def _preflight_backup(
         plan.blockers.append(f"{label} 备份无法安全读取: {exc}")
         return
     plan.current_fingerprints[path] = fingerprint
-    if not _portable_matches(path, expected):
+    if not _fingerprint_matches_portable(fingerprint, expected):
         plan.blockers.append(f"{label} 备份内容或时间戳不匹配: {path}")
 
 
@@ -5633,9 +5835,7 @@ def inspect_uninstall_directory(
     hooks = manifest["hooks"]
     legacy = manifest["legacy"]
     previous = manifest["previous_manifest"]
-    _preflight_manifest_path(
-        plan, codex_dir / config["path"], config["after"], "config.toml"
-    )
+    _preflight_uninstall_config(plan, config, md)
     _preflight_manifest_path(plan, codex_dir / md["path"], md["after"], "提示词文件")
     hooks_path = codex_dir / "hooks.json"
     disabled_path = codex_dir / "hooks.json.disabled"
@@ -5677,7 +5877,14 @@ def inspect_uninstall_directory(
             plan, codex_dir / legacy["path"], legacy["after"], "旧版提示词"
         )
 
-    _preflight_backup(plan, config["backup"], config["before"] if config["changed"] else None, "config.toml")
+    config_backup = codex_dir / config["backup"] if config["backup"] else None
+    if plan.merged_config_content is None or config_backup not in plan.current_fingerprints:
+        _preflight_backup(
+            plan,
+            config["backup"],
+            config["before"] if config["changed"] else None,
+            "config.toml",
+        )
     _preflight_backup(plan, md["backup"], md["before"], "提示词文件")
     if inspect_hook_backups:
         _preflight_backup(
@@ -7309,15 +7516,30 @@ def _validate_uninstall_terminal_state(data: Dict[str, Any], phase: str) -> None
         codex_dir = Path(directory)
         resources = data["directories"][directory]["resources"]
         for resource in resources.values():
-            expected = (
-                resource["before"]
-                if phase == "recovered"
-                else _uninstall_after_state(resource)
-            )
             path = codex_dir / resource["path"]
-            if not _portable_matches(path, expected):
+            valid = (
+                _portable_matches(path, resource["before"])
+                if phase == "recovered"
+                else _uninstall_resource_matches_after(path, resource)
+            )
+            if not valid:
                 raise HooksConflict(
                     f"uninstall {phase} 终态验证失败: {path}"
+                )
+        manifest_resource = resources["manifest"]
+        if phase == "committed" or manifest_resource["before"] is not None:
+            ownership = inspect_uninstall_directory(
+                codex_dir,
+                inspect_residue=False,
+            )
+            if ownership.blockers:
+                raise HooksConflict(
+                    _localized(
+                        f"uninstall {phase} 事务清单所有权无效: "
+                        + "; ".join(ownership.blockers),
+                        f"uninstall {phase} manifest-layer ownership is invalid; "
+                        f"{len(ownership.blockers)} blocker(s) found",
+                    )
                 )
 
 
@@ -7333,6 +7555,16 @@ def _cleanup_uninstall_terminal_journals(
     if not yes:
         _print("[预览] 终态资源不会反向恢复；确认清理请添加 --yes。")
         return
+    _cleanup_uninstall_residues(
+        reference,
+        {
+            directory: (
+                Path(directory)
+                / reference["directories"][directory]["journal_dir"]
+            )
+            for directory in reference["participants"]
+        },
+    )
     _remove_retained_cleanup_markers(retained_cleanup_markers)
     for journal_dir, data in journals:
         if _path_entry_exists(journal_dir / JOURNAL_PENDING_FILENAME):
@@ -7454,8 +7686,7 @@ def _restore_uninstall_before_state(
             current = _fingerprint_or_none(path)
             if before is None:
                 if current is not None:
-                    after = _uninstall_after_state(resource)
-                    if not _portable_matches(path, after):
+                    if not _uninstall_resource_matches_after(path, resource):
                         raise HooksConflict(f"卸载恢复目标已漂移: {path}")
                     _remove_owned_file(path, current)
                 continue
@@ -8464,13 +8695,21 @@ def _select_uninstall_manifest_archive(path: Path, timestamp: str) -> Path:
 
 def _uninstall_after_state(resource: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     portable = resource["allowed_portable"]
-    if len(portable) == 1:
+    if len(portable) == 1 and not resource["allowed_sha256"]:
         return portable[0]
-    if resource["allowed_absent"] and not portable:
+    if resource["allowed_absent"] and not portable and not resource["allowed_sha256"]:
         return None
-    if len(portable) != 1:
-        raise ValueError("uninstall resource 缺少唯一 after 状态")
-    return portable[0]
+    raise ValueError("uninstall resource 缺少唯一 portable after 状态")
+
+
+def _uninstall_resource_matches_after(path: Path, resource: Dict[str, Any]) -> bool:
+    allowed_sha256 = resource["allowed_sha256"]
+    if allowed_sha256:
+        if len(allowed_sha256) != 1:
+            return False
+        current = _fingerprint_or_none(path)
+        return current is not None and current.sha256 == allowed_sha256[0]
+    return _portable_matches(path, _uninstall_after_state(resource))
 
 
 def _validate_uninstall_journal_resources(
@@ -8514,9 +8753,19 @@ def _validate_uninstall_journal_resources(
         )
         if resource["snapshot"] != expected_snapshot:
             raise ValueError(f"卸载恢复日志 {label} 快照名无效: {directory}")
-        if resource["allowed_sha256"]:
-            raise ValueError(f"卸载恢复日志 {label} 不应使用 SHA-only after")
-        _uninstall_after_state(resource)
+        allowed_sha256 = resource["allowed_sha256"]
+        if allowed_sha256:
+            if (
+                label != "config"
+                or len(allowed_sha256) != 1
+                or resource["allowed_absent"]
+                or resource["allowed_portable"]
+            ):
+                raise ValueError(
+                    f"卸载恢复日志 {label} SHA-only after 状态无效: {directory}"
+                )
+        else:
+            _uninstall_after_state(resource)
     if resources["config"]["before"] is None:
         raise ValueError(f"卸载恢复日志 config 缺少 before: {directory}")
     if resources["md"]["before"] is None:
@@ -8560,6 +8809,7 @@ def _create_uninstall_journals(
             path: Path,
             before: Optional[FileFingerprint],
             after: Optional[Dict[str, Any]],
+            after_sha256: Optional[str] = None,
         ) -> Dict[str, Any]:
             return _journal_resource(
                 path.name,
@@ -8569,7 +8819,8 @@ def _create_uninstall_journals(
                     if before is not None
                     else None
                 ),
-                allowed_absent=after is None,
+                allowed_absent=after is None and after_sha256 is None,
+                allowed_sha256=[after_sha256] if after_sha256 is not None else [],
                 allowed_portable=[after] if after is not None else [],
             )
 
@@ -8585,7 +8836,22 @@ def _create_uninstall_journals(
                 "config",
                 config_path,
                 current(config_path),
-                config["before"] if config["changed"] else config["after"],
+                (
+                    None
+                    if plan.merged_config_content is not None
+                    else (
+                        config["before"]
+                        if config["changed"]
+                        else _portable_fingerprint(current(config_path))
+                    )
+                ),
+                (
+                    hashlib.sha256(
+                        plan.merged_config_content.encode("utf-8")
+                    ).hexdigest()
+                    if plan.merged_config_content is not None
+                    else None
+                ),
             ),
             "md": resource("md", md_path, current(md_path), md["before"]),
             "manifest": resource(
@@ -8890,7 +9156,17 @@ def _execute_uninstall_state(state: UninstallState, timestamp: str) -> None:
 
     _update_uninstall_phase(state, "config-intent")
     config_path = codex_dir / config["path"]
-    if config["changed"]:
+    if plan.merged_config_content is not None:
+        atomic_write_text(
+            config_path,
+            plan.merged_config_content,
+            expected_fingerprint=plan.current_fingerprints[config_path],
+            on_published=lambda published: state.post_expected.__setitem__(
+                config_path,
+                _portable_fingerprint(published),
+            ),
+        )
+    elif config["changed"]:
         current = plan.current_fingerprints[config_path]
         config_backup = codex_dir / config["backup"]
         _replace_owned_from_backup(
@@ -8899,7 +9175,17 @@ def _execute_uninstall_state(state: UninstallState, timestamp: str) -> None:
             config_backup,
             plan.current_fingerprints[config_backup],
         )
-    _record_post(state, config_path)
+        _record_post(state, config_path)
+    else:
+        expected = plan.current_fingerprints[config_path]
+        if not _path_has_fingerprint(config_path, expected):
+            raise HooksConflict(
+                _localized(
+                    f"config.toml 在卸载字段检查后发生变化: {config_path}",
+                    f"config.toml changed after uninstall field validation: {config_path}",
+                )
+            )
+        state.post_expected[config_path] = _portable_fingerprint(expected)
 
     _update_uninstall_phase(state, "md-intent")
     md_path = codex_dir / md["path"]
@@ -9166,6 +9452,17 @@ def _uninstall_locked(codex_dirs: List[str], yes: bool) -> None:
             sys.exit(1)
         _print(f"[错误] 卸载失败，开始反向恢复: {exc}")
         rollback_errors = []
+        failed_residue = (
+            exc.transaction_dir
+            if isinstance(exc, TransactionResidueCleanupFailure)
+            else None
+        )
+        if failed_residue is not None:
+            record = _OWNED_DIRECTORY_RECORDS.pop(str(failed_residue), None)
+            if record is None:
+                rollback_errors.append(
+                    f"写入 residue 缺少活动所有权记录: {failed_residue}"
+                )
         for state in reversed(states):
             rollback_errors.extend(_rollback_uninstall_state(state))
         for error in rollback_errors:
@@ -9176,15 +9473,25 @@ def _uninstall_locked(codex_dirs: List[str], yes: bool) -> None:
                     states[0].journal_data,
                     "recovered",
                 )
-                _cleanup_uninstall_residues(
-                    states[0].journal_data,
-                    {
-                        str(state.codex_dir.resolve()): state.journal_dir
-                        for state in states
-                    },
-                )
                 _update_deployment_journals(states, "recovered")
-                _remove_deployment_journals(states)
+                if isinstance(exc, TransactionResidueCleanupFailure):
+                    _print(
+                        _localized(
+                            "[恢复] 写入 residue 清理失败；已保留 recovered journal，"
+                            "请运行 --recover 完成清理。",
+                            "[Restore] Write residue cleanup failed; the recovered "
+                            "journal was preserved. Run --recover to finish cleanup.",
+                        )
+                    )
+                else:
+                    _cleanup_uninstall_residues(
+                        states[0].journal_data,
+                        {
+                            str(state.codex_dir.resolve()): state.journal_dir
+                            for state in states
+                        },
+                    )
+                    _remove_deployment_journals(states)
             except BaseException as recovery_exc:
                 rollback_errors.append(str(recovery_exc))
                 _print(f"  [回滚警告] durable recovery 清理失败: {recovery_exc}")
@@ -9697,6 +10004,10 @@ def _detect_newline(content: str) -> str:
 
 def _analyze_toml_root(content: str) -> TomlRootAnalysis:
     """Conservatively locate top-level TOML keys without parsing nested tables."""
+    # This zero-dependency scanner protects the target field and rejects
+    # unsupported/ambiguous statement boundaries.  It is deliberately not a
+    # complete TOML validator: unrelated value syntax and cross-table key
+    # redefinition can remain outside what it proves.
     index = 1 if content.startswith("\ufeff") else 0
     statements = []
     first_table_start = None
@@ -10456,12 +10767,38 @@ def _deploy_locked(args, codex_dirs: Optional[List[str]] = None) -> None:
             sys.exit(1)
         _print(f"\n[错误] 部署失败，开始回滚: {exc}")
         rollback_errors = []
+        failed_residue = (
+            exc.transaction_dir
+            if isinstance(exc, TransactionResidueCleanupFailure)
+            else None
+        )
+        if failed_residue is not None:
+            record = _OWNED_DIRECTORY_RECORDS.pop(str(failed_residue), None)
+            if record is None:
+                rollback_errors.append(
+                    f"写入 residue 缺少活动所有权记录: {failed_residue}"
+                )
         for state in reversed(states):
             rollback_errors.extend(rollback_deployment_state(state, md_filename))
         for rollback_error in rollback_errors:
             _print(f"  [回滚警告] {rollback_error}")
         if rollback_errors:
             _print("[错误] 部署未完成，部分路径需要使用现有备份手动恢复。")
+        elif isinstance(exc, TransactionResidueCleanupFailure):
+            try:
+                _validate_terminal_journal_state(states[0].journal_data, "recovered")
+                _update_deployment_journals(states, "recovered")
+                _print(
+                    _localized(
+                        "[恢复] 写入 residue 清理失败；已保留 recovered journal，"
+                        "请运行 --recover 完成清理。",
+                        "[Restore] Write residue cleanup failed; the recovered "
+                        "journal was preserved. Run --recover to finish cleanup.",
+                    )
+                )
+            except BaseException as recovery_exc:
+                rollback_errors.append(str(recovery_exc))
+                _print(f"  [回滚警告] durable recovery 持久化失败: {recovery_exc}")
         else:
             try:
                 _remove_deployment_journals(states)

--- a/docs/hooks-transactions.md
+++ b/docs/hooks-transactions.md
@@ -110,7 +110,7 @@ MD 内容、config 更新内容和预检 fingerprint 在 hooks 隔离前完成�
 - config/MD 完成第一轮多目录一致性检查后，才准备并发布 manifest；
 - 已有 manifest 先创建验证备份，并作为上一层写入新 manifest。
 
-manifest 始终拥有本轮 MD 和 config；仅拥有实际 isolated hooks 与实际 archived legacy。它还记录 deployment ID、工具版本、UTC 时间、必要备份和上一层 manifest。portable ownership 使用 `size`、`mtime_ns` 和 SHA-256，不依赖 inode。
+manifest 始终拥有本轮 MD 生命周期；config 的长期所有权仅是顶层 `model_instructions_file` 的语义值，不是整份文件字节。manifest schema 1 中现有 config before/after 整文件指纹继续兼容，并严格用于部署时 final sweep、操作期稳定读取/CAS、journal snapshot、回滚、并发拒绝与崩溃恢复。仅拥有实际 isolated hooks 与实际 archived legacy。它还记录 deployment ID、工具版本、UTC 时间、必要备份和上一层 manifest。
 
 ### 部署 final sweep 与运行时回滚
 
@@ -158,13 +158,13 @@ manifest 始终拥有本轮 MD 和 config；仅拥有实际 isolated hooks 与�
 
 `--uninstall` 默认预览；`--uninstall --yes` 撤销最新一层 manifest-owned 状态：
 
-1. 所有目标目录先验证 manifest schema、MD/config、必要备份和上一层 manifest；
+1. 所有目标目录先验证 manifest schema、MD、config 顶层 `model_instructions_file` 所有权、必要备份和上一层 manifest；config 与 manifest after 字节相同时走原路径（mtime 单独变化不构成长期漂移）；字节漂移但目标字段不存在歧义或不支持结构且仍引用 `./<manifest md.path>` 时允许继续；内置零依赖扫描器不声称验证无关 TOML 值或跨表键冲突的完整语法；
 2. 只有 `hooks.isolated=true` 时才验证/恢复 active、disabled 和 hooks 备份；
 3. 只有 `legacy.action=archive` 时才验证/恢复 legacy 和归档；
 4. 任一目录有冲突时，全部目录在写入前停止；
 5. 在首次 mutation 前，为全部目录创建私有 `.codex-keysmith-transaction-<id>`、immutable intent、资源 before/after 定义和 before snapshots；
-6. 逐阶段恢复 config、MD 和实际受管理的 hooks/legacy，再把当前 manifest 归档到 journal 预先固定的精确路径并恢复上一层；
-7. 对全部参与目录的 post-state 执行 final sweep，持久化 `committed`，之后才以 cleanup claim/marker 可重入地删除 journal 和快照。
+6. 逐阶段恢复 config、MD 和实际受管理的 hooks/legacy，再把当前 manifest 归档到 journal 预先固定的精确路径并恢复上一层。对漂移的 config：`changed=true` 只从已验证备份恢复/移除部署前的目标语句并保留其他 live 内容；`changed=false` 不写 config；目标字段缺失、不同或 TOML 歧义则预检阻塞；
+7. 对全部参与目录的 post-state 执行 final sweep，持久化 `committed`，之后才以 cleanup claim/marker 可重入地删除 journal 和快照。合并 config 会产生新 mtime，因此 immutable intent 对它固定一个唯一 SHA-only after；journal 仍快照卸载开始时的完整 live config，反向恢复仍按完整 before snapshot 执行。其他资源的 after 验证不放宽。
 
 每次成功卸载只撤销一层。没有 manifest 是成功 no-op；v0.1.0 之前的无 manifest 状态不由工具猜测所有权。卸载硬中断留下的 durable journal、已登记 residue 或 cleanup marker 由 `--recover` 验证并恢复卸载前状态；用户并发漂移或证据篡改会 fail closed。
 
@@ -221,7 +221,7 @@ Only a real isolation is stored as managed hooks in the manifest. If no active h
 
 A referenced or recognized historical `gpt5.5-unrestricted.md` is atomically archived only for the default bundled deployment. Only this archive action is journaled and manifest-owned. Unreferenced custom legacy content remains unmanaged: its fingerprint is omitted and uninstall neither verifies nor modifies it.
 
-Markdown and config are prepared before isolation, file-`fsync`ed, fingerprinted, and published atomically. An unchanged config remains byte-identical but still participates in final verification. Manifest always owns this deployment's Markdown and config, plus actual hook isolation, actual legacy archive, required backups, and the previous manifest layer. Portable ownership uses size, `mtime_ns`, and SHA-256 rather than inode identity.
+Markdown and config are prepared before isolation, file-`fsync`ed, fingerprinted, and published atomically. An unchanged config remains byte-identical but still participates in deployment-time final verification. Long-lived config ownership is semantic ownership of the top-level `model_instructions_file`, not all file bytes; schema-1 before/after fingerprints remain valid operation-time CAS, rollback, journal, concurrency, and crash-recovery evidence. Manifest also owns this deployment's Markdown lifecycle, actual hook isolation, actual legacy archive, required backups, and the previous manifest layer.
 
 ### Deployment final sweep and runtime rollback
 
@@ -243,9 +243,9 @@ Deploy recovery processes participants in reverse order and resources as `manife
 
 ### Manifest-based uninstall
 
-Uninstall validates manifest, MD/config, required backups, and the previous manifest for every directory before writes. Hook paths are inspected only when `isolated=true`; legacy is inspected only for `action=archive`. Any blocker stops all directories.
+Uninstall validates manifest, Markdown, semantic top-level `model_instructions_file` ownership, required backups, and the previous manifest for every directory before writes. If live config bytes drift but the conservative scanner finds no target-field ambiguity or unsupported structure and the field still references `./<manifest md.path>`, unrelated rewrites are accepted. The zero-dependency scanner does not claim complete validation of unrelated TOML values or cross-table key conflicts. For `config.changed=true`, uninstall merges only the verified pre-deployment field statement into live content (or removes it if originally absent); for `changed=false`, it leaves config untouched. A missing/different target field, target-field ambiguity/unsupported structure, or abnormal node fails closed. Hook paths are inspected only when `isolated=true`; legacy is inspected only for `action=archive`. Any blocker stops all directories.
 
-Confirmed uninstall publishes an immutable multi-directory durable intent and private before-state snapshots before its first mutation. It then restores config/Markdown and only the actually managed hooks/legacy state, archives the current manifest at the exact journal-selected path, and restores the previous layer. It performs a complete final sweep across all participants, persists `committed`, and uses re-enterable cleanup before removing journal evidence. Each run removes one layer; absent manifest is a successful no-op, and pre-v0.1.0 unmanaged state is never guessed.
+Confirmed uninstall publishes an immutable multi-directory durable intent and private before-state snapshots before its first mutation. The journal snapshots the complete live config. A merged config after-state has one immutable SHA-only allowance because atomic publication creates a new mtime; other resources retain exact portable after-state rules. Config merge uses the existing atomic CAS write path, so a post-preflight race is rejected and reverse recovery restores the complete live-before snapshot. Uninstall then restores Markdown and only the actually managed hooks/legacy state, archives the current manifest at the exact journal-selected path, and restores the previous layer. It performs a complete final sweep across all participants, persists `committed`, and uses re-enterable cleanup before removing journal evidence. Each run removes one layer; absent manifest is a successful no-op, and pre-v0.1.0 unmanaged state is never guessed.
 
 A hard interruption during uninstall leaves a durable journal, registered residue, or cleanup marker that status blocks and preserves. `--recover` validates this evidence and restores the pre-uninstall state; concurrent user drift or tampered evidence fails closed.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -50,7 +50,7 @@ python3 codex-instruct.py --codex-dir ~/.codex --status --lang zh-CN
 | `<codex-dir>/.codex-keysmith-transaction-<id>/` | 保存 deploy/uninstall journal、固定名称 pending 文件、不可变 `intent.json` 和 before snapshots；deploy 另有 manifest companion，终态使用 `committed` / `recovered` 与可重入 cleanup marker 清理 |
 | `<codex-dir>/.keysmith-*` | 单步骤临时目录；正常完成后清理，异常残留会阻止后续写入 |
 
-受管理节点必须是普通文件。符号链接、悬空链接、目录、FIFO、socket、无效 UTF-8 或不安全 TOML 都会 fail closed。只有本次确实隔离的 hooks 和确实归档的 legacy 才进入 manifest 所有权；未隔离 hooks 与未受管理 legacy 不会被 uninstall 验证或改写。显式 `--skip-hooks-isolation` 时，hooks 节点完全排除在计划、manifest 和读写边界之外，但仍可能继续影响模型行为。
+受管理节点必须是普通文件。符号链接、悬空链接、目录、FIFO、socket 或无效 UTF-8 会 fail closed。config 的长期 manifest 所有权是语义化的顶层 `model_instructions_file`，不是整份 `config.toml`：只要当前值仍为 `./<manifest md.path>`，CCSwitch 等外部工具重写无关字段不会阻塞 status/uninstall；若本层部署曾修改该字段，卸载从已验证的整文件备份提取部署前语句并合并进当前 config（部署前无该语句则只删除当前语句），保留其他 live 内容；若本层 `config.changed=false`，卸载不写 config。目标字段缺失、指向其他路径、重复、歧义或扫描器不支持的语句结构仍会 fail closed。内置零依赖扫描器不声称完整验证无关 TOML 值语法或跨表键冲突。完整文件指纹继续用于预检读取、CAS、journal before snapshot、回滚、并发拒绝和崩溃恢复；合并后的 config 在 immutable uninstall intent 中固定唯一 SHA-256 after 状态。只有本次确实隔离的 hooks 和确实归档的 legacy 才进入 manifest 所有权；未隔离 hooks 与未受管理 legacy 不会被 uninstall 验证或改写。显式 `--skip-hooks-isolation` 时，hooks 节点完全排除在计划、manifest 和读写边界之外，但仍可能继续影响模型行为。
 
 ### 内部工作流程
 
@@ -132,7 +132,7 @@ python3 codex-instruct.py --codex-dir ~/.codex --uninstall --yes --lang zh-CN  #
 
 卸载仅处理 `.codex-keysmith-manifest.json` 明确拥有的最新一层：
 
-- 先验证当前 MD/config、实际隔离的 hooks、实际归档的 legacy、全部必要备份和 manifest 的 `size`、`mtime_ns`、SHA-256 与预期存在状态；
+- 先验证当前 MD、config 顶层 `model_instructions_file` 语义所有权、实际隔离的 hooks、实际归档的 legacy、全部必要备份和 manifest 的预期存在状态；config 字节仍匹配 manifest after 时沿用普通路径，只有 mtime 改变但字节相同也可继续；
 - 任一路径漂移、备份缺失、manifest 无效或节点异常时，所有目录都在写入前停止；
 - 首次修改前为全部参与目录发布 immutable durable intent、精确资源定义和 before snapshots；硬中断后由 `--recover` 反向恢复；
 - 恢复该层部署前的 config 与 MD；仅当 manifest 记录了真实隔离/归档时，才恢复 hooks、旧 disabled hooks 或 legacy；
@@ -301,7 +301,7 @@ python3 codex-instruct.py --codex-dir ~/.codex --status --lang en
 | `<codex-dir>/.codex-keysmith-transaction-<id>/` | Holds deploy/uninstall journals, fixed-name pending files, immutable `intent.json`, and before-state snapshots |
 | `<codex-dir>/.keysmith-*` | Per-step temporary directories; normal completion removes them, and residue blocks later writes |
 
-Managed targets must be regular files. Symlinks, dangling links, directories, FIFOs, sockets, invalid UTF-8, and unsafe TOML fail closed. With `--skip-hooks-isolation`, hook paths are completely outside planning, manifest ownership, and the read/write boundary, but active hooks can continue to affect model behavior.
+Managed targets must be regular files. Symlinks, dangling links, directories, FIFOs, sockets, and invalid UTF-8 fail closed. Long-lived config ownership is semantic ownership of the top-level `model_instructions_file`, not ownership of all `config.toml` bytes. CCSwitch-style rewrites of unrelated fields remain compatible while the field still equals `./<manifest md.path>`. If deployment changed that field, uninstall extracts the original statement from the verified full-file backup and merges only that statement into the live config (or removes it when originally absent), preserving all other live content; with `config.changed=false`, uninstall does not write config. Missing/different target references, duplicate or ambiguous target fields, unsupported statement structure, and abnormal nodes fail closed. The built-in zero-dependency scanner does not claim complete validation of unrelated TOML value syntax or cross-table key conflicts. Full-file fingerprints remain operation-time CAS, journal snapshot, rollback, concurrency, and crash-recovery evidence; a merged uninstall after-state is fixed by one SHA-256 in immutable intent. With `--skip-hooks-isolation`, hook paths are completely outside planning, manifest ownership, and the read/write boundary, but active hooks can continue to affect model behavior.
 
 ### Custom prompt and CLI language
 
@@ -337,7 +337,7 @@ python3 codex-instruct.py --codex-dir ~/.codex --uninstall --lang en        # pr
 python3 codex-instruct.py --codex-dir ~/.codex --uninstall --yes --lang en  # remove one layer
 ```
 
-Uninstall only touches the newest layer owned by `.codex-keysmith-manifest.json`. Drift, missing backups, invalid manifests, or abnormal nodes stop every selected directory before writes. An absent manifest is a successful no-op.
+Uninstall only touches the newest layer owned by `.codex-keysmith-manifest.json`. Unrelated live `config.toml` rewrites are preserved when the top-level `model_instructions_file` still references the manifest-owned Markdown. A missing/different target reference, target-field ambiguity or unsupported statement structure, managed-resource drift, missing backups, invalid manifests, or abnormal nodes stops every selected directory before writes. An absent manifest is a successful no-op.
 
 ### Upgrade and rollback
 

--- a/tests/fixtures/schema1-historical-field-restore.json
+++ b/tests/fixtures/schema1-historical-field-restore.json
@@ -1,0 +1,51 @@
+{
+  "config": {
+    "after": {
+      "mtime_ns": 1711111112000000000,
+      "sha256": "4b98f637327a7d3fc2eecc021a3a326d2449748bbca20bcef5e706f8db5b48c7",
+      "size": 75
+    },
+    "backup": "config.toml.bak_20260701_000000",
+    "before": {
+      "mtime_ns": 1711111111000000000,
+      "sha256": "a1f49de4fee2c302c1419c1c544968c10caca5f9dd9f60fb34b1ff3c07f6045c",
+      "size": 69
+    },
+    "changed": true,
+    "path": "config.toml"
+  },
+  "created_at": "2026-07-01T00:00:00Z",
+  "deployment_id": "0123456789abcdef0123456789abcdef",
+  "hooks": {
+    "active_after": null,
+    "active_before": null,
+    "backup": null,
+    "disabled_after": null,
+    "disabled_before": null,
+    "isolated": false,
+    "previous_disabled_backup": null
+  },
+  "legacy": {
+    "action": "none",
+    "after": null,
+    "archive": null,
+    "before": null,
+    "path": "gpt5.5-unrestricted.md"
+  },
+  "md": {
+    "after": {
+      "mtime_ns": 1711111113000000000,
+      "sha256": "16ac2d3ea498b4f15368a032aae682aca116146827b16376e11c40586d0a6dce",
+      "size": 34
+    },
+    "backup": null,
+    "before": null,
+    "path": "gpt-unrestricted.md"
+  },
+  "previous_manifest": {
+    "backup": null,
+    "before": null
+  },
+  "schema_version": 1,
+  "tool_version": "0.1.0"
+}

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -113,6 +113,7 @@ def test_repository_version_metadata_is_release_state_neutral():
     script = (REPO_ROOT / "codex-instruct.py").read_text(encoding="utf-8")
     changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    english_readme = (REPO_ROOT / "README.en.md").read_text(encoding="utf-8")
 
     assert version == VERSION
     assert '__version__ = "{}"'.format(VERSION) in script
@@ -120,19 +121,11 @@ def test_repository_version_metadata_is_release_state_neutral():
     assert "Source version v0.1.1" in readme
     assert "v0.1.1 local candidate" not in readme
     assert "This candidate has no tag" not in readme
-    chinese_candidate = readme.split("### v0.1.1 源码与候选构建", 1)[1].split(
-        "\n## English\n",
-        1,
-    )[0]
-    english_candidate = readme.split("### v0.1.1 source and candidate builds", 1)[1]
-    assert "codex-instruct-v0.1.0.py" in readme.split(
-        "### v0.1.1 源码与候选构建",
-        1,
-    )[0]
-    assert "codex-instruct-v0.1.0.py" not in chinese_candidate
-    assert "codex-instruct-v0.1.0.py" not in english_candidate
-    assert "python3 codex-instruct.py --codex-dir" in chinese_candidate
-    assert "python3 codex-instruct.py --codex-dir" in english_candidate
+    for quick_start in (readme, english_readme):
+        assert "codex-instruct-vX.Y.Z.py" in quick_start
+        assert "codex-instruct-v0.1.0.py" not in quick_start
+        assert "--codex-dir ~/.codex --status" in quick_start
+        assert "--codex-dir ~/.codex --dry-run" in quick_start
 
 
 def test_windows_fresh_deployment_policy_markers_are_complete_and_consistent():

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -11,6 +11,11 @@ from pathlib import Path
 import pytest
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "codex-instruct.py"
+FIXTURE_PATH = (
+    Path(__file__).resolve().parent
+    / "fixtures"
+    / "schema1-historical-field-restore.json"
+)
 spec = importlib.util.spec_from_file_location("codex_instruct_uninstall", MODULE_PATH)
 codex_instruct = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = codex_instruct
@@ -334,6 +339,315 @@ def test_uninstall_previews_then_restores_first_deployment(tmp_path):
     assert not (codex_dir / codex_instruct.MANIFEST_FILENAME).exists()
     assert list(codex_dir.glob(f"{codex_instruct.MANIFEST_FILENAME}.uninstalled_*"))
     assert list(codex_dir.glob("config.toml.bak_*"))
+
+
+def test_frozen_schema1_manifest_supports_external_rewrite_field_only_restore(
+    tmp_path,
+):
+    manifest = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    codex_dir = tmp_path / "historical-schema1"
+    codex_dir.mkdir()
+    original = (
+        'model_instructions_file = "./historical.md"\n'
+        'model = "pre-schema-one"\n'
+    )
+    deployed_config = (
+        'model_instructions_file = "./gpt-unrestricted.md"\n'
+        'model = "pre-schema-one"\n'
+    )
+    prompt = "frozen schema-1 historical prompt\n"
+    config = codex_dir / "config.toml"
+    backup = codex_dir / manifest["config"]["backup"]
+    md = codex_dir / manifest["md"]["path"]
+    config.write_text(deployed_config, encoding="utf-8")
+    backup.write_text(original, encoding="utf-8")
+    md.write_text(prompt, encoding="utf-8")
+    for path, expected in (
+        (config, manifest["config"]["after"]),
+        (backup, manifest["config"]["before"]),
+        (md, manifest["md"]["after"]),
+    ):
+        os.utime(path, ns=(expected["mtime_ns"], expected["mtime_ns"]))
+        assert codex_instruct._portable_matches(path, expected)
+    (codex_dir / codex_instruct.MANIFEST_FILENAME).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    external_rewrite = (
+        'model = "ccswitch-historical"\n'
+        'approval_policy = "never"\n'
+        'model_instructions_file = "./gpt-unrestricted.md" # external rewrite\n'
+    )
+    config.write_text(external_rewrite, encoding="utf-8")
+
+    result = _run(
+        "--codex-dir",
+        codex_dir,
+        "--uninstall",
+        "--yes",
+        "--lang",
+        "en",
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert re.search(r"[\u3400-\u9fff]", result.stdout + result.stderr) is None
+    assert config.read_text(encoding="utf-8") == (
+        'model = "ccswitch-historical"\n'
+        'approval_policy = "never"\n'
+        'model_instructions_file = "./historical.md"\n'
+    )
+    assert not md.exists()
+
+
+def test_ccswitch_rewrite_preserves_unrelated_config_and_restores_old_reference(
+    tmp_path,
+):
+    original = (
+        'model_instructions_file = "./previous.md"\n'
+        'model = "gpt-5.6"\n'
+    )
+    codex_dir = _make_codex_dir(tmp_path, config=original)
+    _deploy(codex_dir)
+    rewritten = (
+        'model = "ccswitch-model"\n'
+        'approval_policy = "never"\n'
+        'model_instructions_file = "./gpt-unrestricted.md" # kept by CCSwitch\n'
+    )
+    (codex_dir / "config.toml").write_text(rewritten, encoding="utf-8")
+
+    status = _run("--codex-dir", codex_dir, "--status")
+    result = _run("--codex-dir", codex_dir, "--uninstall", "--yes")
+
+    assert status.returncode == 0, status.stdout + status.stderr
+    assert "卸载就绪度: ready" in status.stdout
+    assert "可部署性: ready" in status.stdout
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (codex_dir / "config.toml").read_text(encoding="utf-8") == (
+        'model = "ccswitch-model"\n'
+        'approval_policy = "never"\n'
+        'model_instructions_file = "./previous.md"\n'
+    )
+    assert not (codex_dir / "gpt-unrestricted.md").exists()
+
+
+def test_stacked_manifests_keep_semantic_config_ownership_after_rewrite(tmp_path):
+    codex_dir = _make_codex_dir(
+        tmp_path,
+        config=(
+            'model_instructions_file = "./previous.md"\n'
+            'model = "before"\n'
+        ),
+    )
+    _deploy(codex_dir)
+    rewritten = (
+        'model = "ccswitch-model"\n'
+        'model_instructions_file = "./gpt-unrestricted.md"\n'
+        'external = true\n'
+    )
+    (codex_dir / "config.toml").write_text(rewritten, encoding="utf-8")
+
+    _deploy(codex_dir)
+    first_uninstall = _run("--codex-dir", codex_dir, "--uninstall", "--yes")
+    second_uninstall = _run("--codex-dir", codex_dir, "--uninstall", "--yes")
+
+    assert first_uninstall.returncode == 0, first_uninstall.stdout + first_uninstall.stderr
+    assert second_uninstall.returncode == 0, second_uninstall.stdout + second_uninstall.stderr
+    assert (codex_dir / "config.toml").read_text(encoding="utf-8") == (
+        'model = "ccswitch-model"\n'
+        'model_instructions_file = "./previous.md"\n'
+        'external = true\n'
+    )
+
+
+def test_ccswitch_rewrite_preserves_unrelated_config_when_old_reference_absent(
+    tmp_path,
+):
+    codex_dir = _make_codex_dir(tmp_path, config='model = "gpt-5.6"\n')
+    _deploy(codex_dir)
+    rewritten = (
+        'model = "ccswitch-model"\n'
+        'model_instructions_file = "./gpt-unrestricted.md"\n'
+        'sandbox_mode = "workspace-write"\n'
+    )
+    (codex_dir / "config.toml").write_text(rewritten, encoding="utf-8")
+
+    result = _run("--codex-dir", codex_dir, "--uninstall", "--yes")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (codex_dir / "config.toml").read_text(encoding="utf-8") == (
+        'model = "ccswitch-model"\n'
+        'sandbox_mode = "workspace-write"\n'
+    )
+
+
+def test_ccswitch_rewrite_of_unchanged_owned_reference_is_not_touched(tmp_path):
+    codex_dir = _make_codex_dir(
+        tmp_path,
+        config='model_instructions_file = "./gpt-unrestricted.md"\n',
+    )
+    _deploy(codex_dir)
+    manifest = json.loads(
+        (codex_dir / codex_instruct.MANIFEST_FILENAME).read_text(encoding="utf-8")
+    )
+    assert manifest["config"]["changed"] is False
+    rewritten = (
+        'model = "ccswitch-model"\n'
+        'model_instructions_file = "./gpt-unrestricted.md"\n'
+        'notice = "external"\n'
+    )
+    (codex_dir / "config.toml").write_text(rewritten, encoding="utf-8")
+
+    status = _run("--codex-dir", codex_dir, "--status")
+    result = _run("--codex-dir", codex_dir, "--uninstall", "--yes")
+
+    assert status.returncode == 0, status.stdout + status.stderr
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (codex_dir / "config.toml").read_text(encoding="utf-8") == rewritten
+    assert not (codex_dir / "gpt-unrestricted.md").exists()
+
+
+def test_exact_manifest_config_with_missing_owned_reference_still_blocks(tmp_path):
+    codex_dir = _make_codex_dir(tmp_path)
+    _deploy(codex_dir)
+    config = codex_dir / "config.toml"
+    manifest_path = codex_dir / codex_instruct.MANIFEST_FILENAME
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    missing_reference = 'model = "externally-published"\n'
+    config.write_text(missing_reference, encoding="utf-8")
+    fingerprint = codex_instruct._fingerprint_regular_file(config)
+    manifest["config"]["after"] = codex_instruct._portable_fingerprint(fingerprint)
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    result = _run("--codex-dir", codex_dir, "--uninstall", "--yes")
+
+    assert result.returncode == 1
+    assert "model_instructions_file" in result.stdout
+    assert config.read_text(encoding="utf-8") == missing_reference
+    assert (codex_dir / "gpt-unrestricted.md").exists()
+
+
+def test_english_uninstall_target_field_error_has_no_chinese(tmp_path):
+    codex_dir = _make_codex_dir(tmp_path)
+    _deploy(codex_dir)
+    (codex_dir / "config.toml").write_text(
+        'model_instructions_file = "./gpt-unrestricted.md"\ninvalid toml\n',
+        encoding="utf-8",
+    )
+
+    result = _run(
+        "--codex-dir",
+        codex_dir,
+        "--uninstall",
+        "--yes",
+        "--lang",
+        "en",
+    )
+
+    assert result.returncode == 1
+    assert "config.toml drifted and has target-field ambiguity" in result.stdout
+    assert re.search(r"[\u3400-\u9fff]", result.stdout + result.stderr) is None
+
+
+def test_uninstall_accepts_same_config_bytes_with_changed_mtime(tmp_path):
+    codex_dir = _make_codex_dir(tmp_path)
+    _deploy(codex_dir)
+    config = codex_dir / "config.toml"
+    deployed_bytes = config.read_bytes()
+    current_mtime = config.stat().st_mtime_ns
+    os.utime(config, ns=(config.stat().st_atime_ns, current_mtime + 10_000_000))
+    assert config.read_bytes() == deployed_bytes
+
+    result = _run("--codex-dir", codex_dir, "--uninstall", "--yes")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert config.read_text(encoding="utf-8") == 'model = "gpt-5.6"\n'
+
+
+@pytest.mark.parametrize(
+    "current_config",
+    [
+        'model = "ccswitch-model"\n',
+        'model_instructions_file = "./other.md"\nmodel = "ccswitch-model"\n',
+    ],
+)
+def test_config_target_reference_drift_is_field_specific_blocker(
+    tmp_path,
+    current_config,
+):
+    codex_dir = _make_codex_dir(tmp_path)
+    _deploy(codex_dir)
+    (codex_dir / "config.toml").write_text(current_config, encoding="utf-8")
+    before = _snapshot_files(codex_dir)
+
+    status = _run("--codex-dir", codex_dir, "--status")
+    result = _run("--codex-dir", codex_dir, "--uninstall", "--yes")
+
+    assert status.returncode == 1
+    assert result.returncode == 1
+    assert "model_instructions_file" in status.stdout
+    assert "model_instructions_file" in result.stdout
+    assert _snapshot_files(codex_dir) == before
+
+
+@pytest.mark.parametrize(
+    "current_config",
+    [
+        'model_instructions_file = "./gpt-unrestricted.md"\ninvalid toml\n',
+        (
+            'model_instructions_file = "./gpt-unrestricted.md"\n'
+            '"model_instructions_file" = "./gpt-unrestricted.md"\n'
+        ),
+    ],
+)
+def test_invalid_or_ambiguous_drifted_config_blocks_uninstall(
+    tmp_path,
+    current_config,
+):
+    codex_dir = _make_codex_dir(tmp_path)
+    _deploy(codex_dir)
+    (codex_dir / "config.toml").write_text(current_config, encoding="utf-8")
+    before = _snapshot_files(codex_dir)
+
+    result = _run("--codex-dir", codex_dir, "--uninstall", "--yes")
+
+    assert result.returncode == 1
+    assert "config.toml" in result.stdout
+    assert _snapshot_files(codex_dir) == before
+
+
+def test_config_merge_cas_rejects_race_without_overwriting_external_content(
+    tmp_path,
+    monkeypatch,
+):
+    codex_dir = _make_codex_dir(tmp_path)
+    _deploy(codex_dir)
+    config = codex_dir / "config.toml"
+    config.write_text(
+        'model = "ccswitch-model"\n'
+        'model_instructions_file = "./gpt-unrestricted.md"\n',
+        encoding="utf-8",
+    )
+    external = (
+        'model = "concurrent-model"\n'
+        'model_instructions_file = "./gpt-unrestricted.md"\n'
+        'concurrent = true\n'
+    )
+    real_atomic_write = codex_instruct.atomic_write_text
+
+    def race_before_merge(path, content, **kwargs):
+        if Path(path) == config:
+            config.write_text(external, encoding="utf-8")
+        return real_atomic_write(path, content, **kwargs)
+
+    monkeypatch.setattr(codex_instruct, "atomic_write_text", race_before_merge)
+
+    with pytest.raises(SystemExit) as caught:
+        codex_instruct.uninstall([str(codex_dir)], yes=True)
+
+    assert caught.value.code == 1
+    assert config.read_text(encoding="utf-8") == external
+    assert (codex_dir / "gpt-unrestricted.md").exists()
+    assert (codex_dir / codex_instruct.MANIFEST_FILENAME).exists()
 
 
 def test_uninstall_restores_hooks_existing_disabled_and_legacy(tmp_path):

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -359,9 +359,9 @@ def test_frozen_schema1_manifest_supports_external_rewrite_field_only_restore(
     config = codex_dir / "config.toml"
     backup = codex_dir / manifest["config"]["backup"]
     md = codex_dir / manifest["md"]["path"]
-    config.write_text(deployed_config, encoding="utf-8")
-    backup.write_text(original, encoding="utf-8")
-    md.write_text(prompt, encoding="utf-8")
+    config.write_bytes(deployed_config.encode("utf-8"))
+    backup.write_bytes(original.encode("utf-8"))
+    md.write_bytes(prompt.encode("utf-8"))
     for path, expected in (
         (config, manifest["config"]["after"]),
         (backup, manifest["config"]["before"]),

--- a/tests/test_uninstall_recovery.py
+++ b/tests/test_uninstall_recovery.py
@@ -641,6 +641,14 @@ def test_uninstall_initializing_recovery_fails_closed_on_live_drift(tmp_path):
         "first-journal",
     )
     assert interrupted.returncode == HARD_EXIT, interrupted.stdout + interrupted.stderr
+    if os.name == "nt":
+        # TerminateProcess can run after ReplaceFileW publishes journal.json but
+        # before the parent directory flush. Some Windows filesystems may lose
+        # that newest directory entry; this generic fail-closed case cannot
+        # require evidence that the platform did not persist. The dedicated
+        # Windows lifecycle suite covers durable recovery checkpoints.
+        if not any(_journal_dirs(path) for path in (first, second)):
+            pytest.skip("Windows did not persist the interrupted journal entry")
     user_bytes = b'user-owned config drift\nmodel = "custom"\n'
     config = second / "config.toml"
     config.write_bytes(user_bytes)

--- a/tests/test_uninstall_recovery.py
+++ b/tests/test_uninstall_recovery.py
@@ -1540,6 +1540,184 @@ def test_uninstall_recovery_rejects_tampered_evidence_without_mutation(
     assert journal_dir.exists()
 
 
+def test_recovery_after_merged_config_publication_restores_live_rewrite(tmp_path):
+    codex_dir = tmp_path / "merged-config-recovery"
+    codex_dir.mkdir()
+    (codex_dir / "config.toml").write_text('model = "before"\n', encoding="utf-8")
+    deployed = _run("--codex-dir", codex_dir, "--yes")
+    assert deployed.returncode == 0, deployed.stdout + deployed.stderr
+    live_rewrite = (
+        'model = "ccswitch-model"\n'
+        'model_instructions_file = "./gpt-unrestricted.md"\n'
+        'external = true\n'
+    )
+    (codex_dir / "config.toml").write_text(live_rewrite, encoding="utf-8")
+
+    source = f"""
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH)!r})
+m = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = m
+spec.loader.exec_module(m)
+real = m.atomic_write_text
+
+def stop_after_config(path, *args, **kwargs):
+    result = real(path, *args, **kwargs)
+    if Path(path).name == "config.toml":
+        os._exit({HARD_EXIT})
+    return result
+
+m.atomic_write_text = stop_after_config
+m.uninstall([{str(codex_dir)!r}], True)
+"""
+    interrupted = _write_child(tmp_path, "interrupt-merged-config.py", source)
+
+    assert interrupted.returncode == HARD_EXIT, interrupted.stdout + interrupted.stderr
+    journal_dir = _single_journal(codex_dir)
+    journal = json.loads(
+        (journal_dir / codex_instruct.JOURNAL_FILENAME).read_text(encoding="utf-8")
+    )
+    owner = journal["owner_directory"]
+    config_resource = journal["directories"][owner]["resources"]["config"]
+    assert len(config_resource["allowed_sha256"]) == 1
+    assert config_resource["allowed_portable"] == []
+    assert (
+        codex_dir / "config.toml"
+    ).read_text(encoding="utf-8") == (
+        'model = "ccswitch-model"\nexternal = true\n'
+    )
+
+    recovered = _run("--codex-dir", codex_dir, "--recover", "--yes")
+
+    assert recovered.returncode == 0, recovered.stdout + recovered.stderr
+    assert (codex_dir / "config.toml").read_text(encoding="utf-8") == live_rewrite
+    assert (codex_dir / "gpt-unrestricted.md").exists()
+    assert (codex_dir / codex_instruct.MANIFEST_FILENAME).exists()
+    _assert_no_transaction_artifacts(codex_dir)
+
+
+def test_merged_config_write_residue_cleanup_failure_rolls_back_and_keeps_evidence(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    codex_dir = tmp_path / "merged-config-cleanup-failure"
+    codex_dir.mkdir()
+    (codex_dir / "config.toml").write_text('model = "before"\n', encoding="utf-8")
+    deployed = _run("--codex-dir", codex_dir, "--yes")
+    assert deployed.returncode == 0, deployed.stdout + deployed.stderr
+    live_rewrite = (
+        'model = "ccswitch-model"\n'
+        'model_instructions_file = "./gpt-unrestricted.md"\n'
+        'external = true\n'
+    )
+    (codex_dir / "config.toml").write_text(live_rewrite, encoding="utf-8")
+    real_strict_cleanup = codex_instruct._strict_cleanup_transaction_dir
+    cleanup_calls = 0
+    injected = False
+
+    def fail_write_residue_cleanup(transaction_dir):
+        nonlocal cleanup_calls, injected
+        if Path(transaction_dir).name.startswith(".keysmith-write-"):
+            cleanup_calls += 1
+            if cleanup_calls == 1:
+                injected = True
+                raise codex_instruct.TransactionResidueCleanupFailure(
+                    "injected write-residue cleanup failure",
+                    Path(transaction_dir),
+                )
+        return real_strict_cleanup(transaction_dir)
+
+    monkeypatch.setattr(
+        codex_instruct,
+        "_strict_cleanup_transaction_dir",
+        fail_write_residue_cleanup,
+    )
+    monkeypatch.setattr(codex_instruct, "_OUTPUT_LANGUAGE", "en")
+    with pytest.raises(SystemExit) as caught:
+        codex_instruct.uninstall([str(codex_dir)], yes=True)
+
+    assert caught.value.code == 1
+    assert injected is True
+    assert (codex_dir / "config.toml").read_text(encoding="utf-8") == live_rewrite
+    assert (codex_dir / "gpt-unrestricted.md").exists()
+    assert (codex_dir / codex_instruct.MANIFEST_FILENAME).exists()
+    journal_dir = _single_journal(codex_dir)
+    journal = json.loads(
+        (journal_dir / codex_instruct.JOURNAL_FILENAME).read_text(encoding="utf-8")
+    )
+    assert journal["phase"] == "recovered"
+    assert journal_dir.exists()
+    output = capsys.readouterr().out
+    assert "Run --recover to finish cleanup" in output
+    _assert_no_cjk(output)
+
+    monkeypatch.setattr(
+        codex_instruct,
+        "_strict_cleanup_transaction_dir",
+        real_strict_cleanup,
+    )
+    recovered = _run("--codex-dir", codex_dir, "--recover", "--yes")
+
+    assert recovered.returncode == 0, recovered.stdout + recovered.stderr
+    assert (codex_dir / "config.toml").read_text(encoding="utf-8") == live_rewrite
+    assert (codex_dir / "gpt-unrestricted.md").exists()
+    assert (codex_dir / codex_instruct.MANIFEST_FILENAME).exists()
+    _assert_no_transaction_artifacts(codex_dir)
+
+
+def test_merged_config_write_residue_is_pre_authorized_by_immutable_intent(
+    tmp_path,
+    monkeypatch,
+):
+    codex_dir = tmp_path / "merged-config-residue"
+    codex_dir.mkdir()
+    (codex_dir / "config.toml").write_text('model = "before"\n', encoding="utf-8")
+    deployed = _run("--codex-dir", codex_dir, "--yes")
+    assert deployed.returncode == 0, deployed.stdout + deployed.stderr
+    (codex_dir / "config.toml").write_text(
+        'model = "ccswitch-model"\n'
+        'model_instructions_file = "./gpt-unrestricted.md"\n',
+        encoding="utf-8",
+    )
+    real_make_registered = codex_instruct._make_registered_transaction_dir
+    checked = False
+
+    def verify_intent_before_write(parent, kind, allowed_members):
+        nonlocal checked
+        if kind == "write-prepared":
+            states = codex_instruct._ACTIVE_DEPLOYMENT_STATES
+            assert states is not None
+            data = states[0].journal_data
+            owner = str(Path(parent).resolve())
+            resource = data["directories"][owner]["resources"]["config"]
+            assert len(resource["allowed_sha256"]) == 1
+            intent = json.loads(
+                (states[0].journal_dir / codex_instruct.INTENT_FILENAME).read_text(
+                    encoding="utf-8"
+                )
+            )
+            assert intent["directories"][owner]["resources"]["config"][
+                "allowed_sha256"
+            ] == resource["allowed_sha256"]
+            checked = True
+        return real_make_registered(parent, kind, allowed_members)
+
+    monkeypatch.setattr(
+        codex_instruct,
+        "_make_registered_transaction_dir",
+        verify_intent_before_write,
+    )
+
+    codex_instruct.uninstall([str(codex_dir)], yes=True)
+
+    assert checked is True
+
+
 def test_committed_uninstall_cleanup_is_previewable_and_reentrant(tmp_path):
     first = _make_rich_deployment(tmp_path, "committed-cleanup-first")
     second = _make_rich_deployment(tmp_path, "committed-cleanup-second")
@@ -1583,6 +1761,190 @@ m.uninstall([{str(first)!r}, {str(second)!r}], True)
         )
         assert (codex_dir / codex_instruct.LEGACY_MD_FILENAME).read_bytes() == (
             b"legacy prompt\n"
+        )
+        _assert_no_transaction_artifacts(codex_dir)
+
+
+@pytest.mark.parametrize("damage", ["tamper", "delete"])
+def test_terminal_recovered_cleanup_revalidates_restored_manifest_backups(
+    tmp_path,
+    damage,
+):
+    codex_dir = tmp_path / f"recovered-manifest-backup-{damage}"
+    codex_dir.mkdir()
+    (codex_dir / "config.toml").write_text('model = "before"\n', encoding="utf-8")
+    first = _run("--codex-dir", codex_dir, "--yes")
+    assert first.returncode == 0, first.stdout + first.stderr
+    (codex_dir / "config.toml").write_text(
+        'model_instructions_file = "./gpt-unrestricted.md"\n'
+        'model = "changed-before-second-layer"\n',
+        encoding="utf-8",
+    )
+    second = _run("--codex-dir", codex_dir, "--yes")
+    assert second.returncode == 0, second.stdout + second.stderr
+    current_manifest = json.loads(
+        (codex_dir / codex_instruct.MANIFEST_FILENAME).read_text(encoding="utf-8")
+    )
+    restored_manifest_backup = codex_dir / current_manifest["previous_manifest"]["backup"]
+    assert restored_manifest_backup.is_file()
+
+    source = f"""
+import importlib.util
+import os
+import sys
+
+spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH)!r})
+m = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = m
+spec.loader.exec_module(m)
+real_update = m._update_deployment_journals
+real_execute = m._execute_uninstall_state
+
+
+def fail_after_first_mutation(state, timestamp):
+    real_execute(state, timestamp)
+    raise OSError("force reverse recovery")
+
+
+def stop_after_recovered(states, phase):
+    result = real_update(states, phase)
+    if phase == "recovered":
+        os._exit({HARD_EXIT})
+    return result
+
+m._execute_uninstall_state = fail_after_first_mutation
+m._update_deployment_journals = stop_after_recovered
+m.uninstall([{str(codex_dir)!r}], True)
+"""
+    interrupted = _write_child(
+        tmp_path,
+        f"interrupt-recovered-manifest-backup-{damage}.py",
+        source,
+    )
+
+    assert interrupted.returncode == HARD_EXIT
+    journal_dir = _single_journal(codex_dir)
+    journal = json.loads(
+        (journal_dir / codex_instruct.JOURNAL_FILENAME).read_text(encoding="utf-8")
+    )
+    assert journal["phase"] == "recovered"
+    assert (codex_dir / codex_instruct.MANIFEST_FILENAME).is_file()
+    restored_current_manifest = json.loads(
+        (codex_dir / codex_instruct.MANIFEST_FILENAME).read_text(encoding="utf-8")
+    )
+    assert restored_current_manifest["deployment_id"] == current_manifest["deployment_id"]
+    required_backup = codex_dir / restored_current_manifest["previous_manifest"]["backup"]
+    assert required_backup == restored_manifest_backup
+    if damage == "tamper":
+        required_backup.write_bytes(b"tampered historical backup\n")
+    else:
+        required_backup.unlink()
+    evidence = _snapshot_tree(codex_dir)
+
+    recovered = _run("--codex-dir", codex_dir, "--recover", "--yes")
+
+    assert recovered.returncode == 1
+    _assert_no_cjk(recovered.stdout + recovered.stderr)
+    assert _snapshot_tree(codex_dir) == evidence
+    assert journal_dir.exists()
+
+
+def test_committed_terminal_cleanup_revalidates_restored_manifest_backups(tmp_path):
+    first = tmp_path / "committed-manifest-backup-first"
+    second = tmp_path / "committed-manifest-backup-second"
+    for codex_dir in (first, second):
+        codex_dir.mkdir()
+        (codex_dir / "config.toml").write_text('model = "before"\n', encoding="utf-8")
+        first_layer = _run("--codex-dir", codex_dir, "--yes")
+        second_layer = _run("--codex-dir", codex_dir, "--yes")
+        assert first_layer.returncode == 0, first_layer.stdout + first_layer.stderr
+        assert second_layer.returncode == 0, second_layer.stdout + second_layer.stderr
+    source = f"""
+import importlib.util
+import os
+import sys
+
+spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH)!r})
+m = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = m
+spec.loader.exec_module(m)
+{_filesystem_exit_hook_source("journal-directory-removed")}
+m.uninstall([{str(first)!r}, {str(second)!r}], True)
+"""
+    interrupted = _write_child(tmp_path, "interrupt-committed-manifest-backup.py", source)
+
+    assert interrupted.returncode == HARD_EXIT, interrupted.stdout + interrupted.stderr
+    remaining = first if _journal_dirs(first) else second
+    journal_dir = _single_journal(remaining)
+    journal = json.loads(
+        (journal_dir / codex_instruct.JOURNAL_FILENAME).read_text(encoding="utf-8")
+    )
+    assert journal["phase"] == "committed"
+    restored_manifest = json.loads(
+        (remaining / codex_instruct.MANIFEST_FILENAME).read_text(encoding="utf-8")
+    )
+    required_backup = remaining / restored_manifest["config"]["backup"]
+    required_backup.write_bytes(b"tampered historical backup\n")
+    evidence = _snapshot_tree(remaining)
+
+    recovered = _run("--codex-dir", remaining, "--recover", "--yes")
+
+    assert recovered.returncode == 1
+    _assert_no_cjk(recovered.stdout + recovered.stderr)
+    assert _snapshot_tree(remaining) == evidence
+    assert journal_dir.exists()
+
+
+def test_committed_merged_config_cleanup_validates_sha_only_after(tmp_path):
+    first = tmp_path / "committed-merged-first"
+    second = tmp_path / "committed-merged-second"
+    for codex_dir in (first, second):
+        codex_dir.mkdir()
+        (codex_dir / "config.toml").write_text(
+            'model = "before"\n',
+            encoding="utf-8",
+        )
+        deployed = _run("--codex-dir", codex_dir, "--yes")
+        assert deployed.returncode == 0, deployed.stdout + deployed.stderr
+        (codex_dir / "config.toml").write_text(
+            'model = "ccswitch-model"\n'
+            'model_instructions_file = "./gpt-unrestricted.md"\n'
+            'external = true\n',
+            encoding="utf-8",
+        )
+    source = f"""
+import importlib.util
+import os
+import sys
+
+spec = importlib.util.spec_from_file_location("child_keysmith", {str(MODULE_PATH)!r})
+m = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = m
+spec.loader.exec_module(m)
+{_filesystem_exit_hook_source("journal-directory-removed")}
+m.uninstall([{str(first)!r}, {str(second)!r}], True)
+"""
+    interrupted = _write_child(tmp_path, "interrupt-committed-merged.py", source)
+
+    assert interrupted.returncode == HARD_EXIT, interrupted.stdout + interrupted.stderr
+    remaining = first if _journal_dirs(first) else second
+    journal = json.loads(
+        (
+            _single_journal(remaining) / codex_instruct.JOURNAL_FILENAME
+        ).read_text(encoding="utf-8")
+    )
+    assert journal["phase"] == "committed"
+    for directory in journal["participants"]:
+        resource = journal["directories"][directory]["resources"]["config"]
+        assert len(resource["allowed_sha256"]) == 1
+        assert resource["allowed_portable"] == []
+
+    recovered = _run("--codex-dir", remaining, "--recover", "--yes")
+
+    assert recovered.returncode == 0, recovered.stdout + recovered.stderr
+    for codex_dir in (first, second):
+        assert (codex_dir / "config.toml").read_text(encoding="utf-8") == (
+            'model = "ccswitch-model"\nexternal = true\n'
         )
         _assert_no_transaction_artifacts(codex_dir)
 
@@ -1740,6 +2102,34 @@ def test_uninstall_resource_invariants_reject_ambiguous_recovery_state(
 
     with pytest.raises(ValueError):
         codex_instruct._validate_uninstall_journal_resources(resources, owner)
+
+
+def test_uninstall_loader_rejects_residue_outside_immutable_resource_states(
+    tmp_path,
+):
+    codex_dir = _make_rich_deployment(tmp_path, "unauthorized-residue")
+    interrupted = _interrupt_uninstall(tmp_path, [codex_dir], "md-claim")
+    assert interrupted.returncode == HARD_EXIT, interrupted.stdout + interrupted.stderr
+    journal_dir = _single_journal(codex_dir)
+    journal_path = journal_dir / codex_instruct.JOURNAL_FILENAME
+    data = json.loads(journal_path.read_text(encoding="utf-8"))
+    owner = data["owner_directory"]
+    residue = data["directories"][owner]["residues"][0]
+    member = next(iter(residue["members"]))
+    residue["members"][member] = {
+        "size": 7,
+        "mtime_ns": 1,
+        "sha256": "0" * 64,
+    }
+    residue["auth"] = codex_instruct._residue_authorization_digest(
+        data["transaction_id"],
+        owner,
+        residue,
+    )
+    journal_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="residue 成员不属于受管资源"):
+        codex_instruct._load_uninstall_journal(journal_dir)
 
 
 @pytest.mark.parametrize("damage", ["invalid-json", "invalid-operation"])


### PR DESCRIPTION
## Summary

- narrow long-lived `config.toml` ownership to the top-level `model_instructions_file`
- preserve unrelated CCSwitch/external rewrites during status and uninstall
- restore or remove only the pre-deployment instruction statement
- retain full-file CAS, durable snapshots, rollback, concurrency checks, and crash recovery
- keep schema-1 manifests from v0.1.0/v0.1.1 compatible

## Safety behavior

Uninstall still fails closed when `model_instructions_file` is missing, points elsewhere, is ambiguous, or uses an unsupported statement structure. Ownership of Markdown, hooks, legacy archives, manifests, and backups is unchanged.

## Verification

- `python3 -m py_compile codex-instruct.py`
- `python3 -m ruff check .`
- `git diff --check`
- `python3 -m pytest -q` — 509 passed, 22 Windows-only tests skipped on macOS
- manual CCSwitch-style deploy/status/uninstall lifecycle

Fixes #6
