### PR TITLE
发布修复 CLI 误报的桌面安装包

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,15 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ### Desktop prerelease
 
-- Prepared `desktop-v0.2.0-beta.3` as the unified unsigned Desktop Beta with an Apple Silicon macOS DMG, Windows x64 NSIS installer, standalone CLI, deterministic source archives, two platform candidate ZIPs, and one complete `SHA256SUMS`.
+- Prepared `desktop-v0.2.0-beta.4` as the unified unsigned Desktop Beta with an Apple Silicon macOS DMG, Windows x64 NSIS installer, standalone CLI, deterministic source archives, two platform candidate ZIPs, and one complete `SHA256SUMS`.
 - Extended the main-only manual publisher to bind both platform manifests, the signed annotated beta tag, current remote `main`, expected commit, draft Release, and all eight public assets before publication. Pull requests remain read-only and the candidate workflow contains no signing secrets.
-- `desktop-v0.2.0-beta.2` remains the earlier Windows-only prerelease. The signed `desktop-v0.2.0-beta.1` tag is retained after its draft publication aborted before asset upload; it has no public Release or assets. The application source remains `0.2.0`, and the formal signed release keeps the `v0.2.0` tag.
+- `desktop-v0.2.0-beta.3` remains the earlier unified desktop prerelease, and `desktop-v0.2.0-beta.2` remains the earlier Windows-only prerelease. The signed `desktop-v0.2.0-beta.1` tag is retained after its draft publication aborted before asset upload; it has no public Release or assets. The application source remains `0.2.0`, and the formal signed release keeps the `v0.2.0` tag.
 - Added code-signing and privacy policies. The application does not proactively collect or upload user data; SignPath Foundation review remains pending and the current beta is not SignPath-signed.
 - Desktop status is `Beta / unsigned / native-CI-validated`. CI builds both native candidates and installs, exercises, and uninstalls Windows in temporary directories, but no physical macOS or Windows device experience has been accepted.
 
 ### Fixed
 
+- Fixed the desktop startup flow so it no longer reports that the CLI is missing before CLI resolution finishes.
 - GitHub draft Release updates now resend the complete tag, target commit, name, notes, draft state, prerelease state, and Latest Release policy. A partial PATCH had reset the draft tag to GitHub's internal `untagged-*` placeholder; the fail-closed assertion removed that draft before any asset upload or public publication.
 
 ## [0.2.0] - 2026-08-09

--- a/README.en.md
+++ b/README.en.md
@@ -38,7 +38,7 @@ npm install
 npm run tauri dev
 ```
 
-- The unified source version is `0.2.0`. [`desktop-v0.2.0-beta.3`](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.2.0-beta.3) publishes the Apple Silicon macOS DMG, Windows x64 NSIS installer, standalone CLI, and deterministic source archives together.
+- The unified source version is `0.2.0`. [`desktop-v0.2.0-beta.4`](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.2.0-beta.4) publishes the Apple Silicon macOS DMG, Windows x64 NSIS installer, standalone CLI, and deterministic source archives together.
 - macOS users download `codex-keysmith-0.2.0-macos-arm64-unsigned.dmg`; Windows users download `codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe`. Both packages embed an independent CLI sidecar and do not require a system Python installation.
 - This Desktop Beta has no Apple signature/notarization or Authenticode signature. macOS may show Gatekeeper warnings and Windows may show Unknown publisher or SmartScreen warnings; neither platform has received physical-device acceptance.
 - The Windows package uses current-user NSIS and a silent WebView2 download bootstrapper. It does not provide MSI, ARM64, or a formal Windows support commitment; the underlying Windows CLI fresh-deployment path remains `EXPLICIT_BETA`.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm install
 npm run tauri dev
 ```
 
