### PR TITLE
ci: publish unified v0.2.0 desktop beta

### DIFF
--- a/.github/workflows/desktop-candidate.yml
+++ b/.github/workflows/desktop-candidate.yml
@@ -11,8 +11,8 @@ on:
         description: Full main commit SHA expected for build and publication.
         required: false
         type: string
-      publish_windows_prerelease:
-        description: Publish the unsigned Windows x64 candidate as a public prerelease.
+      publish_desktop_prerelease:
+        description: Publish the unsigned macOS ARM64 and Windows x64 desktop candidates.
         required: false
         default: false
         type: boolean
@@ -20,13 +20,25 @@ on:
     paths:
       - ".github/workflows/desktop-candidate.yml"
       - "VERSION"
+      - "CHANGELOG.md"
+      - "CONTRIBUTING.md"
+      - "LICENSE"
+      - "README.md"
+      - "README.en.md"
+      - "SECURITY.md"
       - "codex-instruct.py"
       - "examples/**"
       - "gui/**"
       - "requirements-quality.txt"
       - "CODE_SIGNING_POLICY.md"
       - "PRIVACY.md"
+      - "docs/agent-install.md"
+      - "docs/assets/readme/**"
+      - "docs/hooks-transactions.md"
+      - "docs/reference.md"
       - "docs/releases/desktop-v0.2.0-beta.*.md"
+      - "docs/releases/v0.2.0.md"
+      - "scripts/build_release.py"
       - "scripts/package_desktop_prerelease.py"
       - "scripts/validate_desktop_candidate.py"
       - "tests/**"
@@ -359,12 +371,12 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-  publish-windows-prerelease:
-    name: Publish unsigned Windows x64 prerelease
+  publish-desktop-prerelease:
+    name: Publish unsigned desktop prerelease
     if: >-
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main' &&
-      inputs.publish_windows_prerelease == true
+      inputs.publish_desktop_prerelease == true
     needs:
       - candidate
     runs-on: ubuntu-24.04
@@ -384,6 +396,12 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Download this run's macOS candidate
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: codex-keysmith-desktop-macos-arm64-${{ github.sha }}
+          path: ${{ runner.temp }}/macos-candidate
 
       - name: Download this run's Windows candidate
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
@@ -464,15 +482,41 @@ jobs:
           git cat-file blob "${EXPECTED_COMMIT}:${notes}" > "$notes_blob"
           cmp "$notes" "$notes_blob"
           python scripts/validate_desktop_candidate.py verify-manifest-data \
+            "$RUNNER_TEMP/macos-candidate/build-manifest.json"
+          python scripts/validate_desktop_candidate.py verify-manifest-data \
             "$RUNNER_TEMP/windows-candidate/build-manifest.json"
+          source_first="${RUNNER_TEMP}/desktop-source-first"
+          source_second="${RUNNER_TEMP}/desktop-source-second"
+          source_tag="v$(tr -d '\r\n' < VERSION)"
+          python scripts/build_release.py "$source_tag" \
+            --output-dir "$source_first" \
+            --source-commit "$EXPECTED_COMMIT"
+          python scripts/build_release.py "$source_tag" \
+            --output-dir "$source_second" \
+            --source-commit "$EXPECTED_COMMIT"
+          diff -u "$source_first/SHA256SUMS" "$source_second/SHA256SUMS"
+          while read -r checksum asset; do
+            test -n "$checksum"
+            cmp "$source_first/$asset" "$source_second/$asset"
+          done < "$source_first/SHA256SUMS"
+          (cd "$source_first" && sha256sum --check SHA256SUMS)
+          version_output="$(python "$source_first/codex-instruct-${source_tag}.py" --version)"
+          expected_version_output="codex-instruct-${source_tag}.py $(tr -d '\r\n' < VERSION)"
+          if [ "$version_output" != "$expected_version_output" ]; then
+            echo "Standalone script reported an unexpected version: ${version_output}" >&2
+            exit 1
+          fi
           python scripts/package_desktop_prerelease.py assemble \
-            --candidate-dir "$RUNNER_TEMP/windows-candidate" \
-            --output-dir "$RUNNER_TEMP/windows-prerelease" \
+            --macos-candidate-dir "$RUNNER_TEMP/macos-candidate" \
+            --windows-candidate-dir "$RUNNER_TEMP/windows-candidate" \
+            --source-dir "$source_first" \
+            --output-dir "$RUNNER_TEMP/desktop-prerelease" \
             --release-tag "$RELEASE_TAG" \
             --expected-commit "$EXPECTED_COMMIT"
           python scripts/package_desktop_prerelease.py verify \
-            "$RUNNER_TEMP/windows-prerelease" \
-            --expected-commit "$EXPECTED_COMMIT"
+            "$RUNNER_TEMP/desktop-prerelease" \
+            --expected-commit "$EXPECTED_COMMIT" \
+            --source-dir "$source_first"
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
           {
             printf 'tag=%s\n' "$RELEASE_TAG"
@@ -489,7 +533,7 @@ jobs:
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
-          release_dir="${RUNNER_TEMP}/windows-prerelease"
+          release_dir="${RUNNER_TEMP}/desktop-prerelease"
           tag="${{ steps.source.outputs.tag }}"
           expected_commit="${{ steps.source.outputs.commit }}"
           expected_tag_object="${{ steps.source.outputs.tag_object }}"
@@ -498,6 +542,10 @@ jobs:
           release_id=""
           release_api=""
           release_created=false
+          create_attempted=false
+          create_started_at=""
+          draft_name=""
+          release_author="github-actions[bot]"
 
           verify_remote_main() {
             remote_main="$(
@@ -528,6 +576,77 @@ jobs:
               return 1
             fi
           }
+          get_latest_release_tag() {
+            local repo_owner="${GITHUB_REPOSITORY%%/*}"
+            local repo_name="${GITHUB_REPOSITORY#*/}"
+            gh api graphql \
+              -f query="query(\$owner:String!,\$name:String!){repository(owner:\$owner,name:\$name){latestRelease{tagName}}}" \
+              -F owner="$repo_owner" \
+              -F name="$repo_name" \
+              --jq '.data.repository.latestRelease.tagName // "__NO_LATEST_RELEASE__"'
+          }
+          owned_draft_validator="${RUNNER_TEMP}/validate-owned-desktop-draft.py"
+          cat > "$owned_draft_validator" <<'PY'
+          import json
+          from pathlib import Path
+          import sys
+
+          source_path, output_path, notes_path, tag, commit, started_at, actor, draft_name = sys.argv[1:]
+          raw = json.loads(Path(source_path).read_text(encoding="utf-8"))
+          if isinstance(raw, dict):
+              releases = [raw]
+          elif isinstance(raw, list):
+              releases = []
+              for item in raw:
+                  if isinstance(item, dict):
+                      releases.append(item)
+                  elif isinstance(item, list) and all(isinstance(value, dict) for value in item):
+                      releases.extend(item)
+                  else:
+                      raise SystemExit("release recovery response has an unexpected shape")
+          else:
+              raise SystemExit("release recovery response has an unexpected shape")
+          expected_body = Path(notes_path).read_text(encoding="utf-8")
+          matches = [
+              release
+              for release in releases
+              if isinstance(release.get("id"), int)
+              and release.get("tag_name") == tag
+              and release.get("target_commitish") == commit
+              and release.get("name") == draft_name
+              and release.get("body") == expected_body
+              and release.get("draft") is True
+              and release.get("prerelease") is True
+              and release.get("assets") == []
+              and release.get("created_at", "") >= started_at
+              and release.get("author", {}).get("login") == actor
+          ]
+          if len(matches) != 1:
+              raise SystemExit(
+                  "expected exactly one owned empty draft after lost create response, got {}".format(
+                      len(matches)
+                  )
+              )
+          Path(output_path).write_text(
+              json.dumps(matches[0], ensure_ascii=False, separators=(",", ":")),
+              encoding="utf-8",
+          )
+          PY
+          recover_owned_empty_draft() {
+            local output_path="$1"
+            local recovery_state="${RUNNER_TEMP}/desktop-prerelease-create-recovery.json"
+            for _attempt in {1..5}; do
+              if gh api --paginate --slurp \
+                "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > "$recovery_state" \
+                && python "$owned_draft_validator" \
+                  "$recovery_state" "$output_path" "$notes_blob" "$tag" \
+                  "$expected_commit" "$create_started_at" "$release_author" "$draft_name"; then
+                return 0
+              fi
+              sleep "$_attempt"
+            done
+            return 1
+          }
           cleanup_failed_draft() {
             primary_status=$?
             trap - EXIT
@@ -545,6 +664,29 @@ jobs:
               else
                 echo "::warning::Owned Release ${release_id} is not a draft; cleanup skipped."
               fi
+            elif [ "$primary_status" -ne 0 ] && [ "$create_attempted" = true ]; then
+              set +e
+              cleanup_state="${RUNNER_TEMP}/desktop-prerelease-cleanup-recovery.json"
+              if recover_owned_empty_draft "$cleanup_state"; then
+                recovered_id="$(jq -r '.id // empty' "$cleanup_state")"
+                recovered_api="repos/${GITHUB_REPOSITORY}/releases/${recovered_id}"
+                current_state="${RUNNER_TEMP}/desktop-prerelease-cleanup-current.json"
+                verified_state="${RUNNER_TEMP}/desktop-prerelease-cleanup-verified.json"
+                if [[ "$recovered_id" =~ ^[0-9]+$ ]] \
+                  && gh api "$recovered_api" > "$current_state" \
+                  && python "$owned_draft_validator" \
+                    "$current_state" "$verified_state" "$notes_blob" "$tag" \
+                    "$expected_commit" "$create_started_at" "$release_author" "$draft_name" \
+                  && [ "$(jq -r .id "$verified_state")" = "$recovered_id" ] \
+                  && gh api -X DELETE "$recovered_api" --silent; then
+                  echo "::warning::Removed the uniquely owned empty Draft after a lost create response."
+                else
+                  echo "::warning::Could not safely remove the uniquely owned Draft; primary failure preserved."
+                fi
+              else
+                echo "::warning::No unique owned empty Draft could be recovered for cleanup; primary failure preserved."
+              fi
+              set -e
             fi
             exit "$primary_status"
           }
@@ -559,12 +701,11 @@ jobs:
             echo "Release ${tag} already exists; refusing to overwrite it." >&2
             exit 1
           fi
-          latest_before="$(
-            gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name
-          )"
-          draft_name="codex-keysmith 0.2.0 Windows x64 unsigned Beta [run ${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}]"
+          latest_before="$(get_latest_release_tag)"
+          draft_name="codex-keysmith 0.2.0 Desktop Beta [run ${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}]"
           python scripts/package_desktop_prerelease.py verify "$release_dir" \
-            --expected-commit "$expected_commit"
+            --expected-commit "$expected_commit" \
+            --source-dir "$RUNNER_TEMP/desktop-source-first"
           verify_remote_main
           verify_remote_tag
           request="${RUNNER_TEMP}/desktop-prerelease-create.json"
@@ -591,6 +732,7 @@ jobs:
           created_state="${RUNNER_TEMP}/desktop-prerelease-created.json"
           create_error="${RUNNER_TEMP}/desktop-prerelease-create-error.txt"
           create_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          create_attempted=true
           set +e
           gh api -X POST "repos/${GITHUB_REPOSITORY}/releases" \
             --input "$request" > "$created_state" 2> "$create_error"
