### PR TITLE
release: 准备 desktop-v0.3.5-beta.1 unsigned Desktop

### DIFF
--- a/.github/workflows/desktop-candidate.yml
+++ b/.github/workflows/desktop-candidate.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       publish_desktop_prerelease:
-        description: Historical v0.2.0 publisher; disabled after the source version moved forward.
+        description: Publish the current unsigned desktop line as desktop-v<VERSION>-beta.N.
         required: false
         default: false
         type: boolean
@@ -37,7 +37,7 @@ on:
       - "docs/assets/readme/**"
       - "docs/hooks-transactions.md"
       - "docs/reference.md"
-      - "docs/releases/desktop-v0.2.0-beta.*.md"
+      - "docs/releases/desktop-v*.md"
       - "docs/releases/v0.2.0.md"
       - "scripts/build_release.py"
       - "scripts/package_desktop_prerelease.py"
@@ -893,7 +893,7 @@ jobs:
   publish-desktop-prerelease:
     name: Publish unsigned desktop prerelease
     if: >-
-      ${{ false }}
+      ${{ github.event_name == 'workflow_dispatch' && inputs.publish_desktop_prerelease }}
     needs:
       - candidate
     runs-on: ubuntu-24.04
@@ -946,12 +946,23 @@ jobs:
             echo "expected_commit must be the full current main commit SHA." >&2
             exit 1
           fi
-          if [[ ! "$RELEASE_TAG" =~ ^desktop-v0\.2\.0-beta\.[1-9][0-9]*$ ]]; then
-            echo "release_tag must match desktop-v0.2.0-beta.N." >&2
+          version="$(tr -d '\r\n' < VERSION)"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "VERSION must be a dotted x.y.z source version." >&2
             exit 1
           fi
-          if [ "$(tr -d '\r\n' < VERSION)" != "0.2.0" ]; then
-            echo "Unsigned desktop beta publication is fixed to source version 0.2.0." >&2
+          version_pattern="${version//./\\.}"
+          if [[ ! "$RELEASE_TAG" =~ ^desktop-v${version_pattern}-beta\.[1-9][0-9]*$ ]]; then
+            echo "release_tag must match desktop-v${version}-beta.N." >&2
+            exit 1
+          fi
+          source_tag="v${version}"
+          if [ "$(git cat-file -t "refs/tags/${source_tag}" 2>/dev/null || true)" != "tag" ]; then
+            echo "Desktop line requires annotated source tag ${source_tag}." >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "${source_tag}^{commit}" "$EXPECTED_COMMIT"; then
+            echo "Desktop commit must be a descendant of ${source_tag}." >&2
             exit 1
           fi
           remote_main="$(
@@ -1002,43 +1013,21 @@ jobs:
             "$RUNNER_TEMP/macos-candidate/build-manifest.json"
           python scripts/validate_desktop_candidate.py verify-manifest-data \
             "$RUNNER_TEMP/windows-candidate/build-manifest.json"
-          source_first="${RUNNER_TEMP}/desktop-source-first"
-          source_second="${RUNNER_TEMP}/desktop-source-second"
-          source_tag="v$(tr -d '\r\n' < VERSION)"
-          python scripts/build_release.py "$source_tag" \
-            --output-dir "$source_first" \
-            --source-commit "$EXPECTED_COMMIT"
-          python scripts/build_release.py "$source_tag" \
-            --output-dir "$source_second" \
-            --source-commit "$EXPECTED_COMMIT"
-          diff -u "$source_first/SHA256SUMS" "$source_second/SHA256SUMS"
-          while read -r checksum asset; do
-            test -n "$checksum"
-            cmp "$source_first/$asset" "$source_second/$asset"
-          done < "$source_first/SHA256SUMS"
-          (cd "$source_first" && sha256sum --check SHA256SUMS)
-          version_output="$(python "$source_first/codex-instruct-${source_tag}.py" --version)"
-          expected_version_output="codex-instruct-${source_tag}.py $(tr -d '\r\n' < VERSION)"
-          if [ "$version_output" != "$expected_version_output" ]; then
-            echo "Standalone script reported an unexpected version: ${version_output}" >&2
-            exit 1
-          fi
           python scripts/package_desktop_prerelease.py assemble \
             --macos-candidate-dir "$RUNNER_TEMP/macos-candidate" \
             --windows-candidate-dir "$RUNNER_TEMP/windows-candidate" \
-            --source-dir "$source_first" \
             --output-dir "$RUNNER_TEMP/desktop-prerelease" \
             --release-tag "$RELEASE_TAG" \
             --expected-commit "$EXPECTED_COMMIT"
           python scripts/package_desktop_prerelease.py verify \
             "$RUNNER_TEMP/desktop-prerelease" \
-            --expected-commit "$EXPECTED_COMMIT" \
-            --source-dir "$source_first"
+            --expected-commit "$EXPECTED_COMMIT"
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
           {
             printf 'tag=%s\n' "$RELEASE_TAG"
             printf 'commit=%s\n' "$EXPECTED_COMMIT"
             printf 'tag_object=%s\n' "$tag_object"
+            printf 'version=%s\n' "$version"
             printf 'notes_path=%s\n' "$notes"
             printf 'notes_blob=%s\n' "$notes_blob"
           } >> "$GITHUB_OUTPUT"
@@ -1219,10 +1208,10 @@ jobs:
             exit 1
           fi
           latest_before="$(get_latest_release_tag)"
-          draft_name="codex-keysmith 0.2.0 Desktop Beta [run ${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}]"
+          version="$(tr -d '\r\n' < VERSION)"
+          draft_name="codex-keysmith ${version} Desktop Beta [run ${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}]"
           python scripts/package_desktop_prerelease.py verify "$release_dir" \
-            --expected-commit "$expected_commit" \
-            --source-dir "$RUNNER_TEMP/desktop-source-first"
+            --expected-commit "$expected_commit"
           verify_remote_main
           verify_remote_tag
           request="${RUNNER_TEMP}/desktop-prerelease-create.json"
@@ -1301,16 +1290,16 @@ jobs:
               assert candidate["assets"] == []
           PY
           normalize_request="${RUNNER_TEMP}/desktop-prerelease-normalize.json"
-          python - "$normalize_request" "$notes_blob" "$tag" "$expected_commit" <<'PY'
+          python - "$normalize_request" "$notes_blob" "$tag" "$expected_commit" "$version" <<'PY'
           import json
           from pathlib import Path
           import sys
 
