### PR TITLE
修复 Windows 桌面端状态解析失败

### DIFF
--- a/gui/src/i18n/en.json
+++ b/gui/src/i18n/en.json
@@ -94,6 +94,7 @@
     "previewFailed": "Preview failed; the flow is blocked",
     "previewTimeout": "Preview timed out; the flow is blocked",
     "previewEmpty": "The CLI produced no preview; the flow is blocked",
+    "previewUnrecognized": "The CLI preview format was not recognized; the flow is blocked",
     "confirmDeploy": "Confirm Deploy",
     "confirmHint": "This modifies config.toml and the prompt file in the target directory. The CLI backs up automatically.",
     "deploying": "Deploying…",

--- a/gui/src/i18n/zh-CN.json
+++ b/gui/src/i18n/zh-CN.json
@@ -94,6 +94,7 @@
     "previewFailed": "预览失败，流程已阻断",
     "previewTimeout": "预览超时，流程已阻断",
     "previewEmpty": "CLI 没有产出预览内容，流程已阻断",
+    "previewUnrecognized": "无法识别 CLI 预览格式，流程已阻断",
     "confirmDeploy": "确认部署",
     "confirmHint": "将修改目标目录下的 config.toml 与提示词文件，CLI 会自动备份。",
     "deploying": "正在部署…",