@@ -598,56 +740,12 @@ jobs:
           set -e
           release_id="$(jq -r '.id // empty' "$created_state" 2>/dev/null || true)"
           if [ "$create_status" -ne 0 ] || [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
-            recovery_state="${RUNNER_TEMP}/desktop-prerelease-create-recovery.json"
-            recovery_ok=false
-            for _attempt in {1..3}; do
-              if gh api --paginate --slurp \
-                "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > "$recovery_state"; then
-                recovery_ok=true
-                break
-              fi
-              sleep 1
-            done
-            if [ "$recovery_ok" != true ]; then
+            adopted_state="${RUNNER_TEMP}/desktop-prerelease-adopted.json"
+            if ! recover_owned_empty_draft "$adopted_state"; then
               cat "$create_error" >&2
               echo "Could not recover ownership after the create response was lost." >&2
               exit 1
             fi
-            adopted_state="${RUNNER_TEMP}/desktop-prerelease-adopted.json"
-            python - "$recovery_state" "$adopted_state" "$notes_blob" "$tag" \
-              "$expected_commit" "$create_started_at" "$GITHUB_ACTOR" "$draft_name" <<'PY'
-          import json
-          from pathlib import Path
-          import sys
-
-          source_path, output_path, notes_path, tag, commit, started_at, actor, draft_name = sys.argv[1:]
-          pages = json.loads(Path(source_path).read_text(encoding="utf-8"))
-          releases = [release for page in pages for release in page]
-          expected_body = Path(notes_path).read_text(encoding="utf-8")
-          matches = [
-              release
-              for release in releases
-              if release.get("tag_name") == tag
-              and release.get("target_commitish") == commit
-              and release.get("name") == draft_name
-              and release.get("body") == expected_body
-              and release.get("draft") is True
-              and release.get("prerelease") is True
-              and release.get("assets") == []
-              and release.get("created_at", "") >= started_at
-              and release.get("author", {}).get("login") == actor
-          ]
-          if len(matches) != 1:
-              raise SystemExit(
-                  "expected exactly one owned empty draft after lost create response, got {}".format(
-                      len(matches)
-                  )
-              )
-          Path(output_path).write_text(
-              json.dumps(matches[0], ensure_ascii=False, separators=(",", ":")),
-              encoding="utf-8",
-          )
-          PY
             cp "$adopted_state" "$created_state"
             release_id="$(jq -r '.id // empty' "$created_state")"
             echo "::warning::Recovered numeric-ID ownership after a lost create response."
@@ -658,6 +756,7 @@ jobs:
           fi
           release_api="repos/${GITHUB_REPOSITORY}/releases/${release_id}"
           release_created=true
+          create_attempted=false
           empty_state="${RUNNER_TEMP}/desktop-prerelease-empty.json"
           gh api "$release_api" > "$empty_state"
           python - "$created_state" "$empty_state" "$notes_blob" "$tag" \
@@ -694,7 +793,7 @@ jobs:
           request = {
               "tag_name": tag,
               "target_commitish": commit,
-              "name": "codex-keysmith 0.2.0 Windows x64 unsigned Beta",
+              "name": "codex-keysmith 0.2.0 Desktop Beta",
               "body": Path(notes_path).read_text(encoding="utf-8"),
               "draft": True,
               "prerelease": True,
@@ -717,7 +816,7 @@ jobs:
           assert str(state["id"]) == release_id
           assert state["tag_name"] == tag
           assert state["target_commitish"] == commit
-          assert state["name"] == "codex-keysmith 0.2.0 Windows x64 unsigned Beta"
+          assert state["name"] == "codex-keysmith 0.2.0 Desktop Beta"
           assert state["draft"] is True
           assert state["prerelease"] is True
           assert state["body"].encode("utf-8") == Path(notes_path).read_bytes()
@@ -725,8 +824,13 @@ jobs:
           PY
           upload_url="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets"
           assets=(
+            "$release_dir/codex-keysmith-0.2.0-macos-arm64-unsigned.dmg"
+            "$release_dir/codex-keysmith-0.2.0-macos-arm64-unsigned-candidate.zip"
             "$release_dir/codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe"
             "$release_dir/codex-keysmith-0.2.0-windows-x64-unsigned-candidate.zip"
+            "$release_dir/codex-instruct-v0.2.0.py"
+            "$release_dir/codex-keysmith-v0.2.0.zip"
+            "$release_dir/codex-keysmith-v0.2.0.tar.gz"
             "$release_dir/SHA256SUMS"
           )
           for asset_path in "${assets[@]}"; do
@@ -763,11 +867,11 @@ jobs:
           assert str(state["id"]) == release_id
           assert state["tag_name"] == tag
           assert state["target_commitish"] == commit
-          assert state["name"] == "codex-keysmith 0.2.0 Windows x64 unsigned Beta"
+          assert state["name"] == "codex-keysmith 0.2.0 Desktop Beta"
           assert state["draft"] is True
           assert state["prerelease"] is True
           assert state["body"].encode("utf-8") == Path(notes_path).read_bytes()
-          assert len(state["assets"]) == 3
+          assert len(state["assets"]) == 8
           PY
           jq -r '.assets[] | [.name, .digest, .state, (.size | tostring)] | @tsv' \
             "$uploaded_state" | sort > "$actual"
@@ -777,7 +881,8 @@ jobs:
           git cat-file blob "${expected_commit}:${notes_path}" > "$tagged_notes"
           cmp "$notes_blob" "$tagged_notes"
           python scripts/package_desktop_prerelease.py verify "$release_dir" \
-            --expected-commit "$expected_commit"
+            --expected-commit "$expected_commit" \
+            --source-dir "$RUNNER_TEMP/desktop-source-first"
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
           verify_remote_main
           verify_remote_tag
@@ -792,7 +897,7 @@ jobs:
           request = {
               "tag_name": tag,
               "target_commitish": commit,
-              "name": "codex-keysmith 0.2.0 Windows x64 unsigned Beta",
+              "name": "codex-keysmith 0.2.0 Desktop Beta",
               "body": Path(notes_path).read_text(encoding="utf-8"),
               "draft": False,
               "prerelease": True,
@@ -847,19 +952,18 @@ jobs:
           assert str(state["id"]) == release_id
           assert state["tag_name"] == tag
           assert state["target_commitish"] == commit
-          assert state["name"] == "codex-keysmith 0.2.0 Windows x64 unsigned Beta"
+          assert state["name"] == "codex-keysmith 0.2.0 Desktop Beta"
           assert state["draft"] is False
           assert state["prerelease"] is True
           assert state["published_at"]
           assert state["body"].encode("utf-8") == Path(notes_path).read_bytes()
-          assert len(state["assets"]) == 3
+          assert len(state["assets"]) == 8
           PY
           jq -r '.assets[] | [.name, .digest, .state, (.size | tostring)] | @tsv' \
             "$final_state" | sort > "$actual"
           diff -u "$expected" "$actual"
-          latest_after="$(
-            gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name
-          )"
+          verify_remote_tag
+          latest_after="$(get_latest_release_tag)"
           if [ "$latest_after" != "$latest_before" ]; then
             echo "Unsigned prerelease unexpectedly changed the repository's Latest Release." >&2
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ### Desktop prerelease
 
-- Added the public `desktop-v0.2.0-beta.2` Windows x64 unsigned NSIS Pre-release with fixed setup, candidate ZIP, and `SHA256SUMS` assets. The signed `desktop-v0.2.0-beta.1` tag is retained after its draft publication aborted before asset upload; it has no public Release or assets. The application source remains `0.2.0`, and the formal signed release keeps the `v0.2.0` tag.
-- Added a main-only manual publisher that binds the signed annotated beta tag, current remote `main`, expected commit, Windows build manifest, draft Release, and final asset digests before publication. Pull requests remain read-only and the candidate workflow contains no signing secrets.
+- Prepared `desktop-v0.2.0-beta.3` as the unified unsigned Desktop Beta with an Apple Silicon macOS DMG, Windows x64 NSIS installer, standalone CLI, deterministic source archives, two platform candidate ZIPs, and one complete `SHA256SUMS`.
+- Extended the main-only manual publisher to bind both platform manifests, the signed annotated beta tag, current remote `main`, expected commit, draft Release, and all eight public assets before publication. Pull requests remain read-only and the candidate workflow contains no signing secrets.
+- `desktop-v0.2.0-beta.2` remains the earlier Windows-only prerelease. The signed `desktop-v0.2.0-beta.1` tag is retained after its draft publication aborted before asset upload; it has no public Release or assets. The application source remains `0.2.0`, and the formal signed release keeps the `v0.2.0` tag.
 - Added code-signing and privacy policies. The application does not proactively collect or upload user data; SignPath Foundation review remains pending and the current beta is not SignPath-signed.
-- Windows status is `Beta / unsigned / native-CI-validated`. The CI installs, exercises, and uninstalls the package in temporary directories, but no physical Windows device or SmartScreen experience has been accepted.
+- Desktop status is `Beta / unsigned / native-CI-validated`. CI builds both native candidates and installs, exercises, and uninstalls Windows in temporary directories, but no physical macOS or Windows device experience has been accepted.
 
 ### Fixed
 

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -2,7 +2,9 @@
 
 ## Current desktop beta
 
-`desktop-v0.2.0-beta.2` publishes a Windows x64 NSIS installer without Authenticode signing. It is a public prerelease, not a formally signed Windows release. Windows may show **Unknown publisher** and Microsoft Defender SmartScreen warnings.
+`desktop-v0.2.0-beta.3` publishes an Apple Silicon macOS DMG and Windows x64 NSIS installer as one unsigned Desktop Beta. The DMG is not Apple-signed or notarized, and the installer has no Authenticode signature. macOS may show Gatekeeper warnings; Windows may show **Unknown publisher** and Microsoft Defender SmartScreen warnings.
+
+`desktop-v0.2.0-beta.2` remains the earlier Windows-only prerelease and is not overwritten by the unified beta.
 
 The signed `desktop-v0.2.0-beta.1` tag is retained as immutable evidence of an aborted publication attempt. Its draft was removed before asset upload, so it has no public Release or downloadable assets.
 
@@ -12,8 +14,8 @@ The desktop candidate workflow is permanently unsigned and does not read Apple o
 
 - Public desktop prereleases must be rebuilt by GitHub Actions from the current `main` commit on pinned runners and toolchains.
 - Publication requires an existing signed annotated `desktop-v0.2.0-beta.N` tag whose GitHub verification result is valid and whose peeled commit equals the current remote `main` HEAD.
-- The build manifest, workflow commit, expected commit, tag commit, release target, asset set, sizes, and SHA-256 digests must all agree before a draft is made public.
-- Existing tags, Releases, and assets are immutable. A failed published candidate is replaced by a new beta number, never by overwriting an existing asset.
+- Both build manifests, the workflow commit, expected commit, tag commit, release target, asset set, sizes, and SHA-256 digests must all agree before a draft is made public.
+- The publisher never overwrites an existing tag, Release, or asset. A failed published candidate is replaced by a new beta number.
 - Self-signed certificates are not used for public distribution.
 
 ## Future signed release

--- a/README.en.md
+++ b/README.en.md
@@ -38,10 +38,10 @@ npm install
 npm run tauri dev
 ```
 
-- The unified source version is `0.2.0`. The macOS candidate includes the CLI sidecar and produces `.app` / `.dmg`; this beta publishes no new macOS asset, and formal macOS signing, notarization, and publication remain separate work.
-- A public unsigned Windows x64 Pre-release is available at [`desktop-v0.2.0-beta.2`](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.2.0-beta.2). Most users should download `codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe`. It is **Beta / unsigned / native-CI-validated**, has no Authenticode signature, may trigger Unknown publisher or SmartScreen warnings, and has not received physical Windows device acceptance.
+- The unified source version is `0.2.0`. [`desktop-v0.2.0-beta.3`](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.2.0-beta.3) publishes the Apple Silicon macOS DMG, Windows x64 NSIS installer, standalone CLI, and deterministic source archives together.
+- macOS users download `codex-keysmith-0.2.0-macos-arm64-unsigned.dmg`; Windows users download `codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe`. Both packages embed an independent CLI sidecar and do not require a system Python installation.
+- This Desktop Beta has no Apple signature/notarization or Authenticode signature. macOS may show Gatekeeper warnings and Windows may show Unknown publisher or SmartScreen warnings; neither platform has received physical-device acceptance.
 - The Windows package uses current-user NSIS and a silent WebView2 download bootstrapper. It does not provide MSI, ARM64, or a formal Windows support commitment; the underlying Windows CLI fresh-deployment path remains `EXPLICIT_BETA`.
-- Packaged builds include a PyInstaller CLI sidecar and do not require end users to install Python separately. Development mode and advanced manual configuration can still fall back to an external `codex-instruct.py`. See `gui/README.md` for development and build details.
 - The application does not proactively collect or upload user data. See [`CODE_SIGNING_POLICY.md`](CODE_SIGNING_POLICY.md) and [`PRIVACY.md`](PRIVACY.md). The SignPath Foundation application is pending, and the current prerelease assets are not SignPath-signed.
 
 ### Quick start (macOS / Linux)
@@ -113,6 +113,7 @@ Uninstall removes only the newest layer each run; repeat it to peel back earlier
 
 - Recommended Python 3.10–3.14; verified against `codex-cli 0.144.1`.
 - macOS / Linux are the primary support range.
+- **macOS GUI**: the Apple Silicon unsigned DMG is built natively on `macos-15` and published as a Desktop Beta without Apple signing, notarization, or physical-device acceptance.
 - **Windows**: the published `v0.1.0` has a known defect (`os.utime` failure followed by a second `PermissionError` that leaves a journal the old script can't recover). v0.1.1 and later include the rewritten Windows filesystem backend under `EXPLICIT_BETA` — usable, but not formally supported yet. If v0.1.0 left a journal on Windows, recover with the latest verified Release script in order: `--status` → `--recover` preview → `--recover --yes` → `--status`; never manually delete evidence.
 - **Windows GUI**: the Windows x64 unsigned NSIS Beta is built natively on `windows-2025` and published as a Pre-release, but it has no Authenticode signature or physical-device acceptance. It does not expand the CLI's `EXPLICIT_BETA` support boundary or constitute formal Windows support.
 - Single-file CLI, no `pip install` or auto-updater; backups and uninstall archives are not cleaned automatically.

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ npm install
 npm run tauri dev
 ```
 
-- 当前统一源码版本为 `0.2.0`。macOS 候选构建已包含 CLI sidecar 并产出 `.app` / `.dmg`；本轮不公开新的 macOS 资产，正式签名、公证和发布仍待凭据与独立流程完成。
-- Windows x64 已提供公开的 unsigned Pre-release：[`desktop-v0.2.0-beta.2`](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.2.0-beta.2)。普通用户下载 `codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe`；它是 **Beta / unsigned / native-CI-validated**，没有 Authenticode 签名，Windows 可能显示 Unknown publisher 或 SmartScreen 警告，也尚未经过实体 Windows 设备验收。
+- 当前统一源码版本为 `0.2.0`。[`desktop-v0.2.0-beta.3`](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.2.0-beta.3) 统一提供 macOS Apple Silicon DMG、Windows x64 NSIS、单文件 CLI 和确定性源码归档。
+- macOS 用户下载 `codex-keysmith-0.2.0-macos-arm64-unsigned.dmg`；Windows 用户下载 `codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe`。两个安装包都内置独立 CLI sidecar，使用时无需额外安装 Python。
+- 本次 Desktop Beta 未进行 Apple 签名/公证或 Authenticode 签名。macOS 可能触发 Gatekeeper，Windows 可能显示 Unknown publisher 或 SmartScreen 警告；两平台均未经过实体设备验收。
 - Windows 安装包使用 current-user NSIS 和静默 WebView2 download bootstrapper，不提供 MSI、ARM64 或正式 Windows 支持承诺。底层 Windows CLI fresh deployment 继续遵循 `EXPLICIT_BETA`。
-- 正式打包流程会把 PyInstaller CLI sidecar 放入应用包，不要求最终用户另装 Python；开发模式和手动高级配置仍可回退到外部 `codex-instruct.py`。具体开发与构建说明见 `gui/README.md`。
 - 当前应用不主动收集或上传用户数据；签名边界见 [`CODE_SIGNING_POLICY.md`](CODE_SIGNING_POLICY.md)，本地数据说明见 [`PRIVACY.md`](PRIVACY.md)。SignPath Foundation 申请仍在审核中，当前预发布资产并未使用 SignPath 签名。
 
 ### 快速开始（macOS / Linux）
@@ -125,6 +125,7 @@ python3 codex-instruct.py --codex-dir ~/.codex --uninstall --yes --lang zh-CN  #
 
 - 推荐 Python 3.10–3.14；已验证 Codex CLI `codex-cli 0.144.1`。
 - macOS / Linux 是主要支持范围。
+- **macOS GUI**：Apple Silicon unsigned DMG 由 `macos-15` 原生 CI 构建并公开为 Desktop Beta，尚未进行 Apple 签名、公证或实体设备验收。
 - **Windows**：已发布的 `v0.1.0` 存在已知缺陷（`os.utime` 失败后触发第二个 `PermissionError`，会留下无法用旧脚本恢复的 journal）。v0.1.1 及后续版本已重写 Windows 文件系统后端并标记 `EXPLICIT_BETA`，可以试用，但还不是正式支持；如果 v0.1.0 留下了 journal，用最新已校验 Release 脚本按 `--status` → `--recover` 预览 → `--recover --yes` → `--status` 的顺序恢复，不要手工删除任何证据。
 - **Windows GUI**：Windows x64 unsigned NSIS Beta 已由 `windows-2025` 原生 CI 构建并公开为 Pre-release，但没有 Authenticode 签名或实体设备验收；它不扩大上述 CLI 的 `EXPLICIT_BETA` 支持边界，也不等于正式 Windows 支持。
 - 单文件 CLI，没有 `pip install` 或自动更新；备份和卸载归档不会自动清理。

--- a/docs/releases/desktop-v0.2.0-beta.3.md
+++ b/docs/releases/desktop-v0.2.0-beta.3.md
@@ -1,0 +1,37 @@
+# codex-keysmith v0.2.0 Desktop Beta
+
+v0.2.0 在原有 CLI 基础上新增 macOS（Apple Silicon）和 Windows（x64）桌面 GUI。
+
+## 下载
+
+- macOS Apple Silicon：`codex-keysmith-0.2.0-macos-arm64-unsigned.dmg`
+- Windows x64：`codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe`
+- 单文件 CLI：`codex-instruct-v0.2.0.py`
+- 源码：`codex-keysmith-v0.2.0.zip` / `codex-keysmith-v0.2.0.tar.gz`
+- 构建验证包：`codex-keysmith-0.2.0-macos-arm64-unsigned-candidate.zip` / `codex-keysmith-0.2.0-windows-x64-unsigned-candidate.zip`
+- 文件校验：`SHA256SUMS`
+
+下载全部七个发布文件及 `SHA256SUMS` 后，可在资产所在目录执行：
+
+```bash
+sha256sum --check SHA256SUMS
+```
+
+macOS 也可使用 `shasum -a 256 -c SHA256SUMS`；Windows PowerShell 可用
+`Get-FileHash -Algorithm SHA256 <文件名>` 并与 `SHA256SUMS` 逐项比对。
+
+## Beta 边界
+
+- macOS DMG 未进行 Apple 签名或公证，Windows Setup 未进行 Authenticode 签名；macOS 可能触发 Gatekeeper，Windows 可能触发 SmartScreen。
+- 当前产物尚未完成 macOS / Windows 实体设备验收，不应视为正式版安装器验收结论。
+- 两个 `*-candidate.zip` 是构建验证包，不是安装包；普通用户应下载 DMG 或 Setup EXE。
+- Windows Setup 尚未使用 SignPath 签名；后续正式签名仍以 SignPath Foundation 审批和独立签名流程为准。
+
+## 更新内容
+
+- 新增 macOS 和 Windows 桌面客户端。
+- 支持状态查看、变更预览、部署、恢复、hooks 恢复和卸载。
+- 新增中英双语界面和图形化设置。
+- 安装包内置独立 CLI，使用时无需额外安装 Python。
+- GUI 与 CLI 共用同一套部署和恢复逻辑，现有 CLI 参数保持不变。
+- 继续兼容 v0.1.x 部署，无需迁移。

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -10,8 +10,8 @@ v0.2.0 将桌面客户端源码并入 canonical 仓库，并保持 Python CLI �
 - CLI 与 GUI 源码统一为 `0.2.0`。manifest 与 journal schema 仍为 1，已有 v0.1.0-v0.1.3 部署无需迁移。
 - PyInstaller frozen 模式生成 hooks 恢复命令时直接调用打包后的可执行文件，不再追加临时解包目录中的 Python 源文件路径；源码模式仍输出 `python + codex-instruct.py`。
 - 正式打包流程会原生构建 PyInstaller CLI sidecar 并放入应用包，最终用户无需单独安装 Python；开发模式和高级手动配置仍可回退到外部 `codex-instruct.py`。
-- macOS GUI 候选构建已嵌入 CLI sidecar 并产出 `.app` / `.dmg`；`desktop-v0.2.0-beta.2` 不新增 macOS 公开资产，正式签名、公证和发布仍待独立流程完成。
-- Windows x64 GUI 已由 `windows-2025` 原生 CI 构建并以 unsigned NSIS Pre-release 公开。该产物为 `Beta / unsigned / native-CI-validated`，会遇到 Unknown publisher / SmartScreen 边界，且没有实体 Windows 设备验收；底层 Windows CLI fresh deployment 仍为 `EXPLICIT_BETA`，不构成正式支持承诺。
+- `desktop-v0.2.0-beta.3` 统一公开 macOS Apple Silicon unsigned DMG、Windows x64 unsigned NSIS、单文件 CLI、确定性源码归档和完整 `SHA256SUMS`；两个平台 candidate ZIP 保留各自的 build manifest 与内部校验值。
+- macOS DMG 未进行 Apple 签名或公证，Windows 安装器未进行 Authenticode 签名；两者均为 `Beta / unsigned / native-CI-validated`，没有实体设备验收。底层 Windows CLI fresh deployment 仍为 `EXPLICIT_BETA`，不构成正式支持承诺。
 
 桌面客户端源码入口：<https://github.com/Jia-Ethan/codex-keysmith/tree/main/gui>
 
@@ -30,8 +30,8 @@ v0.2.0 brings the desktop client source into the canonical repository while keep
 - Unifies the CLI and GUI source version at `0.2.0`. Manifest and journal schemas remain at 1, so deployments created by v0.1.0-v0.1.3 require no migration.
 - PyInstaller-frozen builds now generate hooks-restore commands that invoke the packaged executable directly instead of appending a Python source path inside the temporary extraction directory. Source mode continues to emit `python + codex-instruct.py`.
 - Packaged builds create a native PyInstaller CLI sidecar and include it in the application bundle, so end users do not need a separate Python installation. Development mode and advanced manual configuration retain the external `codex-instruct.py` fallback.
-- The macOS GUI candidate embeds the CLI sidecar and produces `.app` / `.dmg`; `desktop-v0.2.0-beta.2` adds no public macOS asset, and formal macOS signing, notarization, and publication remain separate.
-- The Windows x64 GUI is built natively on `windows-2025` and published as an unsigned NSIS Pre-release. It remains `Beta / unsigned / native-CI-validated`, may trigger Unknown publisher or SmartScreen warnings, and has no physical Windows device acceptance. Windows CLI fresh deployment remains `EXPLICIT_BETA`, not a formal support commitment.
+- `desktop-v0.2.0-beta.3` publishes the Apple Silicon macOS unsigned DMG, Windows x64 unsigned NSIS installer, standalone CLI, deterministic source archives, and complete `SHA256SUMS` together; both platform candidate ZIPs retain their build manifests and internal checksums.
+- The DMG has no Apple signature or notarization, and the Windows installer has no Authenticode signature. Both remain `Beta / unsigned / native-CI-validated` without physical-device acceptance. Windows CLI fresh deployment remains `EXPLICIT_BETA`, not a formal support commitment.
 
 Desktop client source: <https://github.com/Jia-Ethan/codex-keysmith/tree/main/gui>
 

--- a/gui/README.md
+++ b/gui/README.md
@@ -43,7 +43,7 @@ npm run tauri build
 | macOS Apple Silicon | `codex-keysmith-cli-aarch64-apple-darwin` | `.app` + ARM64 `.dmg` |
 | Windows x64 | `codex-keysmith-cli-x86_64-pc-windows-msvc.exe` | current-user NSIS `.exe` |
 
-Windows 安装器使用 WebView2 download bootstrapper、禁止降级；当前不生成 MSI。公开的 `desktop-v0.2.0-beta.1` 只提供 Windows x64 unsigned NSIS Beta，状态为 `Beta / unsigned / native-CI-validated`，可能触发 Unknown publisher / SmartScreen，且没有实体设备验收。普通用户下载 `codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe`；正式 Authenticode 发行仍待 SignPath Foundation 审核和独立签名流程。
+`desktop-v0.2.0-beta.3` 统一提供 macOS Apple Silicon unsigned DMG 与 Windows x64 unsigned NSIS。Windows 安装器使用 WebView2 download bootstrapper、禁止降级，当前不生成 MSI；两平台均为 `Beta / unsigned / native-CI-validated`，尚未进行正式签名、公证或实体设备验收。普通用户按平台下载 DMG 或 setup EXE；正式 Authenticode 发行仍待 SignPath Foundation 审核和独立签名流程。
 
 图标以 `src-tauri/icons/source.png` 为唯一源文件。修改后运行：
 

--- a/gui/SPEC.md
+++ b/gui/SPEC.md
@@ -1,6 +1,6 @@
 # codex-keysmith GUI 客户端 — 技术方案与交接文档
 
-> 状态：v0.2.0 已具备 React 前端、PyInstaller sidecar、macOS app/dmg 与 Windows x64 NSIS；`desktop-v0.2.0-beta.1` 提供 Windows x64 unsigned Pre-release，正式签名、公证与实体设备验收仍待完成
+> 状态：v0.2.0 已具备 React 前端、PyInstaller sidecar、macOS app/dmg 与 Windows x64 NSIS；`desktop-v0.2.0-beta.3` 统一提供两平台 unsigned Desktop Beta，正式签名、公证与实体设备验收仍待完成
 > 关联 issue：[#10「建议」为小白做一个可视化的界面客户端](https://github.com/Jia-Ethan/codex-keysmith/issues/10)
 
 ## 1. 项目背景
@@ -16,7 +16,7 @@ CLI 对熟练用户很好用，但对小白（issue #10 的目标用户）门槛
 | 技术栈 | **Tauri 2**（Rust 后端 + Web 前端） | 打包体积小（几 MB）、原生感强、界面现代化 |
 | 平台范围 | **macOS Apple Silicon + Windows x64** | 每个平台原生冻结 Python 与构建 Tauri bundle，不做跨平台交叉打包；本轮不提供 Intel Mac 包 |
 | 与 CLI 的关系 | **包装现有 CLI**（subprocess 调用），不重实现逻辑 | 复用已测试的部署/回滚/恢复逻辑，CLI 升级客户端不用跟着改 |
-| 本轮交付 | **M1–M3 完整实现 + Windows x64 unsigned Beta** | GitHub 原生 CI 构建并公开 Pre-release；未签名、无实体设备验收，不等于正式 Windows 支持 |
+| 本轮交付 | **M1–M3 完整实现 + macOS/Windows unsigned Desktop Beta** | GitHub 原生 CI 构建并统一公开 Pre-release；未签名、无实体设备验收，不等于正式平台支持 |
 
 ## 3. 总体架构
 

--- a/scripts/package_desktop_prerelease.py
+++ b/scripts/package_desktop_prerelease.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Assemble and verify the public unsigned Windows desktop prerelease assets."""
+"""Assemble and verify the public unsigned desktop prerelease assets."""
 
 from __future__ import annotations
 
@@ -22,20 +22,74 @@ else:
     import validate_desktop_candidate as candidate_validator
 
 
-VERSION = "0.2.0"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VERSION = (REPO_ROOT / "VERSION").read_text(encoding="ascii").strip()
 PRODUCT = "codex-keysmith"
-TAG_RE = re.compile(r"^desktop-v0\.2\.0-beta\.[1-9][0-9]*$")
+TAG_RE = re.compile(rf"^desktop-v{re.escape(VERSION)}-beta\.[1-9][0-9]*$")
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
-SETUP_NAME = "codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe"
-CANDIDATE_ZIP_NAME = "codex-keysmith-0.2.0-windows-x64-unsigned-candidate.zip"
 CHECKSUMS_NAME = "SHA256SUMS"
-PUBLIC_ASSET_NAMES = (SETUP_NAME, CANDIDATE_ZIP_NAME, CHECKSUMS_NAME)
-EXPECTED_FIXED_CANDIDATE_FILES = {
-    "build-manifest.json",
-    "codex-keysmith-gui.exe",
-    "codex-keysmith-cli.exe",
-    "icon.ico",
-    "SHA256SUMS",
+
+MACOS_DMG_NAME = f"{PRODUCT}-{VERSION}-macos-arm64-unsigned.dmg"
+MACOS_CANDIDATE_ZIP_NAME = f"{PRODUCT}-{VERSION}-macos-arm64-unsigned-candidate.zip"
+WINDOWS_SETUP_NAME = f"{PRODUCT}-{VERSION}-windows-x64-unsigned-setup.exe"
+WINDOWS_CANDIDATE_ZIP_NAME = f"{PRODUCT}-{VERSION}-windows-x64-unsigned-candidate.zip"
+CLI_NAME = f"codex-instruct-v{VERSION}.py"
+SOURCE_ZIP_NAME = f"{PRODUCT}-v{VERSION}.zip"
+SOURCE_TAR_NAME = f"{PRODUCT}-v{VERSION}.tar.gz"
+
+# Retain the legacy names for callers that only need the Windows asset constants.
+SETUP_NAME = WINDOWS_SETUP_NAME
+CANDIDATE_ZIP_NAME = WINDOWS_CANDIDATE_ZIP_NAME
+
+SOURCE_PAYLOAD_NAMES = (CLI_NAME, SOURCE_ZIP_NAME, SOURCE_TAR_NAME)
+PUBLIC_PAYLOAD_NAMES = (
+    MACOS_DMG_NAME,
+    MACOS_CANDIDATE_ZIP_NAME,
+    WINDOWS_SETUP_NAME,
+    WINDOWS_CANDIDATE_ZIP_NAME,
+    *SOURCE_PAYLOAD_NAMES,
+)
+PUBLIC_ASSET_NAMES = (*PUBLIC_PAYLOAD_NAMES, CHECKSUMS_NAME)
+
+PLATFORM_CONFIGS = {
+    "macos": {
+        "target": {
+            "platform": "macos",
+            "architecture": "arm64",
+            "triple": "aarch64-apple-darwin",
+            "bundle_format": "dmg",
+            "signing_mode": "unsigned",
+        },
+        "bundle_suffix": ".dmg",
+        "public_bundle": MACOS_DMG_NAME,
+        "candidate_zip": MACOS_CANDIDATE_ZIP_NAME,
+        "fixed_files": {
+            "build-manifest.json",
+            "codex-keysmith-gui",
+            "codex-keysmith-cli",
+            "icon.icns",
+            CHECKSUMS_NAME,
+        },
+    },
+    "windows": {
+        "target": {
+            "platform": "windows",
+            "architecture": "x86_64",
+            "triple": "x86_64-pc-windows-msvc",
+            "bundle_format": "nsis",
+            "signing_mode": "unsigned",
+        },
+        "bundle_suffix": ".exe",
+        "public_bundle": WINDOWS_SETUP_NAME,
+        "candidate_zip": WINDOWS_CANDIDATE_ZIP_NAME,
+        "fixed_files": {
+            "build-manifest.json",
+            "codex-keysmith-gui.exe",
+            "codex-keysmith-cli.exe",
+            "icon.ico",
+            CHECKSUMS_NAME,
+        },
+    },
 }
 
 
@@ -75,13 +129,18 @@ def _read_json(path: Path) -> dict[str, Any]:
 def _validate_tag_and_commit(tag: str, expected_commit: str) -> None:
     if TAG_RE.fullmatch(tag) is None:
         raise PrereleaseError(
-            "release tag must match desktop-v0.2.0-beta.N with N starting at 1"
+            f"release tag must match desktop-v{VERSION}-beta.N with N starting at 1"
         )
     if COMMIT_RE.fullmatch(expected_commit) is None:
         raise PrereleaseError("expected commit must be a full lowercase 40-character SHA")
 
 
-def _validate_candidate(candidate_dir: Path, expected_commit: str) -> dict[str, Any]:
+def _validate_candidate(
+    candidate_dir: Path,
+    expected_commit: str,
+    platform: str,
+) -> dict[str, Any]:
+    config = PLATFORM_CONFIGS[platform]
     candidate_dir = candidate_dir.absolute()
     if not candidate_dir.is_dir() or candidate_dir.is_symlink():
         raise PrereleaseError(f"candidate directory is missing or unsafe: {candidate_dir}")
@@ -91,14 +150,8 @@ def _validate_candidate(candidate_dir: Path, expected_commit: str) -> dict[str, 
         raise PrereleaseError(f"candidate versions must both be {VERSION}")
     if manifest.get("source_commit") != expected_commit:
         raise PrereleaseError("candidate manifest source commit does not match expected commit")
-    if manifest.get("target") != {
-        "platform": "windows",
-        "architecture": "x86_64",
-        "triple": "x86_64-pc-windows-msvc",
-        "bundle_format": "nsis",
-        "signing_mode": "unsigned",
-    }:
-        raise PrereleaseError("candidate must be an unsigned Windows x64 NSIS build")
+    if manifest.get("target") != config["target"]:
+        raise PrereleaseError(f"candidate must match the unsigned {platform} target policy")
     provenance = manifest.get("sidecar_provenance")
     if not isinstance(provenance, dict) or provenance.get("relation") != "exact-copy":
         raise PrereleaseError("unsigned candidate sidecar must be the exact tested build output")
@@ -109,9 +162,11 @@ def _validate_candidate(candidate_dir: Path, expected_commit: str) -> dict[str, 
     if not isinstance(bundle, dict) or not isinstance(bundle.get("file"), str):
         raise PrereleaseError("candidate manifest bundle record is missing")
     bundle_name = bundle["file"]
-    if Path(bundle_name).name != bundle_name or not bundle_name.lower().endswith(".exe"):
-        raise PrereleaseError("candidate bundle filename is unsafe or not an EXE")
-    expected_files = EXPECTED_FIXED_CANDIDATE_FILES | {bundle_name}
+    if Path(bundle_name).name != bundle_name or not bundle_name.lower().endswith(
+        str(config["bundle_suffix"])
+    ):
+        raise PrereleaseError(f"candidate bundle filename is unsafe or not a {platform} bundle")
+    expected_files = set(config["fixed_files"]) | {bundle_name}
     entries = list(candidate_dir.iterdir())
     actual_files = {entry.name for entry in entries}
     if actual_files != expected_files:
@@ -128,6 +183,31 @@ def _validate_candidate(candidate_dir: Path, expected_commit: str) -> dict[str, 
     return manifest
 
 
+def _validate_source_assets(source_dir: Path) -> None:
+    source_dir = source_dir.absolute()
+    if not source_dir.is_dir() or source_dir.is_symlink():
+        raise PrereleaseError(f"source asset directory is missing or unsafe: {source_dir}")
+    entries = list(source_dir.iterdir())
+    expected_names = {*SOURCE_PAYLOAD_NAMES, CHECKSUMS_NAME}
+    actual_names = {entry.name for entry in entries}
+    if actual_names != expected_names:
+        raise PrereleaseError(
+            f"source asset set is not exact: expected {sorted(expected_names)}, "
+            f"got {sorted(actual_names)}"
+        )
+    for entry in entries:
+        _require_regular_file(entry)
+    expected_lines = [
+        f"{_sha256(source_dir / name)}  {name}" for name in sorted(SOURCE_PAYLOAD_NAMES)
+    ]
+    try:
+        checksum_lines = (source_dir / CHECKSUMS_NAME).read_text(encoding="ascii").splitlines()
+    except (OSError, UnicodeError) as exc:
+        raise PrereleaseError(f"cannot read source SHA256SUMS: {exc}") from exc
+    if checksum_lines != expected_lines:
+        raise PrereleaseError("source SHA256SUMS does not exactly cover deterministic source assets")
+
+
 def _write_deterministic_zip(candidate_dir: Path, destination: Path) -> None:
     with zipfile.ZipFile(
         destination,
@@ -142,32 +222,22 @@ def _write_deterministic_zip(candidate_dir: Path, destination: Path) -> None:
             info.compress_type = zipfile.ZIP_DEFLATED
             info.create_system = 3
             info.external_attr = (stat.S_IFREG | 0o644) << 16
-            archive.writestr(info, source.read_bytes(), compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)
+            archive.writestr(
+                info,
+                source.read_bytes(),
+                compress_type=zipfile.ZIP_DEFLATED,
+                compresslevel=9,
+            )
 
 
-def verify_public_assets(output_dir: Path, expected_commit: str | None = None) -> None:
-    if expected_commit is not None and COMMIT_RE.fullmatch(expected_commit) is None:
-        raise PrereleaseError("expected commit must be a full lowercase 40-character SHA")
-    output_dir = output_dir.absolute()
-    if not output_dir.is_dir() or output_dir.is_symlink():
-        raise PrereleaseError(f"prerelease output directory is missing or unsafe: {output_dir}")
-    entries = list(output_dir.iterdir())
-    actual_names = {entry.name for entry in entries}
-    if actual_names != set(PUBLIC_ASSET_NAMES):
-        raise PrereleaseError(
-            f"public asset set is not exact: expected {sorted(PUBLIC_ASSET_NAMES)}, "
-            f"got {sorted(actual_names)}"
-        )
-    for entry in entries:
-        _require_regular_file(entry)
-    checksum_lines = (output_dir / CHECKSUMS_NAME).read_text(encoding="ascii").splitlines()
-    expected_lines = sorted(
-        f"{_sha256(output_dir / name)}  {name}"
-        for name in (SETUP_NAME, CANDIDATE_ZIP_NAME)
-    )
-    if checksum_lines != expected_lines:
-        raise PrereleaseError("public SHA256SUMS does not exactly cover setup and candidate ZIP")
-    with zipfile.ZipFile(output_dir / CANDIDATE_ZIP_NAME, "r") as archive:
+def _verify_candidate_zip(
+    output_dir: Path,
+    platform: str,
+    expected_commit: str,
+) -> str:
+    config = PLATFORM_CONFIGS[platform]
+    archive_path = output_dir / str(config["candidate_zip"])
+    with zipfile.ZipFile(archive_path, "r") as archive:
         names = archive.namelist()
         if names != sorted(names) or len(names) != len(set(names)):
             raise PrereleaseError("candidate ZIP entries must be sorted and unique")
@@ -185,30 +255,83 @@ def verify_public_assets(output_dir: Path, expected_commit: str | None = None) -
                 (extracted / info.filename).write_bytes(archive.read(info))
             manifest = _read_json(extracted / "build-manifest.json")
             manifest_commit = manifest.get("source_commit")
-            if not isinstance(manifest_commit, str):
-                raise PrereleaseError("candidate ZIP manifest source commit is missing")
-            if expected_commit is not None and manifest_commit != expected_commit:
+            if not isinstance(manifest_commit, str) or COMMIT_RE.fullmatch(manifest_commit) is None:
+                raise PrereleaseError("candidate ZIP manifest source commit is missing or invalid")
+            if manifest_commit != expected_commit:
                 raise PrereleaseError(
                     "candidate ZIP manifest source commit does not match expected commit"
                 )
-            verified_manifest = _validate_candidate(extracted, manifest_commit)
+            verified_manifest = _validate_candidate(extracted, manifest_commit, platform)
             bundle_name = verified_manifest["artifacts"]["bundle"]["file"]
-            if _sha256(output_dir / SETUP_NAME) != _sha256(extracted / bundle_name):
+            public_bundle = output_dir / str(config["public_bundle"])
+            if _sha256(public_bundle) != _sha256(extracted / bundle_name):
                 raise PrereleaseError(
-                    "public setup EXE does not match the original installer in the candidate ZIP"
+                    f"public {platform} bundle does not match the original bundle in its candidate ZIP"
+                )
+            return manifest_commit
+
+
+def verify_public_assets(
+    output_dir: Path,
+    expected_commit: str,
+    source_dir: Path | None = None,
+) -> None:
+    if COMMIT_RE.fullmatch(expected_commit) is None:
+        raise PrereleaseError("expected commit must be a full lowercase 40-character SHA")
+    output_dir = output_dir.absolute()
+    if not output_dir.is_dir() or output_dir.is_symlink():
+        raise PrereleaseError(f"prerelease output directory is missing or unsafe: {output_dir}")
+    entries = list(output_dir.iterdir())
+    actual_names = {entry.name for entry in entries}
+    if actual_names != set(PUBLIC_ASSET_NAMES):
+        raise PrereleaseError(
+            f"public asset set is not exact: expected {sorted(PUBLIC_ASSET_NAMES)}, "
+            f"got {sorted(actual_names)}"
+        )
+    for entry in entries:
+        _require_regular_file(entry)
+    try:
+        checksum_lines = (output_dir / CHECKSUMS_NAME).read_text(encoding="ascii").splitlines()
+    except (OSError, UnicodeError) as exc:
+        raise PrereleaseError(f"cannot read public SHA256SUMS: {exc}") from exc
+    expected_lines = [
+        f"{_sha256(output_dir / name)}  {name}" for name in sorted(PUBLIC_PAYLOAD_NAMES)
+    ]
+    if checksum_lines != expected_lines:
+        raise PrereleaseError("public SHA256SUMS does not exactly cover all public payloads")
+    macos_commit = _verify_candidate_zip(output_dir, "macos", expected_commit)
+    windows_commit = _verify_candidate_zip(output_dir, "windows", expected_commit)
+    if macos_commit != windows_commit:
+        raise PrereleaseError("macOS and Windows candidate manifests do not bind the same commit")
+    if source_dir is not None:
+        source_dir = source_dir.absolute()
+        _validate_source_assets(source_dir)
+        for name in SOURCE_PAYLOAD_NAMES:
+            if _sha256(output_dir / name) != _sha256(source_dir / name):
+                raise PrereleaseError(
+                    f"public source asset does not match the commit-bound build output: {name}"
                 )
 
 
 def assemble_prerelease(
-    candidate_dir: Path,
+    macos_candidate_dir: Path,
+    windows_candidate_dir: Path,
+    source_dir: Path,
     output_dir: Path,
     tag: str,
     expected_commit: str,
 ) -> Path:
     _validate_tag_and_commit(tag, expected_commit)
-    candidate_dir = candidate_dir.absolute()
-    manifest = _validate_candidate(candidate_dir, expected_commit)
-    bundle_name = manifest["artifacts"]["bundle"]["file"]
+    candidate_dirs = {
+        "macos": macos_candidate_dir.absolute(),
+        "windows": windows_candidate_dir.absolute(),
+    }
+    manifests = {
+        platform: _validate_candidate(candidate_dir, expected_commit, platform)
+        for platform, candidate_dir in candidate_dirs.items()
+    }
+    source_dir = source_dir.absolute()
+    _validate_source_assets(source_dir)
     output_dir = output_dir.absolute()
     if output_dir.exists():
         if output_dir.is_symlink() or not output_dir.is_dir() or any(output_dir.iterdir()):
@@ -216,26 +339,36 @@ def assemble_prerelease(
     output_dir.parent.mkdir(parents=True, exist_ok=True)
     temporary = Path(tempfile.mkdtemp(prefix=".desktop-prerelease-", dir=output_dir.parent))
     try:
-        setup = temporary / SETUP_NAME
-        shutil.copyfile(candidate_dir / bundle_name, setup)
-        os.chmod(setup, 0o644)
-        _write_deterministic_zip(candidate_dir, temporary / CANDIDATE_ZIP_NAME)
-        checksum_lines = sorted(
+        for platform, candidate_dir in candidate_dirs.items():
+            config = PLATFORM_CONFIGS[platform]
+            bundle_name = manifests[platform]["artifacts"]["bundle"]["file"]
+            public_bundle = temporary / str(config["public_bundle"])
+            shutil.copyfile(candidate_dir / bundle_name, public_bundle)
+            os.chmod(public_bundle, 0o644)
+            _write_deterministic_zip(
+                candidate_dir,
+                temporary / str(config["candidate_zip"]),
+            )
+        for name in SOURCE_PAYLOAD_NAMES:
+            destination = temporary / name
+            shutil.copyfile(source_dir / name, destination)
+            os.chmod(destination, 0o755 if name == CLI_NAME else 0o644)
+        checksum_lines = [
             f"{_sha256(temporary / name)}  {name}"
-            for name in (SETUP_NAME, CANDIDATE_ZIP_NAME)
-        )
+            for name in sorted(PUBLIC_PAYLOAD_NAMES)
+        ]
         (temporary / CHECKSUMS_NAME).write_text(
             "\n".join(checksum_lines) + "\n",
             encoding="ascii",
         )
-        verify_public_assets(temporary, expected_commit)
+        verify_public_assets(temporary, expected_commit, source_dir)
         if output_dir.exists():
             output_dir.rmdir()
         temporary.rename(output_dir)
     except Exception:
         shutil.rmtree(temporary, ignore_errors=True)
         raise
-    verify_public_assets(output_dir, expected_commit)
+    verify_public_assets(output_dir, expected_commit, source_dir)
     return output_dir
 
 
@@ -243,14 +376,18 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
     assemble = subparsers.add_parser("assemble", help="assemble fixed public prerelease assets")
-    assemble.add_argument("--candidate-dir", type=Path, required=True)
+    assemble.add_argument("--macos-candidate-dir", type=Path, required=True)
+    assemble.add_argument("--windows-candidate-dir", type=Path, required=True)
+    assemble.add_argument("--source-dir", type=Path, required=True)
     assemble.add_argument("--output-dir", type=Path, required=True)
     assemble.add_argument("--release-tag", required=True)
     assemble.add_argument("--expected-commit", required=True)
     assemble.set_defaults(
         handler=lambda args: print(
             assemble_prerelease(
-                args.candidate_dir,
+                args.macos_candidate_dir,
+                args.windows_candidate_dir,
+                args.source_dir,
                 args.output_dir,
                 args.release_tag,
                 args.expected_commit,
@@ -259,9 +396,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     verify = subparsers.add_parser("verify", help="verify the fixed public asset set")
     verify.add_argument("output_dir", type=Path)
-    verify.add_argument("--expected-commit")
+    verify.add_argument("--expected-commit", required=True)
+    verify.add_argument("--source-dir", type=Path)
     verify.set_defaults(
-        handler=lambda args: verify_public_assets(args.output_dir, args.expected_commit)
+        handler=lambda args: verify_public_assets(
+            args.output_dir,
+            args.expected_commit,
+            args.source_dir,
+        )
     )
     return parser
 
@@ -270,7 +412,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         args = build_parser().parse_args(argv)
         args.handler(args)
-    except PrereleaseError as exc:
+    except (OSError, zipfile.BadZipFile, PrereleaseError) as exc:
         print(f"desktop prerelease packaging failed: {exc}", file=sys.stderr)
         return 1
     return 0

--- a/scripts/validate_desktop_candidate.py
+++ b/scripts/validate_desktop_candidate.py
@@ -184,9 +184,9 @@ def _validate_workflow_policy(path: Path, sidecar_basename: str) -> None:
     for label, pattern in forbidden_patterns.items():
         if re.search(pattern, text, re.I | re.M):
             raise CandidateError(f"{path} contains forbidden {label}")
-    publish_marker = "\n  publish-windows-prerelease:\n"
+    publish_marker = "\n  publish-desktop-prerelease:\n"
     if publish_marker not in text:
-        raise CandidateError(f"{path} is missing the Windows prerelease publisher job")
+        raise CandidateError(f"{path} is missing the desktop prerelease publisher job")
     candidate_section, publish_section = text.split(publish_marker, 1)
     if "contents: write" in candidate_section:
         raise CandidateError(f"{path} grants write permission outside the publisher job")
@@ -195,11 +195,12 @@ def _validate_workflow_policy(path: Path, sidecar_basename: str) -> None:
     publish_required = (
         "github.event_name == 'workflow_dispatch'",
         "github.ref == 'refs/heads/main'",
-        "inputs.publish_windows_prerelease == true",
+        "inputs.publish_desktop_prerelease == true",
         "needs:\n      - candidate",
         "runs-on: ubuntu-24.04",
         "permissions:\n      contents: write",
         "actions/download-artifact@",
+        "codex-keysmith-desktop-macos-arm64-${{ github.sha }}",
         "codex-keysmith-desktop-windows-x64-${{ github.sha }}",
         "verify-manifest-data",
         "desktop-v0\\.2\\.0-beta\\.[1-9][0-9]*",
@@ -209,9 +210,18 @@ def _validate_workflow_policy(path: Path, sidecar_basename: str) -> None:
         ".verification.verified",
         ".verification.reason",
         "package_desktop_prerelease.py assemble",
+        '--macos-candidate-dir "$RUNNER_TEMP/macos-candidate"',
+        '--windows-candidate-dir "$RUNNER_TEMP/windows-candidate"',
+        '--source-dir "$source_first"',
         '--expected-commit "$expected_commit"',
+        'scripts/build_release.py "$source_tag"',
+        "codex-keysmith-0.2.0-macos-arm64-unsigned.dmg",
+        "codex-keysmith-0.2.0-macos-arm64-unsigned-candidate.zip",
         "codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe",
         "codex-keysmith-0.2.0-windows-x64-unsigned-candidate.zip",
+        "codex-instruct-v0.2.0.py",
+        "codex-keysmith-v0.2.0.zip",
+        "codex-keysmith-v0.2.0.tar.gz",
         '"draft": True',
         '"prerelease": True',
         '"make_latest": "false"',
@@ -219,8 +229,9 @@ def _validate_workflow_policy(path: Path, sidecar_basename: str) -> None:
         'gh api -X PATCH "$release_api"',
         'gh api -X DELETE "$release_api"',
         "Recovered numeric-ID ownership after a lost create response.",
+        'release_author="github-actions[bot]"',
         "Release ${tag} already exists; refusing to overwrite it.",
-        "len(state[\"assets\"]) == 3",
+        "len(state[\"assets\"]) == 8",
         ".assets[] | [.name, .digest, .state, (.size | tostring)]",
     )
     publish_missing = [marker for marker in publish_required if marker not in publish_section]
@@ -243,7 +254,7 @@ def _validate_workflow_policy(path: Path, sidecar_basename: str) -> None:
         "workflow_dispatch:",
         "release_tag:",
         "expected_commit:",
-        "publish_windows_prerelease:",
+        "publish_desktop_prerelease:",
         "pull_request:",
         "contents: read",
         "macos-15",

--- a/tests/test_desktop_candidate.py
+++ b/tests/test_desktop_candidate.py
@@ -32,7 +32,7 @@ on:
         type: string
       expected_commit:
         type: string
-      publish_windows_prerelease:
+      publish_desktop_prerelease:
         type: boolean
   pull_request:
 permissions:
@@ -65,17 +65,20 @@ jobs:
         with:
           retention-days: 14
 
-  publish-windows-prerelease:
+  publish-desktop-prerelease:
     if: >-
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main' &&
-      inputs.publish_windows_prerelease == true
+      inputs.publish_desktop_prerelease == true
     needs:
       - candidate
     runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
+      - uses: actions/download-artifact@0123456789012345678901234567890123456789
+        with:
+          name: codex-keysmith-desktop-macos-arm64-${{ github.sha }}
       - uses: actions/download-artifact@0123456789012345678901234567890123456789
         with:
           name: codex-keysmith-desktop-windows-x64-${{ github.sha }}
@@ -86,16 +89,26 @@ jobs:
           echo 'git/ref/heads/main git/ref/tags/${RELEASE_TAG}'
           echo '.verification.verified .verification.reason'
           echo 'package_desktop_prerelease.py assemble'
+          echo '--macos-candidate-dir "$RUNNER_TEMP/macos-candidate"'
+          echo '--windows-candidate-dir "$RUNNER_TEMP/windows-candidate"'
+          echo '--source-dir "$source_first"'
           echo '--expected-commit "$expected_commit"'
+          echo 'scripts/build_release.py "$source_tag"'
+          echo codex-keysmith-0.2.0-macos-arm64-unsigned.dmg
+          echo codex-keysmith-0.2.0-macos-arm64-unsigned-candidate.zip
           echo codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe
           echo codex-keysmith-0.2.0-windows-x64-unsigned-candidate.zip
+          echo codex-instruct-v0.2.0.py
+          echo codex-keysmith-v0.2.0.zip
+          echo codex-keysmith-v0.2.0.tar.gz
           echo '"draft": True "prerelease": True "make_latest": "false"'
           echo 'gh api -X POST "repos/${GITHUB_REPOSITORY}/releases"'
           echo 'gh api -X PATCH "$release_api"'
           echo 'gh api -X DELETE "$release_api"'
           echo 'Recovered numeric-ID ownership after a lost create response.'
+          echo 'release_author="github-actions[bot]"'
           echo 'Release ${tag} already exists; refusing to overwrite it.'
-          echo 'len(state["assets"]) == 3'
+          echo 'len(state["assets"]) == 8'
           echo '.assets[] | [.name, .digest, .state, (.size | tostring)]'
           echo '"tag_name": tag "target_commitish": commit "body": Path(notes_path).read_text(encoding="utf-8") "make_latest": "false"'
           echo '"tag_name": tag "target_commitish": commit "body": Path(notes_path).read_text(encoding="utf-8") "make_latest": "false"'
@@ -237,7 +250,7 @@ def test_validate_config_accepts_package_json_version_source(tmp_path):
             "outside the publisher job",
         ),
         (
-            lambda text: text.replace("inputs.publish_windows_prerelease == true", "true"),
+            lambda text: text.replace("inputs.publish_desktop_prerelease == true", "true"),
             "publisher markers",
         ),
         (

--- a/tests/test_desktop_prerelease.py
+++ b/tests/test_desktop_prerelease.py
@@ -13,7 +13,7 @@ import pytest
 from scripts import package_desktop_prerelease as prerelease
 
 COMMIT = "a" * 40
-TAG = "desktop-v0.2.0-beta.2"
+TAG = "desktop-v0.2.0-beta.3"
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -30,21 +30,55 @@ def _pe_binary() -> bytes:
     return bytes(data)
 
 
+def _macho_binary() -> bytes:
+    return b"\xcf\xfa\xed\xfe" + struct.pack("<I", 0x0100000C) + bytes(32)
+
+
 def _write_ico(path: Path) -> None:
     path.write_bytes(struct.pack("<HHH", 0, 1, 1) + bytes(16))
 
 
-def _candidate(tmp_path: Path) -> Path:
-    candidate = tmp_path / "candidate"
+def _write_icns(path: Path) -> None:
+    path.write_bytes(b"icns" + struct.pack(">I", 8))
+
+
+def _candidate(tmp_path: Path, platform: str) -> Path:
+    candidate = tmp_path / platform
     candidate.mkdir(parents=True)
-    bundle = candidate / "codex-keysmith_0.2.0_x64-setup.exe"
-    app = candidate / "codex-keysmith-gui.exe"
-    sidecar = candidate / "codex-keysmith-cli.exe"
-    icon = candidate / "icon.ico"
-    bundle.write_bytes(b"unsigned nsis installer")
-    app.write_bytes(_pe_binary())
-    sidecar.write_bytes(_pe_binary() + b"sidecar")
-    _write_ico(icon)
+    if platform == "windows":
+        bundle = candidate / "codex-keysmith_0.2.0_x64-setup.exe"
+        app = candidate / "codex-keysmith-gui.exe"
+        sidecar = candidate / "codex-keysmith-cli.exe"
+        icon = candidate / "icon.ico"
+        architecture = "x86_64"
+        target = {
+            "platform": "windows",
+            "architecture": architecture,
+            "triple": "x86_64-pc-windows-msvc",
+            "bundle_format": "nsis",
+            "signing_mode": "unsigned",
+        }
+        bundle.write_bytes(b"unsigned nsis installer")
+        app.write_bytes(_pe_binary())
+        sidecar.write_bytes(_pe_binary() + b"sidecar")
+        _write_ico(icon)
+    else:
+        bundle = candidate / "codex-keysmith_0.2.0_aarch64.dmg"
+        app = candidate / "codex-keysmith-gui"
+        sidecar = candidate / "codex-keysmith-cli"
+        icon = candidate / "icon.icns"
+        architecture = "arm64"
+        target = {
+            "platform": "macos",
+            "architecture": architecture,
+            "triple": "aarch64-apple-darwin",
+            "bundle_format": "dmg",
+            "signing_mode": "unsigned",
+        }
+        bundle.write_bytes(b"unsigned dmg")
+        app.write_bytes(_macho_binary())
+        sidecar.write_bytes(_macho_binary() + b"sidecar")
+        _write_icns(icon)
 
     def record(path: Path, architecture: str | None = None) -> dict[str, object]:
         value: dict[str, object] = {
@@ -63,20 +97,14 @@ def _candidate(tmp_path: Path) -> Path:
         "desktop_version": "0.2.0",
         "cli_version": "0.2.0",
         "source_commit": COMMIT,
-        "target": {
-            "platform": "windows",
-            "architecture": "x86_64",
-            "triple": "x86_64-pc-windows-msvc",
-            "bundle_format": "nsis",
-            "signing_mode": "unsigned",
-        },
+        "target": target,
         "toolchain": {
             "node": "22.14.0",
             "python": "3.12.9",
             "pyinstaller": "6.16.0",
             "rust": "1.88.0",
         },
-        "sidecar_version_output": "codex-keysmith-cli.exe 0.2.0",
+        "sidecar_version_output": f"{sidecar.name} 0.2.0",
         "sidecar_provenance": {
             "source_sha256": sidecar_hash,
             "packaged_sha256": sidecar_hash,
@@ -84,8 +112,8 @@ def _candidate(tmp_path: Path) -> Path:
         },
         "artifacts": {
             "bundle": record(bundle),
-            "app_executable": record(app, "x86_64"),
-            "sidecar": record(sidecar, "x86_64"),
+            "app_executable": record(app, architecture),
+            "sidecar": record(sidecar, architecture),
             "icon": record(icon),
         },
     }
@@ -104,6 +132,41 @@ def _candidate(tmp_path: Path) -> Path:
     return candidate
 
 
+def _source_assets(tmp_path: Path) -> Path:
+    source = tmp_path / "source"
+    source.mkdir(parents=True)
+    (source / prerelease.CLI_NAME).write_text(
+        '#!/usr/bin/env python3\n__version__ = "0.2.0"\n',
+        encoding="utf-8",
+    )
+    (source / prerelease.SOURCE_ZIP_NAME).write_bytes(b"deterministic source zip")
+    (source / prerelease.SOURCE_TAR_NAME).write_bytes(b"deterministic source tar")
+    checksum_lines = [
+        f"{_sha256(source / name)}  {name}"
+        for name in sorted(prerelease.SOURCE_PAYLOAD_NAMES)
+    ]
+    (source / prerelease.CHECKSUMS_NAME).write_text(
+        "\n".join(checksum_lines) + "\n",
+        encoding="ascii",
+    )
+    return source
+
+
+def _assemble(tmp_path: Path, output_name: str = "out") -> tuple[Path, Path, Path, Path]:
+    macos = _candidate(tmp_path / "candidates", "macos")
+    windows = _candidate(tmp_path / "candidates", "windows")
+    source = _source_assets(tmp_path)
+    output = prerelease.assemble_prerelease(
+        macos,
+        windows,
+        source,
+        tmp_path / output_name,
+        TAG,
+        COMMIT,
+    )
+    return output, macos, windows, source
+
+
 def _mutate_manifest(candidate: Path, callback) -> None:
     path = candidate / "build-manifest.json"
     manifest = json.loads(path.read_text(encoding="utf-8"))
@@ -112,39 +175,50 @@ def _mutate_manifest(candidate: Path, callback) -> None:
 
 
 def _rewrite_public_checksums(output: Path) -> None:
-    lines = sorted(
+    lines = [
         f"{_sha256(output / name)}  {name}"
-        for name in (prerelease.SETUP_NAME, prerelease.CANDIDATE_ZIP_NAME)
-    )
+        for name in sorted(prerelease.PUBLIC_PAYLOAD_NAMES)
+    ]
     (output / prerelease.CHECKSUMS_NAME).write_text(
         "\n".join(lines) + "\n",
         encoding="ascii",
     )
 
 
-def test_assemble_creates_exact_public_assets_and_candidate_zip(tmp_path):
-    candidate = _candidate(tmp_path)
-    output = prerelease.assemble_prerelease(candidate, tmp_path / "out", TAG, COMMIT)
+def test_assemble_creates_exact_public_assets_and_candidate_zips(tmp_path):
+    output, macos, windows, source = _assemble(tmp_path)
 
     assert {path.name for path in output.iterdir()} == set(prerelease.PUBLIC_ASSET_NAMES)
-    assert (output / prerelease.SETUP_NAME).read_bytes() == (
-        candidate / "codex-keysmith_0.2.0_x64-setup.exe"
+    assert (output / prerelease.MACOS_DMG_NAME).read_bytes() == (
+        macos / "codex-keysmith_0.2.0_aarch64.dmg"
     ).read_bytes()
-    prerelease.verify_public_assets(output)
-    with zipfile.ZipFile(output / prerelease.CANDIDATE_ZIP_NAME) as archive:
-        assert archive.namelist() == sorted(path.name for path in candidate.iterdir())
-        for source in candidate.iterdir():
-            assert archive.read(source.name) == source.read_bytes()
+    assert (output / prerelease.WINDOWS_SETUP_NAME).read_bytes() == (
+        windows / "codex-keysmith_0.2.0_x64-setup.exe"
+    ).read_bytes()
+    for name in prerelease.SOURCE_PAYLOAD_NAMES:
+        assert (output / name).read_bytes() == (source / name).read_bytes()
+    prerelease.verify_public_assets(output, COMMIT, source)
+    for candidate, zip_name in (
+        (macos, prerelease.MACOS_CANDIDATE_ZIP_NAME),
+        (windows, prerelease.WINDOWS_CANDIDATE_ZIP_NAME),
+    ):
+        with zipfile.ZipFile(output / zip_name) as archive:
+            assert archive.namelist() == sorted(path.name for path in candidate.iterdir())
+            for candidate_file in candidate.iterdir():
+                assert archive.read(candidate_file.name) == candidate_file.read_bytes()
 
 
 def test_candidate_zip_is_reproducible(tmp_path):
-    candidate = _candidate(tmp_path)
-    first = prerelease.assemble_prerelease(candidate, tmp_path / "first", TAG, COMMIT)
-    second = prerelease.assemble_prerelease(candidate, tmp_path / "second", TAG, COMMIT)
+    first, macos, windows, source = _assemble(tmp_path, "first")
+    second = prerelease.assemble_prerelease(
+        macos, windows, source, tmp_path / "second", TAG, COMMIT
+    )
 
-    assert (first / prerelease.CANDIDATE_ZIP_NAME).read_bytes() == (
-        second / prerelease.CANDIDATE_ZIP_NAME
-    ).read_bytes()
+    for name in (
+        prerelease.MACOS_CANDIDATE_ZIP_NAME,
+        prerelease.WINDOWS_CANDIDATE_ZIP_NAME,
+    ):
+        assert (first / name).read_bytes() == (second / name).read_bytes()
     assert (first / prerelease.CHECKSUMS_NAME).read_bytes() == (
         second / prerelease.CHECKSUMS_NAME
     ).read_bytes()
@@ -159,10 +233,14 @@ def test_candidate_zip_is_reproducible(tmp_path):
     ],
 )
 def test_assemble_rejects_invalid_identity(tmp_path, tag, commit, message):
-    candidate = _candidate(tmp_path)
+    macos = _candidate(tmp_path, "macos")
+    windows = _candidate(tmp_path, "windows")
+    source = _source_assets(tmp_path)
 
     with pytest.raises(prerelease.PrereleaseError, match=message):
-        prerelease.assemble_prerelease(candidate, tmp_path / "out", tag, commit)
+        prerelease.assemble_prerelease(
+            macos, windows, source, tmp_path / "out", tag, commit
+        )
 
 
 @pytest.mark.parametrize(
@@ -170,10 +248,10 @@ def test_assemble_rejects_invalid_identity(tmp_path, tag, commit, message):
     [
         (lambda value: value.update(source_commit="b" * 40), "source commit"),
         (lambda value: value.update(desktop_version="0.2.1"), "versions"),
-        (lambda value: value["target"].update(platform="macos"), "unsigned Windows"),
-        (lambda value: value["target"].update(architecture="arm64"), "unsigned Windows"),
-        (lambda value: value["target"].update(bundle_format="msi"), "unsigned Windows"),
-        (lambda value: value["target"].update(signing_mode="signed"), "unsigned Windows"),
+        (lambda value: value["target"].update(platform="macos"), "windows target policy"),
+        (lambda value: value["target"].update(architecture="arm64"), "windows target policy"),
+        (lambda value: value["target"].update(bundle_format="msi"), "windows target policy"),
+        (lambda value: value["target"].update(signing_mode="signed"), "windows target policy"),
         (
             lambda value: value["sidecar_provenance"].update(relation="signed-build-output"),
             "exact tested build output",
@@ -181,85 +259,132 @@ def test_assemble_rejects_invalid_identity(tmp_path, tag, commit, message):
     ],
 )
 def test_assemble_rejects_manifest_policy_drift(tmp_path, mutation, message):
-    candidate = _candidate(tmp_path)
-    _mutate_manifest(candidate, mutation)
+    macos = _candidate(tmp_path, "macos")
+    windows = _candidate(tmp_path, "windows")
+    source = _source_assets(tmp_path)
+    _mutate_manifest(windows, mutation)
 
     with pytest.raises(prerelease.PrereleaseError, match=message):
-        prerelease.assemble_prerelease(candidate, tmp_path / "out", TAG, COMMIT)
+        prerelease.assemble_prerelease(
+            macos, windows, source, tmp_path / "out", TAG, COMMIT
+        )
+
+
+def test_assemble_rejects_cross_platform_candidate_swap(tmp_path):
+    macos = _candidate(tmp_path, "macos")
+    windows = _candidate(tmp_path, "windows")
+    source = _source_assets(tmp_path)
+
+    with pytest.raises(prerelease.PrereleaseError, match="macos target policy"):
+        prerelease.assemble_prerelease(
+            windows, macos, source, tmp_path / "out", TAG, COMMIT
+        )
 
 
 def test_assemble_rejects_tampering_extra_files_symlinks_and_overwrite(tmp_path):
-    tampered = _candidate(tmp_path / "tampered")
+    macos = _candidate(tmp_path / "tampered", "macos")
+    tampered = _candidate(tmp_path / "tampered", "windows")
+    source = _source_assets(tmp_path / "tampered")
     (tampered / "codex-keysmith-cli.exe").write_bytes(b"tampered")
     with pytest.raises(prerelease.PrereleaseError, match="hash or size mismatch"):
-        prerelease.assemble_prerelease(tampered, tmp_path / "tampered-out", TAG, COMMIT)
+        prerelease.assemble_prerelease(
+            macos, tampered, source, tmp_path / "tampered-out", TAG, COMMIT
+        )
 
-    extra = _candidate(tmp_path / "extra")
+    macos = _candidate(tmp_path / "extra", "macos")
+    extra = _candidate(tmp_path / "extra", "windows")
+    source = _source_assets(tmp_path / "extra")
     (extra / "unexpected.txt").write_text("unexpected", encoding="utf-8")
     with pytest.raises(prerelease.PrereleaseError, match="file set is not exact"):
-        prerelease.assemble_prerelease(extra, tmp_path / "extra-out", TAG, COMMIT)
+        prerelease.assemble_prerelease(
+            macos, extra, source, tmp_path / "extra-out", TAG, COMMIT
+        )
 
-    linked = _candidate(tmp_path / "linked")
+    macos = _candidate(tmp_path / "linked", "macos")
+    linked = _candidate(tmp_path / "linked", "windows")
+    source = _source_assets(tmp_path / "linked")
     icon = linked / "icon.ico"
     icon.unlink()
     icon.symlink_to(linked / "codex-keysmith-cli.exe")
     with pytest.raises(prerelease.PrereleaseError, match="not a symlink"):
-        prerelease.assemble_prerelease(linked, tmp_path / "linked-out", TAG, COMMIT)
+        prerelease.assemble_prerelease(
+            macos, linked, source, tmp_path / "linked-out", TAG, COMMIT
+        )
 
-    real_candidate = _candidate(tmp_path / "linked-directory")
+    macos = _candidate(tmp_path / "linked-directory", "macos")
+    real_candidate = _candidate(tmp_path / "linked-directory", "windows")
+    source = _source_assets(tmp_path / "linked-directory")
     candidate_link = tmp_path / "candidate-link"
     candidate_link.symlink_to(real_candidate, target_is_directory=True)
     with pytest.raises(prerelease.PrereleaseError, match="missing or unsafe"):
         prerelease.assemble_prerelease(
+            macos,
             candidate_link,
+            source,
             tmp_path / "linked-directory-out",
             TAG,
             COMMIT,
         )
 
-    candidate = _candidate(tmp_path / "overwrite")
+    macos = _candidate(tmp_path / "overwrite", "macos")
+    windows = _candidate(tmp_path / "overwrite", "windows")
+    source = _source_assets(tmp_path / "overwrite")
     output = tmp_path / "existing-output"
     output.mkdir()
     (output / "keep.txt").write_text("keep", encoding="utf-8")
     with pytest.raises(prerelease.PrereleaseError, match="absent or empty"):
-        prerelease.assemble_prerelease(candidate, output, TAG, COMMIT)
+        prerelease.assemble_prerelease(macos, windows, source, output, TAG, COMMIT)
     assert (output / "keep.txt").read_text(encoding="utf-8") == "keep"
+
+    macos = _candidate(tmp_path / "bad-source", "macos")
+    windows = _candidate(tmp_path / "bad-source", "windows")
+    source = _source_assets(tmp_path / "bad-source")
+    (source / prerelease.CLI_NAME).write_text("tampered", encoding="utf-8")
+    with pytest.raises(prerelease.PrereleaseError, match="source SHA256SUMS"):
+        prerelease.assemble_prerelease(
+            macos, windows, source, tmp_path / "bad-source-out", TAG, COMMIT
+        )
 
 
 def test_verify_public_assets_rejects_tampering_and_extra_assets(tmp_path):
-    candidate = _candidate(tmp_path)
-    output = prerelease.assemble_prerelease(candidate, tmp_path / "out", TAG, COMMIT)
+    output, _macos, _windows, _source = _assemble(tmp_path)
     with pytest.raises(prerelease.PrereleaseError, match="source commit"):
         prerelease.verify_public_assets(output, "b" * 40)
-    (output / prerelease.SETUP_NAME).write_bytes(b"tampered")
+    (output / prerelease.WINDOWS_SETUP_NAME).write_bytes(b"tampered")
 
     with pytest.raises(prerelease.PrereleaseError, match="SHA256SUMS"):
-        prerelease.verify_public_assets(output)
+        prerelease.verify_public_assets(output, COMMIT)
 
     _rewrite_public_checksums(output)
-    with pytest.raises(prerelease.PrereleaseError, match="does not match the original installer"):
-        prerelease.verify_public_assets(output)
+    with pytest.raises(prerelease.PrereleaseError, match="public windows bundle"):
+        prerelease.verify_public_assets(output, COMMIT)
 
-    output = prerelease.assemble_prerelease(candidate, tmp_path / "out-zip", TAG, COMMIT)
+    output, _macos, _windows, _source = _assemble(tmp_path / "zip-case")
     extracted = tmp_path / "tampered-zip"
     extracted.mkdir()
-    with zipfile.ZipFile(output / prerelease.CANDIDATE_ZIP_NAME) as archive:
+    with zipfile.ZipFile(output / prerelease.WINDOWS_CANDIDATE_ZIP_NAME) as archive:
         for name in archive.namelist():
             (extracted / name).write_bytes(archive.read(name))
     (extracted / "codex-keysmith-cli.exe").write_bytes(b"tampered sidecar")
-    (output / prerelease.CANDIDATE_ZIP_NAME).unlink()
+    (output / prerelease.WINDOWS_CANDIDATE_ZIP_NAME).unlink()
     prerelease._write_deterministic_zip(
         extracted,
-        output / prerelease.CANDIDATE_ZIP_NAME,
+        output / prerelease.WINDOWS_CANDIDATE_ZIP_NAME,
     )
     _rewrite_public_checksums(output)
     with pytest.raises(prerelease.PrereleaseError, match="hash or size mismatch"):
-        prerelease.verify_public_assets(output)
+        prerelease.verify_public_assets(output, COMMIT)
 
-    output = prerelease.assemble_prerelease(candidate, tmp_path / "out-2", TAG, COMMIT)
+    output, _macos, _windows, source = _assemble(tmp_path / "source-case")
+    (output / prerelease.CLI_NAME).write_text("tampered", encoding="utf-8")
+    _rewrite_public_checksums(output)
+    with pytest.raises(prerelease.PrereleaseError, match="commit-bound build output"):
+        prerelease.verify_public_assets(output, COMMIT, source)
+
+    output, _macos, _windows, _source = _assemble(tmp_path / "extra-case")
     (output / "unexpected.txt").write_text("unexpected", encoding="utf-8")
     with pytest.raises(prerelease.PrereleaseError, match="asset set is not exact"):
-        prerelease.verify_public_assets(output)
+        prerelease.verify_public_assets(output, COMMIT)
 
 
 def test_prerelease_workflow_is_separate_unsigned_and_main_only():
@@ -272,13 +397,25 @@ def test_prerelease_workflow_is_separate_unsigned_and_main_only():
     assert "pull_request_target:" not in desktop
     assert "workflow_run:" not in desktop
     assert desktop.count("contents: write") == 1
-    assert "inputs.publish_windows_prerelease == true" in desktop
+    assert "inputs.publish_desktop_prerelease == true" in desktop
     assert "github.ref == 'refs/heads/main'" in desktop
     assert "verify-manifest-data" in desktop
     assert '"prerelease": True' in desktop
     assert '"make_latest": "false"' in desktop
     assert "latest_after" in desktop and "latest_before" in desktop
+    assert "latestRelease{tagName}" in desktop
+    assert "__NO_LATEST_RELEASE__" in desktop
+    assert 'releases/latest" --jq .tag_name' not in desktop
+    assert "create_attempted=true" in desktop
+    assert "Removed the uniquely owned empty Draft" in desktop
     assert "Recovered numeric-ID ownership after a lost create response." in desktop
+    assert 'release_author="github-actions[bot]"' in desktop
+    final_state = desktop.index(
+        'final_state="${RUNNER_TEMP}/desktop-prerelease-published.json"'
+    )
+    assert desktop.index("verify_remote_tag", final_state) < desktop.index(
+        "latest_after", final_state
+    )
     assert "--clobber" not in desktop
     assert 'tags:\n      - "v*.*.*"' in stable
     assert 'expected_tag="v${version}"' in stable
@@ -300,7 +437,7 @@ def test_prerelease_creation_validator_binds_numeric_id_and_unsigned_metadata(
 
     repo = "Jia-Ethan/codex-keysmith"
     release_id = "400000001"
-    draft_name = "codex-keysmith 0.2.0 Windows x64 unsigned Beta [run 123.1]"
+    draft_name = "codex-keysmith 0.2.0 Desktop Beta [run 123.1]"
     notes = tmp_path / "notes.md"
     notes.write_bytes(b"unsigned beta notes\n")
     payload = {
@@ -357,7 +494,7 @@ def test_lost_create_response_recovery_requires_unique_run_owned_draft(
     workflow = (REPO_ROOT / ".github/workflows/desktop-candidate.yml").read_text(
         encoding="utf-8"
     )
-    marker = 'adopted_state="${RUNNER_TEMP}/desktop-prerelease-adopted.json"'
+    marker = 'owned_draft_validator="${RUNNER_TEMP}/validate-owned-desktop-draft.py"'
     validator_start = workflow.index("          import json\n", workflow.index(marker))
     validator_end = workflow.index("\n          PY", validator_start)
     validator = textwrap.dedent(workflow[validator_start:validator_end])
@@ -365,9 +502,9 @@ def test_lost_create_response_recovery_requires_unique_run_owned_draft(
     notes.write_text("unsigned beta notes\n", encoding="utf-8")
     source = tmp_path / "releases.json"
     output = tmp_path / "adopted.json"
-    actor = "Jaaay50"
+    actor = "github-actions[bot]"
     started_at = "2026-08-10T01:00:00Z"
-    draft_name = "codex-keysmith 0.2.0 Windows x64 unsigned Beta [run 123.1]"
+    draft_name = "codex-keysmith 0.2.0 Desktop Beta [run 123.1]"
     release = {
         "id": 400000002,
         "tag_name": TAG,
@@ -382,7 +519,7 @@ def test_lost_create_response_recovery_requires_unique_run_owned_draft(
     }
 
     def run(releases):
-        source.write_text(json.dumps([releases]), encoding="utf-8")
+        source.write_text(json.dumps(releases), encoding="utf-8")
         monkeypatch.setattr(
             sys,
             "argv",
@@ -400,19 +537,25 @@ def test_lost_create_response_recovery_requires_unique_run_owned_draft(
         )
         exec(compile(validator, "<lost-create-recovery>", "exec"), {})
 
-    run([release])
+    run([[release]])
+    assert json.loads(output.read_text(encoding="utf-8"))["id"] == release["id"]
+    run(release)
     assert json.loads(output.read_text(encoding="utf-8"))["id"] == release["id"]
     with pytest.raises(SystemExit, match="exactly one"):
-        run([dict(release, name="wrong")])
+        run([[dict(release, name="wrong")]])
     with pytest.raises(SystemExit, match="exactly one"):
-        run([release, dict(release, id=400000003)])
+        run([[release, dict(release, id=400000003)]])
+    with pytest.raises(SystemExit, match="exactly one"):
+        run([[dict(release, author={"login": "Jaaay50"})]])
+    with pytest.raises(SystemExit, match="unexpected shape"):
+        run(["not-a-release"])
 
 
 def test_prerelease_docs_disclose_assets_privacy_and_beta_boundaries():
     paths = [
         REPO_ROOT / "README.md",
         REPO_ROOT / "README.en.md",
-        REPO_ROOT / "docs/releases/desktop-v0.2.0-beta.2.md",
+        REPO_ROOT / "docs/releases/desktop-v0.2.0-beta.3.md",
         REPO_ROOT / "CODE_SIGNING_POLICY.md",
         REPO_ROOT / "PRIVACY.md",
     ]
@@ -420,19 +563,40 @@ def test_prerelease_docs_disclose_assets_privacy_and_beta_boundaries():
 
     for marker in (
         TAG,
-        prerelease.SETUP_NAME,
-        prerelease.CANDIDATE_ZIP_NAME,
+        prerelease.MACOS_DMG_NAME,
+        prerelease.MACOS_CANDIDATE_ZIP_NAME,
+        prerelease.WINDOWS_SETUP_NAME,
+        prerelease.WINDOWS_CANDIDATE_ZIP_NAME,
+        prerelease.CLI_NAME,
+        prerelease.SOURCE_ZIP_NAME,
+        prerelease.SOURCE_TAR_NAME,
         "SHA256SUMS",
         "unsigned",
         "SmartScreen",
+        "Gatekeeper",
+        "Apple Silicon",
         "Windows x64",
         "SignPath Foundation",
     ):
         assert marker in combined
     assert "不主动收集或上传用户数据" in combined
     assert "does not proactively collect or upload user data" in combined
-    assert "No physical Windows device" in combined
+    assert "physical-device acceptance" in combined
     assert "not SignPath-signed" in combined
+
+    release_notes = (REPO_ROOT / "docs/releases/desktop-v0.2.0-beta.3.md").read_text(
+        encoding="utf-8"
+    )
+    for marker in (
+        "未进行 Apple 签名或公证",
+        "未进行 Authenticode 签名",
+        "Gatekeeper",
+        "SmartScreen",
+        "实体设备验收",
+        "sha256sum --check SHA256SUMS",
+        "构建验证包，不是安装包",
+    ):
+        assert marker in release_notes
 
     readmes = "\n".join(
         (REPO_ROOT / name).read_text(encoding="utf-8")

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 import pytest
 
+from scripts import package_desktop_prerelease as desktop_prerelease
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BUILDER_PATH = REPO_ROOT / "scripts" / "build_release.py"
 TAG = "v0.2.0"
@@ -309,6 +311,18 @@ def test_standalone_script_and_checksums_match_assets(release_builder, tmp_path)
     assert set(checksums.values()) == expected_assets
     for digest, name in checksums.items():
         assert digest == _file_sha256(output_dir / name)
+
+
+def test_release_builder_output_is_accepted_by_desktop_prerelease_packager(
+    release_builder,
+    tmp_path,
+):
+    repo, _ = _make_release_repo(tmp_path, release_builder)
+    output_dir = tmp_path / "assets"
+
+    release_builder.build_release(TAG, repo, output_dir)
+
+    desktop_prerelease._validate_source_assets(output_dir)
 
 
 def test_default_in_repository_output_can_be_rebuilt(release_builder, tmp_path):


### PR DESCRIPTION
## 内容

- 统一发布 macOS Apple Silicon DMG 与 Windows x64 NSIS Desktop Beta
- 同步提供单文件 CLI、确定性源码归档、双平台 candidate ZIP 和统一 SHA256SUMS
- 加强提交、签名标签、双平台 manifest、Draft Release 与最终资产校验
- 修复源码校验排序及丢失 Release 创建响应时的安全恢复

## 验证

- Python：575 passed，22 skipped
- GUI：15 passed，production build 通过
- Rust：fmt、6 tests、clippy 通过
- Ruff、Actionlint、配置验证与 git diff --check 通过