-- 当前统一源码版本为 `0.2.0`。[`desktop-v0.2.0-beta.3`](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.2.0-beta.3) 统一提供 macOS Apple Silicon DMG、Windows x64 NSIS、单文件 CLI 和确定性源码归档。
+- 当前统一源码版本为 `0.2.0`。[`desktop-v0.2.0-beta.4`](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.2.0-beta.4) 统一提供 macOS Apple Silicon DMG、Windows x64 NSIS、单文件 CLI 和确定性源码归档。
 - macOS 用户下载 `codex-keysmith-0.2.0-macos-arm64-unsigned.dmg`；Windows 用户下载 `codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe`。两个安装包都内置独立 CLI sidecar，使用时无需额外安装 Python。
 - 本次 Desktop Beta 未进行 Apple 签名/公证或 Authenticode 签名。macOS 可能触发 Gatekeeper，Windows 可能显示 Unknown publisher 或 SmartScreen 警告；两平台均未经过实体设备验收。
 - Windows 安装包使用 current-user NSIS 和静默 WebView2 download bootstrapper，不提供 MSI、ARM64 或正式 Windows 支持承诺。底层 Windows CLI fresh deployment 继续遵循 `EXPLICIT_BETA`。

--- a/docs/releases/desktop-v0.2.0-beta.4.md
+++ b/docs/releases/desktop-v0.2.0-beta.4.md
@@ -1,0 +1,10 @@
+# codex-keysmith v0.2.0 Desktop Beta
+
+修复了桌面端启动后误报“未找到 CLI”的问题。
+
+## 下载
+
+- macOS Apple Silicon：`codex-keysmith-0.2.0-macos-arm64-unsigned.dmg`
+- Windows x64：`codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe`
+- 单文件 CLI：`codex-instruct-v0.2.0.py`
+- 文件校验：`SHA256SUMS`

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -8,9 +8,10 @@ v0.2.0 将桌面客户端源码并入 canonical 仓库，并保持 Python CLI �
 
 - 新增 `gui/` 桌面客户端源码，使用 Tauri 2 + React，覆盖状态查看、强制预览门禁、部署、卸载、hooks 恢复、中断恢复、设置和中英双语界面。
 - CLI 与 GUI 源码统一为 `0.2.0`。manifest 与 journal schema 仍为 1，已有 v0.1.0-v0.1.3 部署无需迁移。
+- 桌面端启动时会等待当前 CLI 定位完成，不再在内置 CLI 或手动路径仍在验证时误报“未找到 CLI”。
 - PyInstaller frozen 模式生成 hooks 恢复命令时直接调用打包后的可执行文件，不再追加临时解包目录中的 Python 源文件路径；源码模式仍输出 `python + codex-instruct.py`。
 - 正式打包流程会原生构建 PyInstaller CLI sidecar 并放入应用包，最终用户无需单独安装 Python；开发模式和高级手动配置仍可回退到外部 `codex-instruct.py`。
-- `desktop-v0.2.0-beta.3` 统一公开 macOS Apple Silicon unsigned DMG、Windows x64 unsigned NSIS、单文件 CLI、确定性源码归档和完整 `SHA256SUMS`；两个平台 candidate ZIP 保留各自的 build manifest 与内部校验值。
+- `desktop-v0.2.0-beta.4` 统一公开 macOS Apple Silicon unsigned DMG、Windows x64 unsigned NSIS、单文件 CLI、确定性源码归档和完整 `SHA256SUMS`；两个平台 candidate ZIP 保留各自的 build manifest 与内部校验值。
 - macOS DMG 未进行 Apple 签名或公证，Windows 安装器未进行 Authenticode 签名；两者均为 `Beta / unsigned / native-CI-validated`，没有实体设备验收。底层 Windows CLI fresh deployment 仍为 `EXPLICIT_BETA`，不构成正式支持承诺。
 
 桌面客户端源码入口：<https://github.com/Jia-Ethan/codex-keysmith/tree/main/gui>
@@ -28,9 +29,10 @@ v0.2.0 brings the desktop client source into the canonical repository while keep
 
 - Adds the `gui/` desktop client source using Tauri 2 + React, with status, mandatory preview gates, deployment, uninstall, hooks restore, interrupted-operation recovery, settings, and bilingual UI flows.
 - Unifies the CLI and GUI source version at `0.2.0`. Manifest and journal schemas remain at 1, so deployments created by v0.1.0-v0.1.3 require no migration.