-          request_path, notes_path, tag, commit = sys.argv[1:]
+          request_path, notes_path, tag, commit, version = sys.argv[1:]
           request = {
               "tag_name": tag,
               "target_commitish": commit,
-              "name": "codex-keysmith 0.2.0 Desktop Beta",
+              "name": "codex-keysmith {} Desktop Beta".format(version),
               "body": Path(notes_path).read_text(encoding="utf-8"),
               "draft": True,
               "prerelease": True,
@@ -1323,17 +1312,17 @@ jobs:
           PY
           normalized_state="${RUNNER_TEMP}/desktop-prerelease-normalized.json"
           gh api -X PATCH "$release_api" --input "$normalize_request" > "$normalized_state"
-          python - "$normalized_state" "$notes_blob" "$tag" "$expected_commit" "$release_id" <<'PY'
+          python - "$normalized_state" "$notes_blob" "$tag" "$expected_commit" "$release_id" "$version" <<'PY'
           import json
           from pathlib import Path
           import sys
 
-          state_path, notes_path, tag, commit, release_id = sys.argv[1:]
+          state_path, notes_path, tag, commit, release_id, version = sys.argv[1:]
           state = json.loads(Path(state_path).read_text(encoding="utf-8"))
           assert str(state["id"]) == release_id
           assert state["tag_name"] == tag
           assert state["target_commitish"] == commit
-          assert state["name"] == "codex-keysmith 0.2.0 Desktop Beta"
+          assert state["name"] == "codex-keysmith {} Desktop Beta".format(version)
           assert state["draft"] is True
           assert state["prerelease"] is True
           assert state["body"].encode("utf-8") == Path(notes_path).read_bytes()
@@ -1341,13 +1330,10 @@ jobs:
           PY
           upload_url="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets"
           assets=(
-            "$release_dir/codex-keysmith-0.2.0-macos-arm64-unsigned.dmg"
-            "$release_dir/codex-keysmith-0.2.0-macos-arm64-unsigned-candidate.zip"
-            "$release_dir/codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe"
-            "$release_dir/codex-keysmith-0.2.0-windows-x64-unsigned-candidate.zip"
-            "$release_dir/codex-instruct-v0.2.0.py"
-            "$release_dir/codex-keysmith-v0.2.0.zip"
-            "$release_dir/codex-keysmith-v0.2.0.tar.gz"
+            "$release_dir/codex-keysmith-${version}-macos-arm64-unsigned.dmg"
+            "$release_dir/codex-keysmith-${version}-macos-arm64-unsigned-candidate.zip"
+            "$release_dir/codex-keysmith-${version}-windows-x64-unsigned-setup.exe"
+            "$release_dir/codex-keysmith-${version}-windows-x64-unsigned-candidate.zip"
             "$release_dir/SHA256SUMS"
           )
           for asset_path in "${assets[@]}"; do
@@ -1374,21 +1360,21 @@ jobs:
           done | sort > "$expected"
           uploaded_state="${RUNNER_TEMP}/desktop-prerelease-uploaded.json"
           gh api "$release_api" > "$uploaded_state"
-          python - "$uploaded_state" "$notes_blob" "$tag" "$expected_commit" "$release_id" <<'PY'
+          python - "$uploaded_state" "$notes_blob" "$tag" "$expected_commit" "$release_id" "$version" <<'PY'
           import json
           from pathlib import Path
           import sys
 
-          state_path, notes_path, tag, commit, release_id = sys.argv[1:]
+          state_path, notes_path, tag, commit, release_id, version = sys.argv[1:]
           state = json.loads(Path(state_path).read_text(encoding="utf-8"))
           assert str(state["id"]) == release_id
           assert state["tag_name"] == tag
           assert state["target_commitish"] == commit
-          assert state["name"] == "codex-keysmith 0.2.0 Desktop Beta"
+          assert state["name"] == "codex-keysmith {} Desktop Beta".format(version)
           assert state["draft"] is True
           assert state["prerelease"] is True
           assert state["body"].encode("utf-8") == Path(notes_path).read_bytes()
-          assert len(state["assets"]) == 8
+          assert len(state["assets"]) == 5
           PY
           jq -r '.assets[] | [.name, .digest, .state, (.size | tostring)] | @tsv' \
             "$uploaded_state" | sort > "$actual"
@@ -1398,23 +1384,22 @@ jobs:
           git cat-file blob "${expected_commit}:${notes_path}" > "$tagged_notes"
           cmp "$notes_blob" "$tagged_notes"
           python scripts/package_desktop_prerelease.py verify "$release_dir" \
-            --expected-commit "$expected_commit" \
-            --source-dir "$RUNNER_TEMP/desktop-source-first"
+            --expected-commit "$expected_commit"
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
           verify_remote_main
           verify_remote_tag
 
           publish_request="${RUNNER_TEMP}/desktop-prerelease-publish.json"
-          python - "$publish_request" "$notes_blob" "$tag" "$expected_commit" <<'PY'
+          python - "$publish_request" "$notes_blob" "$tag" "$expected_commit" "$version" <<'PY'
           import json
           from pathlib import Path
           import sys
 
-          request_path, notes_path, tag, commit = sys.argv[1:]
+          request_path, notes_path, tag, commit, version = sys.argv[1:]
           request = {
               "tag_name": tag,
               "target_commitish": commit,
-              "name": "codex-keysmith 0.2.0 Desktop Beta",
+              "name": "codex-keysmith {} Desktop Beta".format(version),
               "body": Path(notes_path).read_text(encoding="utf-8"),
               "draft": False,
               "prerelease": True,
@@ -1459,22 +1444,22 @@ jobs:
           done
           final_state="${RUNNER_TEMP}/desktop-prerelease-published.json"
           printf '%s' "$published_state" > "$final_state"
-          python - "$final_state" "$notes_blob" "$tag" "$expected_commit" "$release_id" <<'PY'
+          python - "$final_state" "$notes_blob" "$tag" "$expected_commit" "$release_id" "$version" <<'PY'
           import json
           from pathlib import Path
           import sys
 
-          state_path, notes_path, tag, commit, release_id = sys.argv[1:]
+          state_path, notes_path, tag, commit, release_id, version = sys.argv[1:]
           state = json.loads(Path(state_path).read_text(encoding="utf-8"))
           assert str(state["id"]) == release_id
           assert state["tag_name"] == tag
           assert state["target_commitish"] == commit
-          assert state["name"] == "codex-keysmith 0.2.0 Desktop Beta"
+          assert state["name"] == "codex-keysmith {} Desktop Beta".format(version)
           assert state["draft"] is False
           assert state["prerelease"] is True
           assert state["published_at"]
           assert state["body"].encode("utf-8") == Path(notes_path).read_bytes()
-          assert len(state["assets"]) == 8
+          assert len(state["assets"]) == 5
           PY
           jq -r '.assets[] | [.name, .digest, .state, (.size | tostring)] | @tsv' \
             "$final_state" | sort > "$actual"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ## [Unreleased]
 
+### Desktop
+
+- Prepared `desktop-v0.3.5-beta.1` as the next unsigned Desktop Beta on source version `0.3.5`. Public assets are the Apple Silicon DMG, Windows x64 NSIS installer, two candidate ZIPs, and `SHA256SUMS`. The GUI Scenarios view ships in those installers. The standalone CLI, source archives, and sealed scenario bundle remain on the `v0.3.5` source Release. The historical `desktop-v0.2.0-beta.*` line is unchanged.
+
 ## [0.3.5] - 2026-08-15
 
 ### Desktop

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -2,18 +2,18 @@
 
 ## Current desktop beta
 
-`desktop-v0.2.0-beta.6` publishes an Apple Silicon macOS DMG and Windows x64 NSIS installer as one unsigned Desktop Beta. The DMG is not Apple-signed or notarized, and the installer has no Authenticode signature. macOS may show Gatekeeper warnings; Windows may show **Unknown publisher** and Microsoft Defender SmartScreen warnings.
+`desktop-v0.3.5-beta.1` publishes an Apple Silicon macOS DMG and Windows x64 NSIS installer as one unsigned Desktop Beta on source version `0.3.5`. The public asset set is those two installers, two candidate ZIPs, and `SHA256SUMS`. The standalone CLI, source archives, and sealed scenario bundle remain on the `v0.3.5` source Release. The DMG is not Apple-signed or notarized, and the installer has no Authenticode signature. macOS may show Gatekeeper warnings; Windows may show **Unknown publisher** and Microsoft Defender SmartScreen warnings.
 
-`desktop-v0.2.0-beta.5`, `desktop-v0.2.0-beta.4`, and `desktop-v0.2.0-beta.3` remain earlier unified prereleases. `desktop-v0.2.0-beta.2` remains the earlier Windows-only prerelease. None is overwritten by a later beta.
+`desktop-v0.2.0-beta.6` remains the last unified 0.2.0 unsigned Desktop Beta. `desktop-v0.2.0-beta.5`, `desktop-v0.2.0-beta.4`, and `desktop-v0.2.0-beta.3` remain earlier unified prereleases. `desktop-v0.2.0-beta.2` remains the earlier Windows-only prerelease. None is overwritten by a later beta.
 
 The signed `desktop-v0.2.0-beta.1` tag is retained as immutable evidence of an aborted publication attempt. Its draft was removed before asset upload, so it has no public Release or downloadable assets.
 
-The desktop candidate workflow is permanently unsigned and does not read Apple or Windows signing credentials. Pull requests receive only `contents: read`. Its historical v0.2.0 manual publisher remains disabled now that the source version has moved beyond 0.2.0; candidate builds remain available for CI validation, but publishing a new desktop line requires an explicit versioned release design.
+The desktop candidate workflow is permanently unsigned and does not read Apple or Windows signing credentials. Pull requests receive only `contents: read`. Publication of `desktop-v<VERSION>-beta.N` is a main-only manual dispatch that binds the current `VERSION` file, a descendant of the matching annotated `v<VERSION>` source tag, and a signed annotated desktop tag.
 
 ## Release controls
 
-- The published `desktop-v0.2.0-beta.N` line was rebuilt by GitHub Actions from its tagged 0.2.0 source commits on pinned runners and toolchains.
-- Historical publication required an existing signed annotated `desktop-v0.2.0-beta.N` tag whose GitHub verification result was valid and whose peeled commit equaled the then-current remote `main` HEAD.
+- The published `desktop-v0.3.5-beta.N` line is rebuilt by GitHub Actions from its tagged 0.3.5-line source commits on pinned runners and toolchains.
+- Publication requires an existing signed annotated `desktop-v<VERSION>-beta.N` tag whose GitHub verification result is valid and whose peeled commit equals the then-current remote `main` HEAD.
 - Both build manifests, the workflow commit, expected commit, tag commit, release target, asset set, sizes, and SHA-256 digests must all agree before a draft is made public.
 - The publisher never overwrites an existing tag, Release, or asset. A failed published candidate is replaced by a new beta number.
 - Self-signed certificates are not used for public distribution.

--- a/README.en.md
+++ b/README.en.md
@@ -38,8 +38,8 @@ npm install
 npm run tauri dev
 ```
 
-- The unified source version is `0.3.5`. This release publishes the source GUI Scenarios view (list, explicit target directory, preview gate, status, uninstall, recovery) and hardens compatible-endpoint validation, canonicalization, and redaction in the M3 runner; frozen sidecars still embed the same-version scenario bundle. The published installer remains [`desktop-v0.2.0-beta.6`](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.2.0-beta.6) and does not include that view or a new DMG/NSIS.
-- macOS users download `codex-keysmith-0.2.0-macos-arm64-unsigned.dmg`; Windows users download `codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe`. Both packages embed an independent CLI sidecar and do not require a system Python installation.
+- The unified source version is `0.3.5`. The published Desktop installer is [`desktop-v0.3.5-beta.1`](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.3.5-beta.1) and includes the GUI Scenarios view (list, explicit target directory, preview gate, status, uninstall, recovery); frozen sidecars still embed the same-version scenario bundle. The standalone CLI `codex-instruct-v0.3.5.py`, source archives, and sealed bundle remain on [`v0.3.5`](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/v0.3.5).
+- macOS users download `codex-keysmith-0.3.5-macos-arm64-unsigned.dmg`; Windows users download `codex-keysmith-0.3.5-windows-x64-unsigned-setup.exe`. Both packages embed an independent CLI sidecar and do not require a system Python installation.
 - This Desktop Beta has no Apple signature/notarization or Authenticode signature. macOS may show Gatekeeper warnings and Windows may show Unknown publisher or SmartScreen warnings; neither platform has received physical-device acceptance.
 - The Windows package uses current-user NSIS and a silent WebView2 download bootstrapper. It does not provide MSI, ARM64, or a formal Windows support commitment; the underlying Windows CLI fresh-deployment path remains `EXPLICIT_BETA`.
 - Normal CLI and Desktop operations do not proactively collect or upload user data. The M3 live runner sends temporary scenario context to the selected model service only when a maintainer explicitly runs it. See [`CODE_SIGNING_POLICY.md`](CODE_SIGNING_POLICY.md) and [`PRIVACY.md`](PRIVACY.md). The SignPath Foundation application is pending, and the current prerelease assets are not SignPath-signed.
@@ -132,7 +132,7 @@ OPENAI_API_KEY=YOUR_KEY OPENAI_BASE_URL=https://HOST/v1 \
   --report /absolute/reports/scenario-bank.jsonl
 ```
 
-Live evaluation sends temporary scenario context to the selected model service and may incur cost. `verify.py` / `validator.py` are host-executed code, so use only the same-version Release bundle or a reviewed scenario directory; see [`SECURITY.md`](SECURITY.md). Public scores and new Desktop installers remain out of scope. Source GUI scenario pages are documented in [`gui/SPEC.md`](gui/SPEC.md). The first private evaluation protocol is recorded in [`docs/v0.3-scenario-deployment-design.md`](docs/v0.3-scenario-deployment-design.md).
+Live evaluation sends temporary scenario context to the selected model service and may incur cost. `verify.py` / `validator.py` are host-executed code, so use only the same-version Release bundle or a reviewed scenario directory; see [`SECURITY.md`](SECURITY.md). Public scores remain out of scope. Desktop scenario pages are documented in [`gui/SPEC.md`](gui/SPEC.md). The first private evaluation protocol is recorded in [`docs/v0.3-scenario-deployment-design.md`](docs/v0.3-scenario-deployment-design.md).
 
 ### Using CCSwitch profiles as an activation switch
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ npm install
 npm run tauri dev
 ```
 
-- 当前统一源码版本为 `0.3.5`。本版发布源码 GUI 场景库页（列表、显式目标目录、preview 门禁、status、卸载、恢复），并收紧 M3 runner 的兼容 endpoint 校验、规范化与脱敏；冻结 sidecar 仍嵌入同版本场景 bundle。公开安装包仍是 [`desktop-v0.2.0-beta.6`](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.2.0-beta.6)，不包含该场景页，也不发布新的 DMG / NSIS。
-- macOS 用户下载 `codex-keysmith-0.2.0-macos-arm64-unsigned.dmg`；Windows 用户下载 `codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe`。两个安装包都内置独立 CLI sidecar，使用时无需额外安装 Python。
+- 当前统一源码版本为 `0.3.5`。公开 Desktop 安装包是 [`desktop-v0.3.5-beta.1`](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.3.5-beta.1)，包含 GUI 场景库页（列表、显式目标目录、preview 门禁、status、卸载、恢复）；冻结 sidecar 仍嵌入同版本场景 bundle。单文件 CLI `codex-instruct-v0.3.5.py`、源码归档和密封 bundle 仍在 [`v0.3.5`](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/v0.3.5)。
+- macOS 用户下载 `codex-keysmith-0.3.5-macos-arm64-unsigned.dmg`；Windows 用户下载 `codex-keysmith-0.3.5-windows-x64-unsigned-setup.exe`。两个安装包都内置独立 CLI sidecar，使用时无需额外安装 Python。
 - 本次 Desktop Beta 未进行 Apple 签名/公证或 Authenticode 签名。macOS 可能触发 Gatekeeper，Windows 可能显示 Unknown publisher 或 SmartScreen 警告；两平台均未经过实体设备验收。
 - Windows 安装包使用 current-user NSIS 和静默 WebView2 download bootstrapper，不提供 MSI、ARM64 或正式 Windows 支持承诺。底层 Windows CLI fresh deployment 继续遵循 `EXPLICIT_BETA`。
 - 常规 CLI / Desktop 操作不主动收集或上传用户数据；M3 live runner 只有在维护者显式执行时才会把临时场景上下文发送到所选模型服务。签名边界见 [`CODE_SIGNING_POLICY.md`](CODE_SIGNING_POLICY.md)，数据说明见 [`PRIVACY.md`](PRIVACY.md)。SignPath Foundation 申请仍在审核中，当前预发布资产并未使用 SignPath 签名。
@@ -144,7 +144,7 @@ OPENAI_API_KEY=YOUR_KEY OPENAI_BASE_URL=https://HOST/v1 \
   --report /absolute/reports/scenario-bank.jsonl
 ```
 
-Live 评估会把临时场景上下文发送到所选模型服务，可能产生费用。`verify.py` / `validator.py` 是本机执行代码，只应使用同版本 Release bundle 或已审阅场景目录；完整边界见 [`SECURITY.md`](SECURITY.md)。公开跑分和新的 Desktop 安装包仍不在范围内。源码 GUI 场景页见 [`gui/SPEC.md`](gui/SPEC.md)。首批私有评测协议见 [`docs/v0.3-scenario-deployment-design.md`](docs/v0.3-scenario-deployment-design.md#8-评估引擎m3)。
+Live 评估会把临时场景上下文发送到所选模型服务，可能产生费用。`verify.py` / `validator.py` 是本机执行代码，只应使用同版本 Release bundle 或已审阅场景目录；完整边界见 [`SECURITY.md`](SECURITY.md)。公开跑分仍不在范围内。Desktop 场景页见 [`gui/SPEC.md`](gui/SPEC.md)。首批私有评测协议见 [`docs/v0.3-scenario-deployment-design.md`](docs/v0.3-scenario-deployment-design.md#8-评估引擎m3)。
 
 ### 与 CCSwitch 配置切换配合
 

--- a/docs/releases/desktop-v0.3.5-beta.1.md
+++ b/docs/releases/desktop-v0.3.5-beta.1.md
@@ -1,0 +1,10 @@
+# codex-keysmith v0.3.5 Desktop Beta
+
+把源码 GUI 场景库页打进 unsigned 安装包：列表、显式目标目录、preview 门禁、status、按 deployment_id 卸载和恢复。GUI 只调用 CLI 场景命令。Windows 上三个生产场景仍只声明 darwin/linux，部署会被 blocker 拦住。
+
+## 下载
+
+- macOS Apple Silicon：`codex-keysmith-0.3.5-macos-arm64-unsigned.dmg`
+- Windows x64：`codex-keysmith-0.3.5-windows-x64-unsigned-setup.exe`
+- 单文件 CLI 与场景 bundle：见 [v0.3.5](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/v0.3.5)
+- 文件校验：`SHA256SUMS`

--- a/docs/v0.3-scenario-deployment-design.md
+++ b/docs/v0.3-scenario-deployment-design.md
@@ -4,7 +4,7 @@
 
 # v0.3 设计方案：场景部署（Scenario Deployment）
 
-> 状态：**M1–M3 已收口；M4 场景库页已在源码实现，未发布新 Desktop 安装包**，2026-08-15
+> 状态：**M1–M3 已收口；M4 场景库页随 `desktop-v0.3.5-beta.1` 进入 unsigned Desktop**，2026-08-16
 > 范围：在不改变既有 Codex 指令部署语义的前提下，新增可恢复的目标目录场景包部署能力。
 > 本文只定义产品和事务边界；具体场景内容、跑分结果和发布决策由后续里程碑记录。
 
@@ -314,7 +314,7 @@ M4 才增加 GUI 场景列表、详情、显式目录选择、preview 门禁、s
 | M2 第一阶段 | 三个首批场景、依赖/平台元数据、篡改检测 | 第 7 节 1-3 通过。已随 `v0.3.1` 发布；`v0.3.2` 关闭发布校验缺口。 |
 | M2 第二阶段 | 密封 bundle、index/`source_digest`、CLI `--scenario-root`、sidecar 资源定位 | 第 15 节全部通过。不含 win32 生产场景声明、GUI 场景页、真实跑分或自动发版。 |
 | M3 | 隔离 scenario bank runner、对照实验与私有报告 | runner 与数据外发说明随 `v0.3.4` 提供；`OPENAI_BASE_URL` 隔离注入与首批私有报告、探索性阈值已在 2026-08-15 收口。公开分数与 GUI 场景页仍不在范围内。 |
-| M4 | GUI 场景页、文档、发布评审与独立 Desktop beta | 场景列表/详情/显式目录/preview/status/uninstall/recovery 随 `v0.3.5` 进入源码 GUI。本轮按维护者决策不发布新的 unsigned Desktop 安装包；sidecar 仍嵌入同版本 bundle。 |
+| M4 | GUI 场景页、文档、发布评审与独立 Desktop beta | 场景列表/详情/显式目录/preview/status/uninstall/recovery 随 `v0.3.5` 进入源码 GUI，并由 `desktop-v0.3.5-beta.1` 打进 unsigned 安装包。sidecar 仍嵌入同版本 bundle。CLI / 源码 / bundle 仍留在 `v0.3.5`。 |
 
 ## 14. 仍开放事项
 
@@ -322,7 +322,7 @@ M4 才增加 GUI 场景列表、详情、显式目录选择、preview 门禁、s
 2. ~~`scenarios.bundle` 格式与资产命名~~：已由 D12 关闭。
 3. ~~三个生产场景的 `win32` 声明是否进入 M2 第二阶段~~：已由 D13 关闭，保持 `darwin`/`linux`。日后若某包自己的 Windows `verify.py` 门禁通过，再单独改该包的 `platforms`。
 4. ~~M3 的重复次数、对照组、统计阈值和成本上限~~：已由 2026-08-15 首批私有评测关闭。协议为 `--attempts 2` / `--timeout 600` / 默认跳过 blocker；探索性 channel-ready 阈值为两次内至少一次 validator 0；不进入 CI；报告不入库；成本按显式维护者动作逐次承担，不设仓库内美元上限。对照模型可另跑。`cyber_keystone` 在 TAC 过滤通道上未达标。
-5. ~~M4 是否将场景库页面纳入下一个 desktop beta 资产~~：源码已纳入场景库页。2026-08-15 决策是实现并提交，不把该页打进新的公开 Desktop Pre-release；现网安装包仍是 `desktop-v0.2.0-beta.6`。
+5. ~~M4 是否将场景库页面纳入下一个 desktop beta 资产~~：2026-08-16 决策是把场景页打进 `desktop-v0.3.5-beta.1` unsigned Desktop；`desktop-v0.2.0-beta.*` 资产不变。
 
 ## 15. M2 第二阶段验收标准
 

--- a/gui/README.md
+++ b/gui/README.md
@@ -43,7 +43,7 @@ npm run tauri build
 | macOS Apple Silicon | `codex-keysmith-cli-aarch64-apple-darwin` | `.app` + ARM64 `.dmg` |
 | Windows x64 | `codex-keysmith-cli-x86_64-pc-windows-msvc.exe` | current-user NSIS `.exe` |
 
-`desktop-v0.2.0-beta.6` 统一提供 macOS Apple Silicon unsigned DMG 与 Windows x64 unsigned NSIS。Windows 安装器使用 WebView2 download bootstrapper、禁止降级，当前不生成 MSI；两平台均为 `Beta / unsigned / native-CI-validated`，尚未进行正式签名、公证或实体设备验收。普通用户按平台下载 DMG 或 setup EXE；正式 Authenticode 发行仍待 SignPath Foundation 审核和独立签名流程。
+`desktop-v0.3.5-beta.1` 统一提供 macOS Apple Silicon unsigned DMG 与 Windows x64 unsigned NSIS，并包含 GUI 场景库页。Windows 安装器使用 WebView2 download bootstrapper、禁止降级，当前不生成 MSI；两平台均为 `Beta / unsigned / native-CI-validated`，尚未进行正式签名、公证或实体设备验收。普通用户按平台下载 DMG 或 setup EXE；正式 Authenticode 发行仍待 SignPath Foundation 审核和独立签名流程。
 
 图标以 `src-tauri/icons/source.png` 为唯一源文件。修改后运行：
 

--- a/gui/SPEC.md
+++ b/gui/SPEC.md
@@ -1,6 +1,6 @@
 # codex-keysmith GUI 客户端 — 技术方案与交接文档
 
-> 状态：源码 v0.3.5 已具备指令层 GUI（M1–M5）与场景库页（场景 M4 实现，未发新 Desktop 安装包）；公开安装包仍是 `desktop-v0.2.0-beta.6`。正式签名、公证与实体设备验收仍待完成
+> 状态：源码 v0.3.5 已具备指令层 GUI（M1–M5）与场景库页；公开安装包是 `desktop-v0.3.5-beta.1` unsigned Beta。正式签名、公证与实体设备验收仍待完成
 > 关联 issue：[#10「建议」为小白做一个可视化的界面客户端](https://github.com/Jia-Ethan/codex-keysmith/issues/10)
 
 ## 1. 项目背景
@@ -16,7 +16,7 @@ CLI 对熟练用户很好用，但对小白（issue #10 的目标用户）门槛
 | 技术栈 | **Tauri 2**（Rust 后端 + Web 前端） | 打包体积小（几 MB）、原生感强、界面现代化 |
 | 平台范围 | **macOS Apple Silicon + Windows x64** | 每个平台原生冻结 Python 与构建 Tauri bundle，不做跨平台交叉打包；本轮不提供 Intel Mac 包 |
 | 与 CLI 的关系 | **包装现有 CLI**（subprocess 调用），不重实现逻辑 | 复用已测试的部署/回滚/恢复逻辑，CLI 升级客户端不用跟着改 |
-| 本轮交付 | **指令层 M1–M5 + 场景库页实现** | 场景页只调用 CLI 场景命令；本轮不发布新的 DMG / NSIS |
+| 本轮交付 | **指令层 M1–M5 + 场景库页进入 unsigned Desktop** | 场景页只调用 CLI 场景命令；公开安装包是 `desktop-v0.3.5-beta.1` |
 
 ## 3. 总体架构
 
@@ -333,7 +333,7 @@ async fn cli_runtime(cli_path: Option<String>) -> Result<String, String>;
 | **M3 管理操作** ✅ | 卸载 / 恢复 hooks / 恢复中断 | 与 CLI 逐层回滚语义一致；残留场景可恢复 |
 | **M4 打包基础** ✅ | PyInstaller sidecar、统一图标、macOS app/dmg 配置 | 安装包内置冻结 CLI，不依赖系统 Python；签名/公证/Release CI 单独验收 |
 | **M5 Windows x64 打包基础** ✅ | 原生 sidecar + current-user NSIS + WebView2 bootstrapper | 可在 Windows x64 原生环境产出 `.exe`；CI 安装后验证配置/运行目录隔离、活动 sidecar 期间排队关闭、单实例交接、原生空闲关闭及无 GUI/sidecar 残留；正式发布前仍需 Authenticode 与实体设备验收 |
-| **场景 M4 场景库页** ✅ | 列表、详情、显式 `--target-dir`、preview 门禁、status、uninstall、recovery | GUI 只调用 CLI 场景命令；预览绑定规范目标与场景/部署标识，选择变化后失效；状态与写结果保留 blocker、stdout/stderr，并在每次写操作后刷新；不发新 Desktop 安装包 |
+| **场景 M4 场景库页** ✅ | 列表、详情、显式 `--target-dir`、preview 门禁、status、uninstall、recovery | GUI 只调用 CLI 场景命令；预览绑定规范目标与场景/部署标识，选择变化后失效；状态与写结果保留 blocker、stdout/stderr，并在每次写操作后刷新；进入 `desktop-v0.3.5-beta.1` |
 
 ## 10. 交接说明（给接手 Agent）
 

--- a/scripts/package_desktop_prerelease.py
+++ b/scripts/package_desktop_prerelease.py
@@ -23,13 +23,25 @@ else:
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-# The unsigned desktop beta line is immutable and intentionally remains on 0.2.0.
-VERSION = "0.2.0"
 PRODUCT = "codex-keysmith"
-TAG_RE = re.compile(rf"^desktop-v{re.escape(VERSION)}-beta\.[1-9][0-9]*$")
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 CHECKSUMS_NAME = "SHA256SUMS"
 
+
+class PrereleaseError(RuntimeError):
+    """Raised when an unsigned desktop prerelease invariant is violated."""
+
+
+def _read_version() -> str:
+    raw = (REPO_ROOT / "VERSION").read_text(encoding="ascii").strip()
+    if VERSION_RE.fullmatch(raw) is None:
+        raise PrereleaseError("VERSION must be a dotted x.y.z source version")
+    return raw
+
+
+VERSION = _read_version()
+TAG_RE = re.compile(rf"^desktop-v{re.escape(VERSION)}-beta\.[1-9][0-9]*$")
 MACOS_DMG_NAME = f"{PRODUCT}-{VERSION}-macos-arm64-unsigned.dmg"
 MACOS_CANDIDATE_ZIP_NAME = f"{PRODUCT}-{VERSION}-macos-arm64-unsigned-candidate.zip"
 WINDOWS_SETUP_NAME = f"{PRODUCT}-{VERSION}-windows-x64-unsigned-setup.exe"
@@ -37,18 +49,24 @@ WINDOWS_CANDIDATE_ZIP_NAME = f"{PRODUCT}-{VERSION}-windows-x64-unsigned-candidat
 CLI_NAME = f"codex-instruct-v{VERSION}.py"
 SOURCE_ZIP_NAME = f"{PRODUCT}-v{VERSION}.zip"
 SOURCE_TAR_NAME = f"{PRODUCT}-v{VERSION}.tar.gz"
+SCENARIO_BUNDLE_NAME = f"{PRODUCT}-scenarios-v{VERSION}.bundle"
 
 # Retain the legacy names for callers that only need the Windows asset constants.
 SETUP_NAME = WINDOWS_SETUP_NAME
 CANDIDATE_ZIP_NAME = WINDOWS_CANDIDATE_ZIP_NAME
 
-SOURCE_PAYLOAD_NAMES = (CLI_NAME, SOURCE_ZIP_NAME, SOURCE_TAR_NAME)
+# Source CLI/archives/bundle stay on the matching v<VERSION> source Release.
+SOURCE_RELEASE_PAYLOAD_NAMES = (
+    CLI_NAME,
+    SOURCE_ZIP_NAME,
+    SOURCE_TAR_NAME,
+    SCENARIO_BUNDLE_NAME,
+)
 PUBLIC_PAYLOAD_NAMES = (
     MACOS_DMG_NAME,
     MACOS_CANDIDATE_ZIP_NAME,
     WINDOWS_SETUP_NAME,
     WINDOWS_CANDIDATE_ZIP_NAME,
-    *SOURCE_PAYLOAD_NAMES,
 )
 PUBLIC_ASSET_NAMES = (*PUBLIC_PAYLOAD_NAMES, CHECKSUMS_NAME)
 
@@ -92,10 +110,6 @@ PLATFORM_CONFIGS = {
         },
     },
 }
-
-
-class PrereleaseError(RuntimeError):
-    """Raised when an unsigned desktop prerelease invariant is violated."""
 
 
 def _require_regular_file(path: Path) -> None:
@@ -184,31 +198,6 @@ def _validate_candidate(
     return manifest
 
 
-def _validate_source_assets(source_dir: Path) -> None:
-    source_dir = source_dir.absolute()
-    if not source_dir.is_dir() or source_dir.is_symlink():
-        raise PrereleaseError(f"source asset directory is missing or unsafe: {source_dir}")
-    entries = list(source_dir.iterdir())
-    expected_names = {*SOURCE_PAYLOAD_NAMES, CHECKSUMS_NAME}
-    actual_names = {entry.name for entry in entries}
-    if actual_names != expected_names:
-        raise PrereleaseError(
-            f"source asset set is not exact: expected {sorted(expected_names)}, "
-            f"got {sorted(actual_names)}"
-        )
-    for entry in entries:
-        _require_regular_file(entry)
-    expected_lines = [
-        f"{_sha256(source_dir / name)}  {name}" for name in sorted(SOURCE_PAYLOAD_NAMES)
-    ]
-    try:
-        checksum_lines = (source_dir / CHECKSUMS_NAME).read_text(encoding="ascii").splitlines()
-    except (OSError, UnicodeError) as exc:
-        raise PrereleaseError(f"cannot read source SHA256SUMS: {exc}") from exc
-    if checksum_lines != expected_lines:
-        raise PrereleaseError("source SHA256SUMS does not exactly cover deterministic source assets")
-
-
 def _write_deterministic_zip(candidate_dir: Path, destination: Path) -> None:
     with zipfile.ZipFile(
         destination,
@@ -275,7 +264,6 @@ def _verify_candidate_zip(
 def verify_public_assets(
     output_dir: Path,
     expected_commit: str,
-    source_dir: Path | None = None,
 ) -> None:
     if COMMIT_RE.fullmatch(expected_commit) is None:
         raise PrereleaseError("expected commit must be a full lowercase 40-character SHA")
@@ -288,6 +276,12 @@ def verify_public_assets(
         raise PrereleaseError(
             f"public asset set is not exact: expected {sorted(PUBLIC_ASSET_NAMES)}, "
             f"got {sorted(actual_names)}"
+        )
+    leaked = set(actual_names) & set(SOURCE_RELEASE_PAYLOAD_NAMES)
+    if leaked:
+        raise PrereleaseError(
+            "desktop prerelease must not republish source-release assets: "
+            + ", ".join(sorted(leaked))
         )
     for entry in entries:
         _require_regular_file(entry)
@@ -304,20 +298,11 @@ def verify_public_assets(
     windows_commit = _verify_candidate_zip(output_dir, "windows", expected_commit)
     if macos_commit != windows_commit:
         raise PrereleaseError("macOS and Windows candidate manifests do not bind the same commit")
-    if source_dir is not None:
-        source_dir = source_dir.absolute()
-        _validate_source_assets(source_dir)
-        for name in SOURCE_PAYLOAD_NAMES:
-            if _sha256(output_dir / name) != _sha256(source_dir / name):
-                raise PrereleaseError(
-                    f"public source asset does not match the commit-bound build output: {name}"
-                )
 
 
 def assemble_prerelease(
     macos_candidate_dir: Path,
     windows_candidate_dir: Path,
-    source_dir: Path,
     output_dir: Path,
     tag: str,
     expected_commit: str,
@@ -331,8 +316,6 @@ def assemble_prerelease(
         platform: _validate_candidate(candidate_dir, expected_commit, platform)
         for platform, candidate_dir in candidate_dirs.items()
     }
-    source_dir = source_dir.absolute()
-    _validate_source_assets(source_dir)
     output_dir = output_dir.absolute()
     if output_dir.exists():
         if output_dir.is_symlink() or not output_dir.is_dir() or any(output_dir.iterdir()):
@@ -350,10 +333,6 @@ def assemble_prerelease(
                 candidate_dir,
                 temporary / str(config["candidate_zip"]),
             )
-        for name in SOURCE_PAYLOAD_NAMES:
-            destination = temporary / name
-            shutil.copyfile(source_dir / name, destination)
-            os.chmod(destination, 0o755 if name == CLI_NAME else 0o644)
         checksum_lines = [
             f"{_sha256(temporary / name)}  {name}"
             for name in sorted(PUBLIC_PAYLOAD_NAMES)
@@ -362,14 +341,14 @@ def assemble_prerelease(
             "\n".join(checksum_lines) + "\n",
             encoding="ascii",
         )
-        verify_public_assets(temporary, expected_commit, source_dir)
+        verify_public_assets(temporary, expected_commit)
         if output_dir.exists():
             output_dir.rmdir()
         temporary.rename(output_dir)
     except Exception:
         shutil.rmtree(temporary, ignore_errors=True)
         raise
-    verify_public_assets(output_dir, expected_commit, source_dir)
+    verify_public_assets(output_dir, expected_commit)
     return output_dir
 
 
@@ -379,7 +358,6 @@ def build_parser() -> argparse.ArgumentParser:
     assemble = subparsers.add_parser("assemble", help="assemble fixed public prerelease assets")
     assemble.add_argument("--macos-candidate-dir", type=Path, required=True)
     assemble.add_argument("--windows-candidate-dir", type=Path, required=True)
-    assemble.add_argument("--source-dir", type=Path, required=True)
     assemble.add_argument("--output-dir", type=Path, required=True)
     assemble.add_argument("--release-tag", required=True)
     assemble.add_argument("--expected-commit", required=True)
@@ -388,7 +366,6 @@ def build_parser() -> argparse.ArgumentParser:
             assemble_prerelease(
                 args.macos_candidate_dir,
                 args.windows_candidate_dir,
-                args.source_dir,
                 args.output_dir,
                 args.release_tag,
                 args.expected_commit,
@@ -398,12 +375,10 @@ def build_parser() -> argparse.ArgumentParser:
     verify = subparsers.add_parser("verify", help="verify the fixed public asset set")
     verify.add_argument("output_dir", type=Path)
     verify.add_argument("--expected-commit", required=True)
-    verify.add_argument("--source-dir", type=Path)
     verify.set_defaults(
         handler=lambda args: verify_public_assets(
             args.output_dir,
             args.expected_commit,
-            args.source_dir,
         )
     )
     return parser

--- a/scripts/validate_desktop_candidate.py
+++ b/scripts/validate_desktop_candidate.py
@@ -230,7 +230,7 @@ def _validate_workflow_policy(path: Path, sidecar_basename: str) -> None:
     if text.count("contents: write") != 1 or "contents: write" not in publish_section:
         raise CandidateError(f"{path} must grant contents: write only to the publisher job")
     publish_required = (
-        "if: >-\n      ${{ false }}",
+        "if: >-\n      ${{ github.event_name == 'workflow_dispatch' && inputs.publish_desktop_prerelease }}",
         "needs:\n      - candidate",
         "runs-on: ubuntu-24.04",
         "permissions:\n      contents: write",
@@ -238,7 +238,7 @@ def _validate_workflow_policy(path: Path, sidecar_basename: str) -> None:
         "codex-keysmith-desktop-macos-arm64-${{ github.sha }}",
         "codex-keysmith-desktop-windows-x64-${{ github.sha }}",
         "verify-manifest-data",
-        "desktop-v0\\.2\\.0-beta\\.[1-9][0-9]*",
+        "desktop-v${version_pattern}-beta\\.[1-9][0-9]*",
         'EXPECTED_COMMIT" != "$GITHUB_SHA',
         "git/ref/heads/main",
         "git/ref/tags/${RELEASE_TAG}",
@@ -247,16 +247,12 @@ def _validate_workflow_policy(path: Path, sidecar_basename: str) -> None:
         "package_desktop_prerelease.py assemble",
         '--macos-candidate-dir "$RUNNER_TEMP/macos-candidate"',
         '--windows-candidate-dir "$RUNNER_TEMP/windows-candidate"',
-        '--source-dir "$source_first"',
         '--expected-commit "$expected_commit"',
-        'scripts/build_release.py "$source_tag"',
-        "codex-keysmith-0.2.0-macos-arm64-unsigned.dmg",
-        "codex-keysmith-0.2.0-macos-arm64-unsigned-candidate.zip",
-        "codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe",
-        "codex-keysmith-0.2.0-windows-x64-unsigned-candidate.zip",
-        "codex-instruct-v0.2.0.py",
-        "codex-keysmith-v0.2.0.zip",
-        "codex-keysmith-v0.2.0.tar.gz",
+        'merge-base --is-ancestor "${source_tag}^{commit}"',
+        "codex-keysmith-${version}-macos-arm64-unsigned.dmg",
+        "codex-keysmith-${version}-macos-arm64-unsigned-candidate.zip",
+        "codex-keysmith-${version}-windows-x64-unsigned-setup.exe",
+        "codex-keysmith-${version}-windows-x64-unsigned-candidate.zip",
         '"draft": True',
         '"prerelease": True',
         '"make_latest": "false"',
@@ -266,9 +262,17 @@ def _validate_workflow_policy(path: Path, sidecar_basename: str) -> None:
         "Recovered numeric-ID ownership after a lost create response.",
         'release_author="github-actions[bot]"',
         "Release ${tag} already exists; refusing to overwrite it.",
-        "len(state[\"assets\"]) == 8",
+        "len(state[\"assets\"]) == 5",
         ".assets[] | [.name, .digest, .state, (.size | tostring)]",
     )
+    if '--source-dir "$source_first"' in publish_section:
+        raise CandidateError(
+            f"{path} desktop publisher must not rebuild or attach source-release assets"
+        )
+    if 'scripts/build_release.py "$source_tag"' in publish_section:
+        raise CandidateError(
+            f"{path} desktop publisher must not rebuild source-release archives"
+        )
     publish_missing = [marker for marker in publish_required if marker not in publish_section]
     if publish_missing:
         raise CandidateError(

--- a/tests/test_desktop_candidate.py
+++ b/tests/test_desktop_candidate.py
@@ -157,7 +157,7 @@ jobs:
 
   publish-desktop-prerelease:
     if: >-
-      ${{ false }}
+      ${{ github.event_name == 'workflow_dispatch' && inputs.publish_desktop_prerelease }}
     needs:
       - candidate
     runs-on: ubuntu-24.04
@@ -172,23 +172,19 @@ jobs:
           name: codex-keysmith-desktop-windows-x64-${{ github.sha }}
       - run: |
           echo verify-manifest-data
-          echo 'desktop-v0\\.2\\.0-beta\\.[1-9][0-9]*'
+          echo 'desktop-v${version_pattern}-beta\\.[1-9][0-9]*'
           echo 'if [ "$EXPECTED_COMMIT" != "$GITHUB_SHA" ]'
           echo 'git/ref/heads/main git/ref/tags/${RELEASE_TAG}'
           echo '.verification.verified .verification.reason'
           echo 'package_desktop_prerelease.py assemble'
           echo '--macos-candidate-dir "$RUNNER_TEMP/macos-candidate"'
           echo '--windows-candidate-dir "$RUNNER_TEMP/windows-candidate"'
-          echo '--source-dir "$source_first"'
           echo '--expected-commit "$expected_commit"'
-          echo 'scripts/build_release.py "$source_tag"'
-          echo codex-keysmith-0.2.0-macos-arm64-unsigned.dmg
-          echo codex-keysmith-0.2.0-macos-arm64-unsigned-candidate.zip
-          echo codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe
-          echo codex-keysmith-0.2.0-windows-x64-unsigned-candidate.zip
-          echo codex-instruct-v0.2.0.py
-          echo codex-keysmith-v0.2.0.zip
-          echo codex-keysmith-v0.2.0.tar.gz
+          echo 'merge-base --is-ancestor "${source_tag}^{commit}"'
+          echo 'codex-keysmith-${version}-macos-arm64-unsigned.dmg'
+          echo 'codex-keysmith-${version}-macos-arm64-unsigned-candidate.zip'
+          echo 'codex-keysmith-${version}-windows-x64-unsigned-setup.exe'
+          echo 'codex-keysmith-${version}-windows-x64-unsigned-candidate.zip'
           echo '"draft": True "prerelease": True "make_latest": "false"'
           echo 'gh api -X POST "repos/${GITHUB_REPOSITORY}/releases"'
           echo 'gh api -X PATCH "$release_api"'
@@ -196,7 +192,7 @@ jobs:
           echo 'Recovered numeric-ID ownership after a lost create response.'
           echo 'release_author="github-actions[bot]"'
           echo 'Release ${tag} already exists; refusing to overwrite it.'
-          echo 'len(state["assets"]) == 8'
+          echo 'len(state["assets"]) == 5'
           echo '.assets[] | [.name, .digest, .state, (.size | tostring)]'
           echo '"tag_name": tag "target_commitish": commit "body": Path(notes_path).read_text(encoding="utf-8") "make_latest": "false"'
           echo '"tag_name": tag "target_commitish": commit "body": Path(notes_path).read_text(encoding="utf-8") "make_latest": "false"'
@@ -398,7 +394,10 @@ def test_validate_config_requires_window_capability_for_main_window(tmp_path):
             "outside the publisher job",
         ),
         (
-            lambda text: text.replace("if: >-\n      ${{ false }}", "if: ${{ true }}"),
+            lambda text: text.replace(
+                "if: >-\n      ${{ github.event_name == 'workflow_dispatch' && inputs.publish_desktop_prerelease }}",
+                "if: ${{ true }}",
+            ),
             "publisher markers",
         ),
         (

--- a/tests/test_desktop_prerelease.py
+++ b/tests/test_desktop_prerelease.py
@@ -13,8 +13,9 @@ import pytest
 from scripts import package_desktop_prerelease as prerelease
 
 COMMIT = "a" * 40
-TAG = "desktop-v0.2.0-beta.6"
+TAG = f"desktop-v{prerelease.VERSION}-beta.1"
 REPO_ROOT = Path(__file__).resolve().parents[1]
+VERSION = prerelease.VERSION
 
 
 def _sha256(path: Path) -> str:
@@ -46,7 +47,7 @@ def _candidate(tmp_path: Path, platform: str) -> Path:
     candidate = tmp_path / platform
     candidate.mkdir(parents=True)
     if platform == "windows":
-        bundle = candidate / "codex-keysmith_0.2.0_x64-setup.exe"
+        bundle = candidate / f"codex-keysmith_{VERSION}_x64-setup.exe"
         app = candidate / "codex-keysmith-gui.exe"
         sidecar = candidate / "codex-keysmith-cli.exe"
         icon = candidate / "icon.ico"
@@ -63,7 +64,7 @@ def _candidate(tmp_path: Path, platform: str) -> Path:
         sidecar.write_bytes(_pe_binary() + b"sidecar")
         _write_ico(icon)
     else:
-        bundle = candidate / "codex-keysmith_0.2.0_aarch64.dmg"
+        bundle = candidate / f"codex-keysmith_{VERSION}_aarch64.dmg"
         app = candidate / "codex-keysmith-gui"
         sidecar = candidate / "codex-keysmith-cli"
         icon = candidate / "icon.icns"
@@ -94,8 +95,8 @@ def _candidate(tmp_path: Path, platform: str) -> Path:
     manifest = {
         "schema_version": 1,
         "product": "codex-keysmith",
-        "desktop_version": "0.2.0",
-        "cli_version": "0.2.0",
+        "desktop_version": VERSION,
+        "cli_version": VERSION,
         "source_commit": COMMIT,
         "target": target,
         "toolchain": {
@@ -104,7 +105,7 @@ def _candidate(tmp_path: Path, platform: str) -> Path:
             "pyinstaller": "6.16.0",
             "rust": "1.88.0",
         },
-        "sidecar_version_output": f"{sidecar.name} 0.2.0",
+        "sidecar_version_output": f"{sidecar.name} {VERSION}",
         "sidecar_provenance": {
             "source_sha256": sidecar_hash,
             "packaged_sha256": sidecar_hash,
@@ -132,39 +133,17 @@ def _candidate(tmp_path: Path, platform: str) -> Path:
     return candidate
 
 
-def _source_assets(tmp_path: Path) -> Path:
-    source = tmp_path / "source"
-    source.mkdir(parents=True)
-    (source / prerelease.CLI_NAME).write_text(
-        '#!/usr/bin/env python3\n__version__ = "0.2.0"\n',
-        encoding="utf-8",
-    )
-    (source / prerelease.SOURCE_ZIP_NAME).write_bytes(b"deterministic source zip")
-    (source / prerelease.SOURCE_TAR_NAME).write_bytes(b"deterministic source tar")
-    checksum_lines = [
-        f"{_sha256(source / name)}  {name}"
-        for name in sorted(prerelease.SOURCE_PAYLOAD_NAMES)
-    ]
-    (source / prerelease.CHECKSUMS_NAME).write_text(
-        "\n".join(checksum_lines) + "\n",
-        encoding="ascii",
-    )
-    return source
-
-
-def _assemble(tmp_path: Path, output_name: str = "out") -> tuple[Path, Path, Path, Path]:
+def _assemble(tmp_path: Path, output_name: str = "out") -> tuple[Path, Path, Path]:
     macos = _candidate(tmp_path / "candidates", "macos")
     windows = _candidate(tmp_path / "candidates", "windows")
-    source = _source_assets(tmp_path)
     output = prerelease.assemble_prerelease(
         macos,
         windows,
-        source,
         tmp_path / output_name,
         TAG,
         COMMIT,
     )
-    return output, macos, windows, source
+    return output, macos, windows
 
 
 def _mutate_manifest(candidate: Path, callback) -> None:
@@ -186,18 +165,18 @@ def _rewrite_public_checksums(output: Path) -> None:
 
 
 def test_assemble_creates_exact_public_assets_and_candidate_zips(tmp_path):
-    output, macos, windows, source = _assemble(tmp_path)
+    output, macos, windows = _assemble(tmp_path)
 
     assert {path.name for path in output.iterdir()} == set(prerelease.PUBLIC_ASSET_NAMES)
     assert (output / prerelease.MACOS_DMG_NAME).read_bytes() == (
-        macos / "codex-keysmith_0.2.0_aarch64.dmg"
+        macos / f"codex-keysmith_{VERSION}_aarch64.dmg"
     ).read_bytes()
     assert (output / prerelease.WINDOWS_SETUP_NAME).read_bytes() == (
-        windows / "codex-keysmith_0.2.0_x64-setup.exe"
+        windows / f"codex-keysmith_{VERSION}_x64-setup.exe"
     ).read_bytes()
-    for name in prerelease.SOURCE_PAYLOAD_NAMES:
-        assert (output / name).read_bytes() == (source / name).read_bytes()
-    prerelease.verify_public_assets(output, COMMIT, source)
+    for name in prerelease.SOURCE_RELEASE_PAYLOAD_NAMES:
+        assert not (output / name).exists()
+    prerelease.verify_public_assets(output, COMMIT)
     for candidate, zip_name in (
         (macos, prerelease.MACOS_CANDIDATE_ZIP_NAME),
         (windows, prerelease.WINDOWS_CANDIDATE_ZIP_NAME),
@@ -209,9 +188,9 @@ def test_assemble_creates_exact_public_assets_and_candidate_zips(tmp_path):
 
 
 def test_candidate_zip_is_reproducible(tmp_path):
-    first, macos, windows, source = _assemble(tmp_path, "first")
+    first, macos, windows = _assemble(tmp_path, "first")
     second = prerelease.assemble_prerelease(
-        macos, windows, source, tmp_path / "second", TAG, COMMIT
+        macos, windows, tmp_path / "second", TAG, COMMIT
     )
 
     for name in (
@@ -228,19 +207,17 @@ def test_candidate_zip_is_reproducible(tmp_path):
     ("tag", "commit", "message"),
     [
         ("v0.2.0", COMMIT, "release tag"),
-        ("desktop-v0.2.0-beta.0", COMMIT, "release tag"),
+        ("desktop-v0.2.0-beta.1", COMMIT, "release tag"),
+        (f"desktop-v{prerelease.VERSION}-beta.0", COMMIT, "release tag"),
         (TAG, "ABC", "expected commit"),
     ],
 )
 def test_assemble_rejects_invalid_identity(tmp_path, tag, commit, message):
     macos = _candidate(tmp_path, "macos")
     windows = _candidate(tmp_path, "windows")
-    source = _source_assets(tmp_path)
 
     with pytest.raises(prerelease.PrereleaseError, match=message):
-        prerelease.assemble_prerelease(
-            macos, windows, source, tmp_path / "out", tag, commit
-        )
+        prerelease.assemble_prerelease(macos, windows, tmp_path / "out", tag, commit)
 
 
 @pytest.mark.parametrize(
@@ -261,66 +238,53 @@ def test_assemble_rejects_invalid_identity(tmp_path, tag, commit, message):
 def test_assemble_rejects_manifest_policy_drift(tmp_path, mutation, message):
     macos = _candidate(tmp_path, "macos")
     windows = _candidate(tmp_path, "windows")
-    source = _source_assets(tmp_path)
     _mutate_manifest(windows, mutation)
 
     with pytest.raises(prerelease.PrereleaseError, match=message):
-        prerelease.assemble_prerelease(
-            macos, windows, source, tmp_path / "out", TAG, COMMIT
-        )
+        prerelease.assemble_prerelease(macos, windows, tmp_path / "out", TAG, COMMIT)
 
 
 def test_assemble_rejects_cross_platform_candidate_swap(tmp_path):
     macos = _candidate(tmp_path, "macos")
     windows = _candidate(tmp_path, "windows")
-    source = _source_assets(tmp_path)
 
     with pytest.raises(prerelease.PrereleaseError, match="macos target policy"):
-        prerelease.assemble_prerelease(
-            windows, macos, source, tmp_path / "out", TAG, COMMIT
-        )
+        prerelease.assemble_prerelease(windows, macos, tmp_path / "out", TAG, COMMIT)
 
 
 def test_assemble_rejects_tampering_extra_files_symlinks_and_overwrite(tmp_path):
     macos = _candidate(tmp_path / "tampered", "macos")
     tampered = _candidate(tmp_path / "tampered", "windows")
-    source = _source_assets(tmp_path / "tampered")
     (tampered / "codex-keysmith-cli.exe").write_bytes(b"tampered")
     with pytest.raises(prerelease.PrereleaseError, match="hash or size mismatch"):
         prerelease.assemble_prerelease(
-            macos, tampered, source, tmp_path / "tampered-out", TAG, COMMIT
+            macos, tampered, tmp_path / "tampered-out", TAG, COMMIT
         )
 
     macos = _candidate(tmp_path / "extra", "macos")
     extra = _candidate(tmp_path / "extra", "windows")
-    source = _source_assets(tmp_path / "extra")
     (extra / "unexpected.txt").write_text("unexpected", encoding="utf-8")
     with pytest.raises(prerelease.PrereleaseError, match="file set is not exact"):
-        prerelease.assemble_prerelease(
-            macos, extra, source, tmp_path / "extra-out", TAG, COMMIT
-        )
+        prerelease.assemble_prerelease(macos, extra, tmp_path / "extra-out", TAG, COMMIT)
 
     macos = _candidate(tmp_path / "linked", "macos")
     linked = _candidate(tmp_path / "linked", "windows")
-    source = _source_assets(tmp_path / "linked")
     icon = linked / "icon.ico"
     icon.unlink()
     icon.symlink_to(linked / "codex-keysmith-cli.exe")
     with pytest.raises(prerelease.PrereleaseError, match="not a symlink"):
         prerelease.assemble_prerelease(
-            macos, linked, source, tmp_path / "linked-out", TAG, COMMIT
+            macos, linked, tmp_path / "linked-out", TAG, COMMIT
         )
 
     macos = _candidate(tmp_path / "linked-directory", "macos")
     real_candidate = _candidate(tmp_path / "linked-directory", "windows")
-    source = _source_assets(tmp_path / "linked-directory")
     candidate_link = tmp_path / "candidate-link"
     candidate_link.symlink_to(real_candidate, target_is_directory=True)
     with pytest.raises(prerelease.PrereleaseError, match="missing or unsafe"):
         prerelease.assemble_prerelease(
             macos,
             candidate_link,
-            source,
             tmp_path / "linked-directory-out",
             TAG,
             COMMIT,
@@ -328,26 +292,16 @@ def test_assemble_rejects_tampering_extra_files_symlinks_and_overwrite(tmp_path)
 
     macos = _candidate(tmp_path / "overwrite", "macos")
     windows = _candidate(tmp_path / "overwrite", "windows")
-    source = _source_assets(tmp_path / "overwrite")
     output = tmp_path / "existing-output"
     output.mkdir()
     (output / "keep.txt").write_text("keep", encoding="utf-8")
     with pytest.raises(prerelease.PrereleaseError, match="absent or empty"):
-        prerelease.assemble_prerelease(macos, windows, source, output, TAG, COMMIT)
+        prerelease.assemble_prerelease(macos, windows, output, TAG, COMMIT)
     assert (output / "keep.txt").read_text(encoding="utf-8") == "keep"
-
-    macos = _candidate(tmp_path / "bad-source", "macos")
-    windows = _candidate(tmp_path / "bad-source", "windows")
-    source = _source_assets(tmp_path / "bad-source")
-    (source / prerelease.CLI_NAME).write_text("tampered", encoding="utf-8")
-    with pytest.raises(prerelease.PrereleaseError, match="source SHA256SUMS"):
-        prerelease.assemble_prerelease(
-            macos, windows, source, tmp_path / "bad-source-out", TAG, COMMIT
-        )
 
 
 def test_verify_public_assets_rejects_tampering_and_extra_assets(tmp_path):
-    output, _macos, _windows, _source = _assemble(tmp_path)
+    output, _macos, _windows = _assemble(tmp_path)
     with pytest.raises(prerelease.PrereleaseError, match="source commit"):
         prerelease.verify_public_assets(output, "b" * 40)
     (output / prerelease.WINDOWS_SETUP_NAME).write_bytes(b"tampered")
@@ -359,7 +313,7 @@ def test_verify_public_assets_rejects_tampering_and_extra_assets(tmp_path):
     with pytest.raises(prerelease.PrereleaseError, match="public windows bundle"):
         prerelease.verify_public_assets(output, COMMIT)
 
-    output, _macos, _windows, _source = _assemble(tmp_path / "zip-case")
+    output, _macos, _windows = _assemble(tmp_path / "zip-case")
     extracted = tmp_path / "tampered-zip"
     extracted.mkdir()
     with zipfile.ZipFile(output / prerelease.WINDOWS_CANDIDATE_ZIP_NAME) as archive:
@@ -375,19 +329,18 @@ def test_verify_public_assets_rejects_tampering_and_extra_assets(tmp_path):
     with pytest.raises(prerelease.PrereleaseError, match="hash or size mismatch"):
         prerelease.verify_public_assets(output, COMMIT)
 
-    output, _macos, _windows, source = _assemble(tmp_path / "source-case")
+    output, _macos, _windows = _assemble(tmp_path / "source-case")
     (output / prerelease.CLI_NAME).write_text("tampered", encoding="utf-8")
-    _rewrite_public_checksums(output)
-    with pytest.raises(prerelease.PrereleaseError, match="commit-bound build output"):
-        prerelease.verify_public_assets(output, COMMIT, source)
+    with pytest.raises(prerelease.PrereleaseError, match="asset set is not exact"):
+        prerelease.verify_public_assets(output, COMMIT)
 
-    output, _macos, _windows, _source = _assemble(tmp_path / "extra-case")
+    output, _macos, _windows = _assemble(tmp_path / "extra-case")
     (output / "unexpected.txt").write_text("unexpected", encoding="utf-8")
     with pytest.raises(prerelease.PrereleaseError, match="asset set is not exact"):
         prerelease.verify_public_assets(output, COMMIT)
 
 
-def test_prerelease_workflow_is_separate_unsigned_and_publisher_disabled():
+def test_prerelease_workflow_is_separate_unsigned_and_versioned():
     desktop = (REPO_ROOT / ".github/workflows/desktop-candidate.yml").read_text(
         encoding="utf-8"
     )
@@ -397,8 +350,11 @@ def test_prerelease_workflow_is_separate_unsigned_and_publisher_disabled():
     assert "pull_request_target:" not in desktop
     assert "workflow_run:" not in desktop
     assert desktop.count("contents: write") == 1
-    assert "if: >-\n      ${{ false }}" in desktop
-    assert "Historical v0.2.0 publisher; disabled" in desktop
+    assert (
+        "if: >-\n      ${{ github.event_name == 'workflow_dispatch' && inputs.publish_desktop_prerelease }}"
+        in desktop
+    )
+    assert "Publish the current unsigned desktop line as desktop-v<VERSION>-beta.N." in desktop
     assert "verify-manifest-data" in desktop
     assert '"prerelease": True' in desktop
     assert '"make_latest": "false"' in desktop
@@ -410,6 +366,8 @@ def test_prerelease_workflow_is_separate_unsigned_and_publisher_disabled():
     assert "Removed the uniquely owned empty Draft" in desktop
     assert "Recovered numeric-ID ownership after a lost create response." in desktop
     assert 'release_author="github-actions[bot]"' in desktop
+    assert 'len(state["assets"]) == 5' in desktop
+    assert "--source-dir" not in desktop
     final_state = desktop.index(
         'final_state="${RUNNER_TEMP}/desktop-prerelease-published.json"'
     )
@@ -437,7 +395,7 @@ def test_prerelease_creation_validator_binds_numeric_id_and_unsigned_metadata(
 
     repo = "Jia-Ethan/codex-keysmith"
     release_id = "400000001"
-    draft_name = "codex-keysmith 0.2.0 Desktop Beta [run 123.1]"
+    draft_name = f"codex-keysmith {VERSION} Desktop Beta [run 123.1]"
     notes = tmp_path / "notes.md"
     notes.write_bytes(b"unsigned beta notes\n")
     payload = {
@@ -504,7 +462,7 @@ def test_lost_create_response_recovery_requires_unique_run_owned_draft(
     output = tmp_path / "adopted.json"
     actor = "github-actions[bot]"
     started_at = "2026-08-10T01:00:00Z"
-    draft_name = "codex-keysmith 0.2.0 Desktop Beta [run 123.1]"
+    draft_name = f"codex-keysmith {VERSION} Desktop Beta [run 123.1]"
     release = {
         "id": 400000002,
         "tag_name": TAG,
@@ -555,7 +513,7 @@ def test_prerelease_docs_disclose_assets_privacy_and_beta_boundaries():
     paths = [
         REPO_ROOT / "README.md",
         REPO_ROOT / "README.en.md",
-        REPO_ROOT / "docs/releases/desktop-v0.2.0-beta.6.md",
+        REPO_ROOT / f"docs/releases/{TAG}.md",
         REPO_ROOT / "CODE_SIGNING_POLICY.md",
         REPO_ROOT / "PRIVACY.md",
     ]
@@ -566,6 +524,7 @@ def test_prerelease_docs_disclose_assets_privacy_and_beta_boundaries():
         prerelease.MACOS_DMG_NAME,
         prerelease.WINDOWS_SETUP_NAME,
         prerelease.CLI_NAME,
+        "v0.3.5",
         "SHA256SUMS",
         "unsigned",
         "SmartScreen",
@@ -588,7 +547,7 @@ def test_prerelease_docs_disclose_assets_privacy_and_beta_boundaries():
     assert "native artifact validation still pending in CI" not in readmes
 
 
-def test_prerelease_release_notes_match_approved_compact_copy():
+def test_historical_desktop_beta6_notes_remain_unchanged():
     release_notes = (REPO_ROOT / "docs/releases/desktop-v0.2.0-beta.6.md").read_text(
         encoding="utf-8"
     )
@@ -603,6 +562,25 @@ def test_prerelease_release_notes_match_approved_compact_copy():
         - macOS Apple Silicon：`codex-keysmith-0.2.0-macos-arm64-unsigned.dmg`
         - Windows x64：`codex-keysmith-0.2.0-windows-x64-unsigned-setup.exe`
         - 单文件 CLI：`codex-instruct-v0.2.0.py`
+        - 文件校验：`SHA256SUMS`
+        """
+    )
+    assert release_notes == expected
+
+
+def test_prerelease_release_notes_match_approved_compact_copy():
+    release_notes = (REPO_ROOT / f"docs/releases/{TAG}.md").read_text(encoding="utf-8")
+    expected = textwrap.dedent(
+        f"""\
+        # codex-keysmith v{VERSION} Desktop Beta
+
+        把源码 GUI 场景库页打进 unsigned 安装包：列表、显式目标目录、preview 门禁、status、按 deployment_id 卸载和恢复。GUI 只调用 CLI 场景命令。Windows 上三个生产场景仍只声明 darwin/linux，部署会被 blocker 拦住。
+
+        ## 下载
+
+        - macOS Apple Silicon：`{prerelease.MACOS_DMG_NAME}`
+        - Windows x64：`{prerelease.WINDOWS_SETUP_NAME}`
+        - 单文件 CLI 与场景 bundle：见 [v{VERSION}](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/v{VERSION})
         - 文件校验：`SHA256SUMS`
         """
     )

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -618,7 +618,7 @@ def test_scenario_bundle_builder_rejects_case_insensitive_member_collision(
         release_builder.write_scenario_bundle(repo, tmp_path / "scenarios.bundle", version=VERSION)
 
 
-def test_release_builder_output_is_not_reused_for_historical_desktop_beta(
+def test_release_builder_output_is_not_reused_as_desktop_prerelease(
     release_builder,
     tmp_path,
 ):
@@ -627,8 +627,8 @@ def test_release_builder_output_is_not_reused_for_historical_desktop_beta(
 
     release_builder.build_release(TAG, repo, output_dir)
 
-    with pytest.raises(desktop_prerelease.PrereleaseError, match="source asset set is not exact"):
-        desktop_prerelease._validate_source_assets(output_dir)
+    with pytest.raises(desktop_prerelease.PrereleaseError, match="public asset set is not exact"):
+        desktop_prerelease.verify_public_assets(output_dir, "a" * 40)
 
 
 def test_default_in_repository_output_can_be_rebuilt(release_builder, tmp_path):


### PR DESCRIPTION
已将 `desktop-v0.3.5-beta.1` unsigned Desktop 发布准备合入 `main`：安装包包含 GUI 场景库页，公开资产固定为 macOS DMG、Windows NSIS、两个 candidate ZIP 和 `SHA256SUMS`；CLI、源码包与场景 bundle 继续留在 `v0.3.5`，Release 保持 Pre-release 且不影响 Latest，历史 `desktop-v0.2.0-beta.*` 不变。当前未打 tag、未 dispatch、未发布。