### PR TITLE
docs: 同步 v0.3.8 发布状态

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ### Desktop
 
-- Prepared unsigned `desktop-v0.3.8-beta.1` for macOS Apple Silicon and Windows x64 with the same GUI and frozen sidecar behavior as `desktop-v0.3.7-beta.1`, plus the inactive-by-config uninstall fix. This source change prepares the candidate; publication remains a separate signed-tag, main-only workflow action.
+- Published unsigned Desktop Beta `desktop-v0.3.8-beta.1` for macOS Apple Silicon and Windows x64 with the same GUI and frozen sidecar behavior as `desktop-v0.3.7-beta.1`, plus the inactive-by-config uninstall fix. Its public assets are the DMG, NSIS setup executable, two candidate ZIPs, and `SHA256SUMS`; stable Latest remains `v0.3.8`.
 
 ## [0.3.7] - 2026-08-18
 

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -2,9 +2,9 @@
 
 ## Current desktop beta
 
-`desktop-v0.3.7-beta.1` publishes `codex-keysmith-0.3.7-macos-arm64-unsigned.dmg` and `codex-keysmith-0.3.7-windows-x64-unsigned-setup.exe` as the current unsigned Desktop Beta. The public asset set is those two installers, two candidate ZIPs, and `SHA256SUMS`. Stable CLI and source assets remain on the separate `v0.3.7` Release. The DMG is not Apple-signed or notarized, and the installer has no Authenticode signature. macOS may show Gatekeeper warnings; Windows may show **Unknown publisher** and Microsoft Defender SmartScreen warnings.
+`desktop-v0.3.8-beta.1` publishes `codex-keysmith-0.3.8-macos-arm64-unsigned.dmg` and `codex-keysmith-0.3.8-windows-x64-unsigned-setup.exe` as the current unsigned Desktop Beta. The public asset set is those two installers, two candidate ZIPs, and `SHA256SUMS`. Stable CLI and source assets remain on the separate `v0.3.8` Release. The DMG is not Apple-signed or notarized, and the installer has no Authenticode signature. macOS may show Gatekeeper warnings; Windows may show **Unknown publisher** and Microsoft Defender SmartScreen warnings.
 
-`desktop-v0.3.8-beta.1` is the next unpublished candidate and will use the same unsigned macOS Apple Silicon / Windows x64 boundary. `desktop-v0.3.5-beta.1` and the `desktop-v0.2.0-beta.*` line remain historical prereleases. None is overwritten by a later beta.
+`desktop-v0.3.7-beta.1`, `desktop-v0.3.5-beta.1`, and the `desktop-v0.2.0-beta.*` line remain historical prereleases. None is overwritten by a later beta.
 
 The signed `desktop-v0.2.0-beta.1` tag is retained as immutable evidence of an aborted publication attempt. Its draft was removed before asset upload, so it has no public Release or downloadable assets.
 

--- a/README.en.md
+++ b/README.en.md
@@ -44,8 +44,8 @@ The Keysmith series **deploys, verifies, and revokes** custom instructions for l
 
 ### Install options
 