+- Desktop startup now waits for the active CLI resolution to finish instead of reporting that the CLI is missing while the bundled sidecar or a manual path is still being validated.
 - PyInstaller-frozen builds now generate hooks-restore commands that invoke the packaged executable directly instead of appending a Python source path inside the temporary extraction directory. Source mode continues to emit `python + codex-instruct.py`.
 - Packaged builds create a native PyInstaller CLI sidecar and include it in the application bundle, so end users do not need a separate Python installation. Development mode and advanced manual configuration retain the external `codex-instruct.py` fallback.
-- `desktop-v0.2.0-beta.3` publishes the Apple Silicon macOS unsigned DMG, Windows x64 unsigned NSIS installer, standalone CLI, deterministic source archives, and complete `SHA256SUMS` together; both platform candidate ZIPs retain their build manifests and internal checksums.
+- `desktop-v0.2.0-beta.4` publishes the Apple Silicon macOS unsigned DMG, Windows x64 unsigned NSIS installer, standalone CLI, deterministic source archives, and complete `SHA256SUMS` together; both platform candidate ZIPs retain their build manifests and internal checksums.
 - The DMG has no Apple signature or notarization, and the Windows installer has no Authenticode signature. Both remain `Beta / unsigned / native-CI-validated` without physical-device acceptance. Windows CLI fresh deployment remains `EXPLICIT_BETA`, not a formal support commitment.
 
 Desktop client source: <https://github.com/Jia-Ethan/codex-keysmith/tree/main/gui>

--- a/tests/test_desktop_prerelease.py
+++ b/tests/test_desktop_prerelease.py
@@ -13,7 +13,7 @@ import pytest
 from scripts import package_desktop_prerelease as prerelease
 
 COMMIT = "a" * 40
-TAG = "desktop-v0.2.0-beta.3"
+TAG = "desktop-v0.2.0-beta.4"
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -555,7 +555,7 @@ def test_prerelease_docs_disclose_assets_privacy_and_beta_boundaries():
     paths = [
         REPO_ROOT / "README.md",
         REPO_ROOT / "README.en.md",
-        REPO_ROOT / "docs/releases/desktop-v0.2.0-beta.3.md",
+        REPO_ROOT / "docs/releases/desktop-v0.2.0-beta.4.md",
         REPO_ROOT / "CODE_SIGNING_POLICY.md",
         REPO_ROOT / "PRIVACY.md",
     ]
@@ -589,14 +589,14 @@ def test_prerelease_docs_disclose_assets_privacy_and_beta_boundaries():
 
 
 def test_prerelease_release_notes_match_approved_compact_copy():
-    release_notes = (REPO_ROOT / "docs/releases/desktop-v0.2.0-beta.3.md").read_text(
+    release_notes = (REPO_ROOT / "docs/releases/desktop-v0.2.0-beta.4.md").read_text(
         encoding="utf-8"
     )
     expected = textwrap.dedent(
         """\
         # codex-keysmith v0.2.0 Desktop Beta
 
-        v0.2.0 在原有 CLI 基础上新增 macOS 和 Windows 桌面 GUI。
+        修复了桌面端启动后误报“未找到 CLI”的问题。
 
         ## 下载
 
@@ -604,15 +604,6 @@ def test_prerelease_release_notes_match_approved_compact_copy():
         - Windows x64：`codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe`
         - 单文件 CLI：`codex-instruct-v0.2.0.py`
         - 文件校验：`SHA256SUMS`
-
-        ## 更新内容
-
-        - 新增 macOS 和 Windows 桌面客户端。
-        - 支持状态查看、变更预览、部署、恢复、hooks 恢复和卸载。
-        - 新增中英双语界面和图形化设置。
-        - 安装包内置独立 CLI，使用时无需额外安装 Python。
-        - GUI 与 CLI 共用同一套部署和恢复逻辑，现有 CLI 参数保持不变。
-        - 继续兼容 v0.1.x 部署，无需迁移。
         """
     )
     assert release_notes == expected


### PR DESCRIPTION
发布包含桌面端 CLI 误报修复的 0.2.0-beta.4 安装包。