--- a/gui/src/lib/api.js
+++ b/gui/src/lib/api.js
@@ -69,9 +69,9 @@ export async function fetchStatus() {
 
   const output = await cliRun(args);
   // status 在目录存在 conflict/异常节点时也会非零退出，但 stdout 仍是完整
-  // 状态报告（SPEC §5.1）。只有连目录列表都没输出时才视为真失败。
+  // 状态报告（SPEC §5.1）。超时或连目录列表都没解析到时才视为真失败。
   const parsed = parseStatus(output.stdout);
-  if (output.exit_code !== 0 && parsed.directories.length === 0) {
+  if (output.timed_out || parsed.directories.length === 0) {
     throw new CliError(output);
   }
   return parsed;

--- a/gui/src/lib/api.test.js
+++ b/gui/src/lib/api.test.js
@@ -1,5 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
-import { resolveCli } from "./api.js";
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchStatus, resolveCli } from "./api.js";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+beforeEach(() => {
+  invoke.mockReset();
+});
 
 describe("resolveCli", () => {
   it("优先验证并使用已保存的手动 CLI 路径", async () => {
@@ -77,5 +84,45 @@ describe("resolveCli", () => {
     });
     expect(getVersion).not.toHaveBeenCalled();
     expect(getRuntime).not.toHaveBeenCalled();
+  });
+});
+
+describe("fetchStatus", () => {
+  it("exit 0 但非空报告不可识别时失败关闭", async () => {
+    invoke.mockResolvedValue({
+      stdout: "[Status] Output contract changed unexpectedly.\r\n",
+      stderr: "",
+      exit_code: 0,
+      timed_out: false,
+    });
+
+    await expect(fetchStatus()).rejects.toThrow("Output contract changed");
+  });
+
+  it("非零退出但已解析到完整目录报告时保留诊断状态", async () => {
+    invoke.mockResolvedValue({
+      stdout: "── Status directory: C:\\Users\\Administrator\\.codex ──\r\n    Config activation: conflict\r\n",
+      stderr: "",
+      exit_code: 1,
+      timed_out: false,
+    });
+
+    await expect(fetchStatus()).resolves.toMatchObject({
+      directories: [{
+        path: "C:\\Users\\Administrator\\.codex",
+        activation: "conflict",
+      }],
+    });
+  });
+
+  it("超时即使已有部分可解析报告也失败", async () => {
+    invoke.mockResolvedValue({
+      stdout: "── Status directory: C:\\Users\\Administrator\\.codex ──\r\n",
+      stderr: "status timed out",
+      exit_code: -1,
+      timed_out: true,
+    });
+
+    await expect(fetchStatus()).rejects.toThrow("status timed out");
   });
 });

--- a/gui/src/lib/parser.js
+++ b/gui/src/lib/parser.js
@@ -20,6 +20,21 @@ const NODE_NAME_MAP = {
   "deployment manifest": "manifest",
 };
 
+const MANAGEMENT_PREVIEW_SENTINELS = new Set([
+  "[Preview] No files were changed; add --yes to confirm uninstall.",
+  "[Preview] No files were changed; add --yes to confirm recovery.",
+  "[Preview] No files were changed; add --yes to clean the initializing journal.",
+  "[Preview] Cleanup residue was not changed; add --yes to confirm cleanup.",
+  "[Preview] Found an empty initializing journal before intent publication; nothing changed. Add --yes to remove it.",
+  "[Preview] 终态资源不会回滚；确认清理请添加 --yes。",
+  "[Preview] 终态资源不会反向恢复；确认清理请添加 --yes。",
+  "[Preview] 业务路径未修改；确认清理初始化日志请添加 --yes。",
+]);
+
+function splitCliLines(text) {
+  return String(text ?? "").replace(/\r\n?/g, "\n").split("\n");
+}
+
 /**
  * 解析 --status 输出（SPEC §5.1）
  * 容错原则：遇到不认识的行直接跳过，绝不抛异常导致整页挂掉。
@@ -29,7 +44,7 @@ export function parseStatus(stdout) {
   const result = { directories: [], raw: stdout };
   let current = null;
 
-  for (const line of stdout.split("\n")) {
+  for (const line of splitCliLines(stdout)) {
     const dirMatch = line.match(/^── Status directory: (.+?) ──$/);
     if (dirMatch) {
       current = {
@@ -136,11 +151,12 @@ export function parseDryRun(stdout) {
     targets: [],
     blockers: [],
     warnings: [],
+    semanticComplete: false,
     raw: stdout,
   };
   let currentTarget = null;
 
-  for (const line of stdout.split("\n")) {
+  for (const line of splitCliLines(stdout)) {
     const promptMatch = line.match(/^\[Prompt\] Source: (.+?); SHA-256: ([0-9a-f]+)$/);
     if (promptMatch) {
       const source = promptMatch[1];
@@ -181,6 +197,12 @@ export function parseDryRun(stdout) {
     }
   }
 
+  result.semanticComplete = Boolean(
+    result.promptSource
+      && result.targets.length > 0
+      && result.targets.every((target) => target.actions.length > 0),
+  );
+
   return result;
 }
 
@@ -190,7 +212,7 @@ export function parseDryRun(stdout) {
  *
  * @param {{stdout: string, stderr: string, exit_code: number, timed_out: boolean}} output 原始 CLI 输出
  * @param {object} parsed parseDryRun / parseUninstallPreview 的结果
- * @returns {{ ok: boolean, reason?: "timeout"|"exit"|"empty"|"blockers", detail?: string }}
+ * @returns {{ ok: boolean, reason?: "timeout"|"exit"|"empty"|"blockers"|"unrecognized", detail?: string }}
  */
 export function gatePreview(output, parsed) {
   if (output.timed_out) {
@@ -215,13 +237,24 @@ export function gatePreview(output, parsed) {
   if (parsed.blockers && parsed.blockers.length > 0) {
     return { ok: false, reason: "blockers", detail: parsed.blockers.join("\n") };
   }
+  if (parsed.semanticComplete === false) {
+    return { ok: false, reason: "unrecognized", detail: output.stdout };
+  }
   return { ok: true };
 }
 
-/** 解析 --uninstall 预览输出：提取每个目录的回滚计划行 */
+/** 解析管理操作输出：识别卸载/恢复计划、合法 no-op 和 restore-hooks 完成态。 */
 export function parseUninstallPreview(stdout) {
-  const result = { plans: [], blockers: [], raw: stdout };
-  const lines = stdout.split("\n");
+  const result = {
+    plans: [],
+    blockers: [],
+    noOp: null,
+    completion: null,
+    preview: null,
+    semanticComplete: false,
+    raw: stdout,
+  };
+  const lines = splitCliLines(stdout);
   for (let i = 0; i < lines.length; i++) {
     const planMatch = lines[i].match(/^ {2}\[Plan\] (.+?): (.+)$/);
     if (planMatch) {
@@ -232,10 +265,36 @@ export function parseUninstallPreview(stdout) {
         detail: detail ? detail[1] : null,
       });
     }
-    if (lines[i].startsWith("[Error]")) {
-      result.blockers.push(lines[i].replace(/^\[Error\] /, ""));
+
+    // v0.2.0 translates the marker but leaves this dynamic verb in Chinese.
+    const recoveryPlanMatch = lines[i].match(/^ {2}\[Plan\] (?:Restore|恢复) (.+)$/);
+    if (recoveryPlanMatch) {
+      result.plans.push({
+        dir: recoveryPlanMatch[1],
+        summary: "Restore interrupted transaction",
+        detail: null,
+      });
+    }
+
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith("[Error]") || trimmed.startsWith("[Blocked]")) {
+      result.blockers.push(trimmed.replace(/^\[(?:Error|Blocked)\]\s*/, ""));
+    }
+
+    if (/^\[Done\] (?:No codex-keysmith deployment manifest was found; nothing to uninstall\.|No managed deployment was found; nothing to uninstall\.|No interrupted (?:deployment|uninstall) transaction requires recovery\.)$/.test(trimmed)) {
+      result.noOp = trimmed;
+    }
+    if (/^\[Done\] Restored \d+ hooks\.json file\(s\)\.$/.test(trimmed)) {
+      result.completion = trimmed;
+    }
+
+    if (MANAGEMENT_PREVIEW_SENTINELS.has(trimmed)) {
+      result.preview = trimmed;
     }
   }
+  result.semanticComplete = result.noOp !== null
+    || result.completion !== null
+    || result.preview !== null;
   return result;
 }
 

--- a/gui/src/lib/parser.test.js
+++ b/gui/src/lib/parser.test.js
@@ -114,6 +114,8 @@ const CLI_USAGE_ERROR = {
   timed_out: false,
 };
 
+const withLineEnding = (text, ending) => text.replace(/\n/g, ending);
+
 describe("parseStatus", () => {
   it("解析 active 状态（SPEC 真实样本）", () => {
     const r = parseStatus(STATUS_ACTIVE);
@@ -134,6 +136,34 @@ describe("parseStatus", () => {
     expect(d.deployability).toBe("ready");
     expect(d.warnings).toEqual([]);
     expect(d.abnormalNodes).toEqual([]);
+  });
+
+  it.each(["\n", "\r\n", "\r"])("兼容 %j 换行", (ending) => {
+    const d = parseStatus(withLineEnding(STATUS_ACTIVE, ending)).directories[0];
+    expect(d.path).toBe("/Users/ethan/.codex");
+    expect(d.activation).toBe("active");
+    expect(d.deployability).toBe("ready");
+  });
+
+  it("解析 Windows CRLF 双目录报告且保留原始输出", () => {
+    const out = [
+      "[Status] Found 2 Codex configuration location(s) (read-only inspection):",
+      "",
+      "── Status directory: C:\\Users\\Administrator\\.codex ──",
+      "    Config activation: not-installed",
+      "",
+      "── Status directory: C:\\Users\\Administrator\\AppData\\Local\\OpenAI\\Codex ──",
+      "    Config activation: conflict",
+      "",
+    ].join("\r\n");
+
+    const result = parseStatus(out);
+    expect(result.raw).toBe(out);
+    expect(result.directories.map((directory) => directory.path)).toEqual([
+      "C:\\Users\\Administrator\\.codex",
+      "C:\\Users\\Administrator\\AppData\\Local\\OpenAI\\Codex",
+    ]);
+    expect(result.directories[1].activation).toBe("conflict");
   });
 
   it("异常节点类型（symbolic link / FIFO / socket）不静默丢弃，升级为 warning", () => {
@@ -228,6 +258,12 @@ describe("parseDryRun", () => {
     expect(r.warnings.some((w) => w.startsWith("No hooks.json detected"))).toBe(true);
   });
 
+  it.each(["\n", "\r\n", "\r"])("兼容 %j 换行", (ending) => {
+    const r = parseDryRun(withLineEnding(DRY_RUN_OK, ending));
+    expect(r.semanticComplete).toBe(true);
+    expect(r.targets[0].actions).toHaveLength(6);
+  });
+
   it("[Blocked] 动作升级为 blocker", () => {
     const r = parseDryRun(DRY_RUN_BLOCKED);
     expect(r.blockers).toHaveLength(1);
@@ -295,17 +331,115 @@ describe("gatePreview（问题 1：门禁不可绕过）", () => {
     expect(gate.ok).toBe(false);
     expect(gate.reason).toBe("blockers");
   });
+
+  it.each([
+    ["缺少 prompt source", DRY_RUN_OK.replace(/^\[Prompt\].*\n/, "")],
+    ["缺少 target", DRY_RUN_OK.replace(/^  Target:.*$(?:\n {4}→.*$)*/m, "")],
+    ["target 缺少 action", "[Prompt] Source: bundled prompt.md; SHA-256: " + "a".repeat(64) + "\n  Target: C:\\Users\\Administrator\\.codex"],
+  ])("退出码 0 但%s → 阻断", (_label, stdout) => {
+    const gate = gatePreview(
+      { stdout, stderr: "", exit_code: 0, timed_out: false },
+      parseDryRun(stdout),
+    );
+    expect(gate.ok).toBe(false);
+    expect(gate.reason).toBe("unrecognized");
+  });
 });
 
 describe("parseUninstallPreview", () => {
   it("解析回滚计划", () => {
     const out = `[Uninstall] Preview (no changes made):
   [Plan] /tmp/fake-codex: revert 3 layer(s)
-         MD restored from backup, config reverted, hooks kept isolated`;
+         MD restored from backup, config reverted, hooks kept isolated
+[Preview] No files were changed; add --yes to confirm uninstall.`;
     const r = parseUninstallPreview(out);
     expect(r.plans).toHaveLength(1);
     expect(r.plans[0].dir).toBe("/tmp/fake-codex");
     expect(r.plans[0].summary).toContain("revert 3 layer(s)");
     expect(r.plans[0].detail).toContain("MD restored");
+    expect(r.semanticComplete).toBe(true);
+  });
+
+  it("只有计划但缺少预览确认标记时阻断", () => {
+    const stdout = "  [Plan] /tmp/fake-codex: revert 1 layer(s)";
+    const parsed = parseUninstallPreview(stdout);
+    expect(parsed.plans).toHaveLength(1);
+    expect(gatePreview(
+      { stdout, stderr: "", exit_code: 0, timed_out: false },
+      parsed,
+    )).toMatchObject({ ok: false, reason: "unrecognized" });
+  });
+
+  it.each(["\n", "\r\n", "\r"])("兼容 %j 换行并解析恢复计划", (ending) => {
+    const out = withLineEnding(
+      "[Restore] Deployment transaction abc has 1 participant(s); phase: prepared\n  [Plan] 恢复 C:\\Users\\Administrator\\.codex\n[Preview] No files were changed; add --yes to confirm recovery.",
+      ending,
+    );
+    const r = parseUninstallPreview(out);
+    expect(r.plans).toEqual([{
+      dir: "C:\\Users\\Administrator\\.codex",
+      summary: "Restore interrupted transaction",
+      detail: null,
+    }]);
+    expect(gatePreview(
+      { stdout: out, stderr: "", exit_code: 0, timed_out: false },
+      r,
+    ).ok).toBe(true);
+  });
+
+  it.each([
+    "[Done] No codex-keysmith deployment manifest was found; nothing to uninstall.",
+    "[Done] No managed deployment was found; nothing to uninstall.",
+    "[Done] No interrupted deployment transaction requires recovery.",
+    "[Done] No interrupted uninstall transaction requires recovery.",
+    "[Done] Restored 0 hooks.json file(s).",
+  ])("明确 no-op/完成输出放行：%s", (stdout) => {
+    const parsed = parseUninstallPreview(stdout);
+    const gate = gatePreview(
+      { stdout, stderr: "", exit_code: 0, timed_out: false },
+      parsed,
+    );
+    expect(parsed.semanticComplete).toBe(true);
+    expect(gate.ok).toBe(true);
+  });
+
+  it.each([
+    "[Preview] No files were changed; add --yes to confirm uninstall.",
+    "[Preview] No files were changed; add --yes to confirm recovery.",
+    "[Preview] No files were changed; add --yes to clean the initializing journal.",
+    "[Preview] Cleanup residue was not changed; add --yes to confirm cleanup.",
+    "[Preview] Found an empty initializing journal before intent publication; nothing changed. Add --yes to remove it.",
+    "[Preview] 终态资源不会回滚；确认清理请添加 --yes。",
+    "[Preview] 终态资源不会反向恢复；确认清理请添加 --yes。",
+    "[Preview] 业务路径未修改；确认清理初始化日志请添加 --yes。",
+  ])("当前 CLI 合法预览终止句放行：%s", (stdout) => {
+    const parsed = parseUninstallPreview(stdout);
+    expect(parsed.preview).toBe(stdout);
+    expect(gatePreview(
+      { stdout, stderr: "", exit_code: 0, timed_out: false },
+      parsed,
+    ).ok).toBe(true);
+  });
+
+  it("未知非空输出失败关闭", () => {
+    const stdout = "[Notice] A future CLI changed this report format.";
+    const parsed = parseUninstallPreview(stdout);
+    const gate = gatePreview(
+      { stdout, stderr: "", exit_code: 0, timed_out: false },
+      parsed,
+    );
+    expect(parsed.semanticComplete).toBe(false);
+    expect(gate).toMatchObject({ ok: false, reason: "unrecognized" });
+  });
+
+  it("未知预览即使包含 --yes 也失败关闭", () => {
+    const stdout = "[Preview] Unsupported format; rerun with --yes";
+    const parsed = parseUninstallPreview(stdout);
+    const gate = gatePreview(
+      { stdout, stderr: "", exit_code: 0, timed_out: false },
+      parsed,
+    );
+    expect(parsed.semanticComplete).toBe(false);
+    expect(gate).toMatchObject({ ok: false, reason: "unrecognized" });
   });
 });

--- a/gui/src/views/Deploy.jsx
+++ b/gui/src/views/Deploy.jsx
@@ -379,6 +379,7 @@ function Step2({ t, preview, loading, onBack, onNext }) {
     empty: t("deploy.previewEmpty"),
     exit: t("deploy.previewFailed"),
     blockers: t("deploy.blockers"),
+    unrecognized: t("deploy.previewUnrecognized"),
   }[gate.reason];
 
   return (


### PR DESCRIPTION
统一处理 Windows CLI 换行，并在状态或预览内容无法完整解析时阻断后续操作。