### PR TITLE
修复 v0.3.1 发布后校验与 Desktop 发布入口

### DIFF
--- a/.github/workflows/desktop-candidate.yml
+++ b/.github/workflows/desktop-candidate.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       publish_desktop_prerelease:
-        description: Publish the unsigned macOS ARM64 and Windows x64 desktop candidates.
+        description: Historical v0.2.0 publisher; disabled after the source version moved forward.
         required: false
         default: false
         type: boolean
@@ -683,9 +683,7 @@ jobs:
   publish-desktop-prerelease:
     name: Publish unsigned desktop prerelease
     if: >-
-      github.event_name == 'workflow_dispatch' &&
-      github.ref == 'refs/heads/main' &&
-      inputs.publish_desktop_prerelease == true
+      ${{ false }}
     needs:
       - candidate
     runs-on: ubuntu-24.04

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -8,12 +8,12 @@
 
 The signed `desktop-v0.2.0-beta.1` tag is retained as immutable evidence of an aborted publication attempt. Its draft was removed before asset upload, so it has no public Release or downloadable assets.
 
-The desktop candidate workflow is permanently unsigned and does not read Apple or Windows signing credentials. Pull requests receive only `contents: read`; the only `contents: write` permission belongs to the main-only manual prerelease publisher.
+The desktop candidate workflow is permanently unsigned and does not read Apple or Windows signing credentials. Pull requests receive only `contents: read`. Its historical v0.2.0 manual publisher remains disabled now that the source version has moved beyond 0.2.0; candidate builds remain available for CI validation, but publishing a new desktop line requires an explicit versioned release design.
 
 ## Release controls
 
-- Public desktop prereleases must be rebuilt by GitHub Actions from the current `main` commit on pinned runners and toolchains.
-- Publication requires an existing signed annotated `desktop-v0.2.0-beta.N` tag whose GitHub verification result is valid and whose peeled commit equals the current remote `main` HEAD.
+- The published `desktop-v0.2.0-beta.N` line was rebuilt by GitHub Actions from its tagged 0.2.0 source commits on pinned runners and toolchains.
+- Historical publication required an existing signed annotated `desktop-v0.2.0-beta.N` tag whose GitHub verification result was valid and whose peeled commit equaled the then-current remote `main` HEAD.
 - Both build manifests, the workflow commit, expected commit, tag commit, release target, asset set, sizes, and SHA-256 digests must all agree before a draft is made public.
 - The publisher never overwrites an existing tag, Release, or asset. A failed published candidate is replaced by a new beta number.
 - Self-signed certificates are not used for public distribution.

--- a/README.en.md
+++ b/README.en.md
@@ -51,7 +51,7 @@ npm run tauri dev
 base='https://github.com/Jia-Ethan/codex-keysmith/releases/download/vX.Y.Z'
 curl --fail --location --remote-name "$base/codex-instruct-vX.Y.Z.py"
 curl --fail --location --remote-name "$base/SHA256SUMS"
-shasum -a 256 -c SHA256SUMS
+awk '$2 == "codex-instruct-vX.Y.Z.py"' SHA256SUMS | shasum -a 256 -c -
 
 # 2. Look before you trust — confirm target directory, prompt source, and the planned write
 python3 codex-instruct-vX.Y.Z.py --version

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ npm run tauri dev
 base='https://github.com/Jia-Ethan/codex-keysmith/releases/download/vX.Y.Z'
 curl --fail --location --remote-name "$base/codex-instruct-vX.Y.Z.py"
 curl --fail --location --remote-name "$base/SHA256SUMS"
-shasum -a 256 -c SHA256SUMS
+awk '$2 == "codex-instruct-vX.Y.Z.py"' SHA256SUMS | shasum -a 256 -c -
 
 # 2. 先看，不要先信——确认目标目录、内置提示词来源和将要写入的内容
 python3 codex-instruct-vX.Y.Z.py --version

--- a/scripts/validate_desktop_candidate.py
+++ b/scripts/validate_desktop_candidate.py
@@ -230,9 +230,7 @@ def _validate_workflow_policy(path: Path, sidecar_basename: str) -> None:
     if text.count("contents: write") != 1 or "contents: write" not in publish_section:
         raise CandidateError(f"{path} must grant contents: write only to the publisher job")
     publish_required = (
-        "github.event_name == 'workflow_dispatch'",
-        "github.ref == 'refs/heads/main'",
-        "inputs.publish_desktop_prerelease == true",
+        "if: >-\n      ${{ false }}",
         "needs:\n      - candidate",
         "runs-on: ubuntu-24.04",
         "permissions:\n      contents: write",

--- a/tests/test_desktop_candidate.py
+++ b/tests/test_desktop_candidate.py
@@ -155,9 +155,7 @@ jobs:
 
   publish-desktop-prerelease:
     if: >-
-      github.event_name == 'workflow_dispatch' &&
-      github.ref == 'refs/heads/main' &&
-      inputs.publish_desktop_prerelease == true
+      ${{ false }}
     needs:
       - candidate
     runs-on: ubuntu-24.04
@@ -387,7 +385,7 @@ def test_validate_config_requires_window_capability_for_main_window(tmp_path):
             "outside the publisher job",
         ),
         (
-            lambda text: text.replace("inputs.publish_desktop_prerelease == true", "true"),
+            lambda text: text.replace("if: >-\n      ${{ false }}", "if: ${{ true }}"),
             "publisher markers",
         ),
         (

--- a/tests/test_desktop_prerelease.py
+++ b/tests/test_desktop_prerelease.py
@@ -387,7 +387,7 @@ def test_verify_public_assets_rejects_tampering_and_extra_assets(tmp_path):
         prerelease.verify_public_assets(output, COMMIT)
 
 
-def test_prerelease_workflow_is_separate_unsigned_and_main_only():
+def test_prerelease_workflow_is_separate_unsigned_and_publisher_disabled():
     desktop = (REPO_ROOT / ".github/workflows/desktop-candidate.yml").read_text(
         encoding="utf-8"
     )
@@ -397,8 +397,8 @@ def test_prerelease_workflow_is_separate_unsigned_and_main_only():
     assert "pull_request_target:" not in desktop
     assert "workflow_run:" not in desktop
     assert desktop.count("contents: write") == 1
-    assert "inputs.publish_desktop_prerelease == true" in desktop
-    assert "github.ref == 'refs/heads/main'" in desktop
+    assert "if: >-\n      ${{ false }}" in desktop
+    assert "Historical v0.2.0 publisher; disabled" in desktop
     assert "verify-manifest-data" in desktop
     assert '"prerelease": True' in desktop
     assert '"make_latest": "false"' in desktop


### PR DESCRIPTION
修复 README 单文件校验会因未下载源码归档失败的问题，并禁用已与 0.3.1 版本线冲突的历史 v0.2.0 Desktop 发布入口。