-1. **Conservative: stable CLI.** Open the [latest stable Release](https://github.com/Jia-Ethan/codex-keysmith/releases/latest), download `codex-instruct-v*.py` and `SHA256SUMS`, verify, then run; the current stable asset is `codex-instruct-v0.3.7.py`. Do not `curl | python`.
-2. **Easier: unsigned Desktop Beta.** See the [Desktop prerelease](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.3.7-beta.1): macOS Apple Silicon DMG and Windows x64 NSIS, with an embedded CLI sidecar, two presets, and four fixture packs. No signing, no auto-update, no Linux GUI. Install notes: [`CODE_SIGNING_POLICY.md`](CODE_SIGNING_POLICY.md).
+1. **Conservative: stable CLI.** Open the [latest stable Release](https://github.com/Jia-Ethan/codex-keysmith/releases/latest), download `codex-instruct-v*.py` and `SHA256SUMS`, verify, then run; the current stable asset is `codex-instruct-v0.3.8.py`. Do not `curl | python`.
+2. **Easier: unsigned Desktop Beta.** See the [Desktop prerelease](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.3.8-beta.1): macOS Apple Silicon DMG and Windows x64 NSIS, with an embedded CLI sidecar, two presets, four fixture packs, and the inactive-by-config uninstall fix. No signing, no auto-update, no Linux GUI. Install notes: [`CODE_SIGNING_POLICY.md`](CODE_SIGNING_POLICY.md).
 3. **Source.** Clone and run `python3 codex-instruct.py`. The default branch source version is `0.3.8`; check the Releases page for the latest stable Release.
 
 ### Quick start

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Keysmith 系列为本地 AI 工具**安全部署、验证和撤销**自定义指
 
 ### 安装方式
 
-1. **稳妥：稳定 CLI。** 打开 [最新稳定 Release](https://github.com/Jia-Ethan/codex-keysmith/releases/latest)，下载单文件 `codex-instruct-v*.py` 与 `SHA256SUMS`，校验后再运行；当前稳定资产名为 `codex-instruct-v0.3.7.py`。不要 `curl | python`。
-2. **更易用：未签名 Desktop Beta。** 见 [Desktop 预发布](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.3.7-beta.1)：macOS Apple Silicon DMG 与 Windows x64 NSIS，内嵌 CLI sidecar、双 preset 与四个 fixture 包。无签名、无自动更新、无 Linux GUI。安装步骤见 [`CODE_SIGNING_POLICY.md`](CODE_SIGNING_POLICY.md)。
+1. **稳妥：稳定 CLI。** 打开 [最新稳定 Release](https://github.com/Jia-Ethan/codex-keysmith/releases/latest)，下载单文件 `codex-instruct-v*.py` 与 `SHA256SUMS`，校验后再运行；当前稳定资产名为 `codex-instruct-v0.3.8.py`。不要 `curl | python`。
+2. **更易用：未签名 Desktop Beta。** 见 [Desktop 预发布](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.3.8-beta.1)：macOS Apple Silicon DMG 与 Windows x64 NSIS，内嵌 CLI sidecar、双 preset 与四个 fixture 包，并包含 inactive-by-config 卸载修复。无签名、无自动更新、无 Linux GUI。安装步骤见 [`CODE_SIGNING_POLICY.md`](CODE_SIGNING_POLICY.md)。
 3. **源码。** clone 后直接 `python3 codex-instruct.py`。当前默认分支源码版本为 `0.3.8`；最新稳定 Release 仍以 Releases 页为准。
 
 ### 快速开始

--- a/gui/README.md
+++ b/gui/README.md
@@ -43,7 +43,7 @@ npm run tauri build
 | macOS Apple Silicon | `codex-keysmith-cli-aarch64-apple-darwin` | `.app` + ARM64 `.dmg` |
 | Windows x64 | `codex-keysmith-cli-x86_64-pc-windows-msvc.exe` | current-user NSIS `.exe` |
 
-当前公开的 `desktop-v0.3.7-beta.1` 提供 macOS Apple Silicon unsigned DMG 与 Windows x64 unsigned NSIS，并包含场景库页、双 preset 部署与四个 fixture 包。下一档 `desktop-v0.3.8-beta.1` 候选继续保持这两个平台与未签名边界，冻结 sidecar 会内嵌四个 `fixture_packs/`，并包含 inactive-by-config 卸载修复。Windows 安装器使用 WebView2 download bootstrapper、禁止降级，当前不生成 MSI；两平台均尚未进行正式签名、公证或实体设备验收。普通用户按平台下载已发布的 DMG 或 setup EXE；正式 Authenticode 发行仍待 SignPath Foundation 审核和独立签名流程。
+当前公开的 `desktop-v0.3.8-beta.1` 提供 macOS Apple Silicon unsigned DMG 与 Windows x64 unsigned NSIS，包含场景库页、双 preset 部署、四个 fixture 包与 inactive-by-config 卸载修复；冻结 sidecar 不依赖源码树即可列出或写入夹具。`desktop-v0.3.7-beta.1` 保持为历史预发布，不被覆盖。Windows 安装器使用 WebView2 download bootstrapper、禁止降级，当前不生成 MSI；两平台均尚未进行正式签名、公证或实体设备验收。普通用户按平台下载已发布的 DMG 或 setup EXE；正式 Authenticode 发行仍待 SignPath Foundation 审核和独立签名流程。
 
 图标以 `src-tauri/icons/source.png` 为唯一源文件。修改后运行：
 

--- a/gui/SPEC.md
+++ b/gui/SPEC.md
@@ -1,6 +1,6 @@
 # codex-keysmith GUI 客户端 — 技术方案与交接文档
 
-> 状态：源码已具备指令层 GUI（M1–M5）、场景库页、preset 选择与 fixture scaffold 页；冻结 sidecar 内嵌 `fixture_packs/`。当前公开安装包是 `desktop-v0.3.7-beta.1`；下一档 unsigned Desktop 候选为 `desktop-v0.3.8-beta.1`。正式签名、公证与实体设备验收仍待完成
+> 状态：源码已具备指令层 GUI（M1–M5）、场景库页、preset 选择与 fixture scaffold 页；冻结 sidecar 内嵌 `fixture_packs/`。`desktop-v0.3.8-beta.1` 已作为当前 unsigned Desktop 公开发布；正式签名、公证与实体设备验收仍待完成
 > 关联 issue：[#10「建议」为小白做一个可视化的界面客户端](https://github.com/Jia-Ethan/codex-keysmith/issues/10)
 
 ## 1. 项目背景
@@ -16,7 +16,7 @@ CLI 对熟练用户很好用，但对小白（issue #10 的目标用户）门槛
 | 技术栈 | **Tauri 2**（Rust 后端 + Web 前端） | 打包体积小（几 MB）、原生感强、界面现代化 |
 | 平台范围 | **macOS Apple Silicon + Windows x64** | 每个平台原生冻结 Python 与构建 Tauri bundle，不做跨平台交叉打包；本轮不提供 Intel Mac 包 |
 | 与 CLI 的关系 | **包装现有 CLI**（subprocess 调用），不重实现逻辑 | 复用已测试的部署/回滚/恢复逻辑，CLI 升级客户端不用跟着改 |
-| 本轮交付 | **指令层 M1–M5 + 场景库 + 双通道 GUI** | 部署页可选 preset；夹具页只调用 CLI scaffold；sidecar 内嵌 `fixture_packs/`；下一档尚未发布的 unsigned 候选为 `desktop-v0.3.8-beta.1` |
+| 本轮交付 | **指令层 M1–M5 + 场景库 + 双通道 GUI** | 部署页可选 preset；夹具页只调用 CLI scaffold；sidecar 内嵌 `fixture_packs/`；已发布为 unsigned `desktop-v0.3.8-beta.1` |
 
 ## 3. 总体架构
 
@@ -343,13 +343,13 @@ async fn cli_runtime(cli_path: Option<String>) -> Result<String, String>;
 | **M4 打包基础** ✅ | PyInstaller sidecar、统一图标、macOS app/dmg 配置 | 安装包内置冻结 CLI，不依赖系统 Python；签名/公证/Release CI 单独验收 |
 | **M5 Windows x64 打包基础** ✅ | 原生 sidecar + current-user NSIS + WebView2 bootstrapper | 可在 Windows x64 原生环境产出 `.exe`；CI 安装后验证配置/运行目录隔离、活动 sidecar 期间排队关闭、单实例交接、原生空闲关闭及无 GUI/sidecar 残留；正式发布前仍需 Authenticode 与实体设备验收 |
 | **场景 M4 场景库页** ✅ | 列表、详情、显式 `--target-dir`、preview 门禁、status、uninstall、recovery | GUI 只调用 CLI 场景命令；预览绑定规范目标与场景/部署标识，选择变化后失效；状态与写结果保留 blocker、stdout/stderr，并在每次写操作后刷新；进入 `desktop-v0.3.5-beta.1` |
-| **Desktop 双通道与夹具页** ✅ | Deploy 双 preset、本地文件模式、Fixtures 列表/预览/写入/删除、sidecar 内嵌 fixture packs | GUI 只调用既有 CLI；部署参数互斥；夹具预览绑定 pack/目录/force 并明确未修改 `~/.codex`；源码候选为 `desktop-v0.3.8-beta.1` |
+| **Desktop 双通道与夹具页** ✅ | Deploy 双 preset、本地文件模式、Fixtures 列表/预览/写入/删除、sidecar 内嵌 fixture packs | GUI 只调用既有 CLI；部署参数互斥；夹具预览绑定 pack/目录/force 并明确未修改 `~/.codex`；已进入 `desktop-v0.3.8-beta.1` |
 
 ## 10. 交接说明（给接手 Agent）
 
 **起点：** canonical 仓库内的 `gui/` 目录；CLI 源码固定取仓库根目录 `codex-instruct.py`，GUI 与 CLI 可绑定到同一提交。
 
-**当前交付（截至 2026-08-19，v0.3.8 源码候选）：**
+**当前交付（截至 2026-08-19，v0.3.8 源码与 unsigned Desktop Beta）：**
 
 - `src-tauri/`：Tauri 2 工程，提供 `cli_run` / `read_manifest` / `detect_cli` / `cli_version` / `cli_runtime`
 - `src/`：React 19 前端，六视图（Dashboard / Deploy / Scenarios / Fixtures / Manage / Settings）+ react-i18next + 双主题设计系统（token 沿用 ethanpier.com：深色 tech blue / 浅色 clay）
@@ -372,11 +372,11 @@ async fn cli_runtime(cli_path: Option<String>) -> Result<String, String>;
 - `Hooks restore: available …` 是提示行不是状态，解析时映射为 `restorable`
 - kv 区可能出现 `[Error] config.toml …` 中文诊断行，需转成 warning 展示而非吞掉
 
-**后续工作（正式发布门禁）：**
+**后续工作（signed Desktop 门禁）：**
 
-1. 从最终发布提交在原生 Apple Silicon / Windows x64 runner 上重跑阻断构建与安装包验证，并绑定标签、source commit、build manifest 和资产校验和
-2. Apple Developer ID 签名、公证和 stapling；Windows Authenticode 签名与时间戳
-3. 验证最终安装版本、架构、sidecar、图标、升级/降级和卸载残留后再创建 GitHub Release
+1. Apple Developer ID 签名、公证和 stapling；Windows Authenticode 签名与时间戳
+2. 在 macOS Apple Silicon 与 Windows x64 实体设备验证安装版本、架构、sidecar、图标、升级/降级和卸载残留
+3. 通过独立签名工作流发布新的 signed Desktop 版本，不覆盖现有 unsigned beta
 
 **长期约束（仍需遵守）：**
 

--- a/tests/test_desktop_prerelease.py
+++ b/tests/test_desktop_prerelease.py
@@ -16,12 +16,13 @@ COMMIT = "a" * 40
 TAG = f"desktop-v{prerelease.VERSION}-beta.1"
 REPO_ROOT = Path(__file__).resolve().parents[1]
 VERSION = prerelease.VERSION
-PUBLISHED_DESKTOP_VERSION = "0.3.7"
+PUBLISHED_DESKTOP_VERSION = "0.3.8"
 PUBLISHED_DESKTOP_TAG = f"desktop-v{PUBLISHED_DESKTOP_VERSION}-beta.1"
-PUBLISHED_SOURCE_VERSION = "0.3.7"
+PUBLISHED_SOURCE_VERSION = "0.3.8"
 HISTORICAL_DESKTOP_VERSION = "0.3.5"
 HISTORICAL_DESKTOP_TAG = f"desktop-v{HISTORICAL_DESKTOP_VERSION}-beta.1"
-CANDIDATE_DESKTOP_TAG = f"desktop-v{VERSION}-beta.1"
+PREVIOUS_DESKTOP_VERSION = "0.3.7"
+PREVIOUS_DESKTOP_TAG = f"desktop-v{PREVIOUS_DESKTOP_VERSION}-beta.1"
 
 
 def _sha256(path: Path) -> str:
@@ -595,18 +596,18 @@ def test_historical_desktop_v035_notes_remain_unchanged():
     assert release_notes == expected
 
 
-def test_published_desktop_v037_notes_remain_unchanged():
+def test_previous_desktop_v037_notes_remain_unchanged():
     release_notes = (
-        REPO_ROOT / f"docs/releases/{PUBLISHED_DESKTOP_TAG}.md"
+        REPO_ROOT / f"docs/releases/{PREVIOUS_DESKTOP_TAG}.md"
     ).read_text(encoding="utf-8")
     assert release_notes.startswith(
-        f"# codex-keysmith v{PUBLISHED_DESKTOP_VERSION} Desktop Beta\n"
+        f"# codex-keysmith v{PREVIOUS_DESKTOP_VERSION} Desktop Beta\n"
     )
     for marker in (
         "WINDOWS_FRESH_DEPLOYMENT_POLICY: EXPLICIT_BETA",
-        f"codex-keysmith-{PUBLISHED_DESKTOP_VERSION}-macos-arm64-unsigned.dmg",
-        f"codex-keysmith-{PUBLISHED_DESKTOP_VERSION}-windows-x64-unsigned-setup.exe",
-        f"v{PUBLISHED_DESKTOP_VERSION}",
+        f"codex-keysmith-{PREVIOUS_DESKTOP_VERSION}-macos-arm64-unsigned.dmg",
+        f"codex-keysmith-{PREVIOUS_DESKTOP_VERSION}-windows-x64-unsigned-setup.exe",
+        f"v{PREVIOUS_DESKTOP_VERSION}",
         "SHA256SUMS",
         "unrestricted",
         "contract",
@@ -615,9 +616,9 @@ def test_published_desktop_v037_notes_remain_unchanged():
         assert marker in release_notes
 
 
-def test_candidate_prerelease_release_notes_match_approved_compact_copy():
+def test_published_prerelease_release_notes_match_approved_compact_copy():
     release_notes = (
-        REPO_ROOT / f"docs/releases/{CANDIDATE_DESKTOP_TAG}.md"
+        REPO_ROOT / f"docs/releases/{PUBLISHED_DESKTOP_TAG}.md"
     ).read_text(encoding="utf-8")
     expected = textwrap.dedent(
         """\


### PR DESCRIPTION
## 说明

- 将中英文 README、签名策略和 GUI 文档更新为已发布的 v0.3.8 / desktop-v0.3.8-beta.1
- 将 CHANGELOG 的 Desktop 状态从候选改为已发布
- 更新 Desktop 发布文档契约测试，保留历史 desktop-v0.3.7-beta.1 断言

## 验证

- python3 -m pytest -q tests/test_desktop_prerelease.py — 24 passed
- python3 -m pytest -q tests/test_release_artifacts.py — 68 passed, 1 skipped
- python3 scripts/validate_desktop_candidate.py config --root .
- python3 -m ruff check tests/test_desktop_prerelease.py
- python3 -m py_compile tests/test_desktop_prerelease.py
- git diff --check
