### PR TITLE
docs: 同步 v0.3.9 发布状态

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ### Desktop
 
-- Prepared the unsigned `desktop-v0.3.9-beta.1` source line with the same `0.3.9` CLI sidecar and GUI recovery path. Publication remains a separate signed-tag, main-only workflow action; the published `desktop-v0.3.8-beta.1` assets remain immutable.
+- Published unsigned Desktop Beta `desktop-v0.3.9-beta.1` for macOS Apple Silicon and Windows x64 with the same `0.3.9` CLI sidecar and GUI recovery path. Its public assets are the DMG, NSIS setup executable, two candidate ZIPs, and `SHA256SUMS`; stable Latest remains `v0.3.9`.
 
 ## [0.3.8] - 2026-08-19
 

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -2,9 +2,9 @@
 
 ## Current desktop beta
 
-`desktop-v0.3.8-beta.1` publishes `codex-keysmith-0.3.8-macos-arm64-unsigned.dmg` and `codex-keysmith-0.3.8-windows-x64-unsigned-setup.exe` as the current unsigned Desktop Beta. The public asset set is those two installers, two candidate ZIPs, and `SHA256SUMS`. Stable CLI and source assets remain on the separate `v0.3.8` Release. The DMG is not Apple-signed or notarized, and the installer has no Authenticode signature. macOS may show Gatekeeper warnings; Windows may show **Unknown publisher** and Microsoft Defender SmartScreen warnings.
+`desktop-v0.3.9-beta.1` publishes `codex-keysmith-0.3.9-macos-arm64-unsigned.dmg` and `codex-keysmith-0.3.9-windows-x64-unsigned-setup.exe` as the current unsigned Desktop Beta. The public asset set is those two installers, two candidate ZIPs, and `SHA256SUMS`. Stable CLI and source assets remain on the separate `v0.3.9` Release. The DMG is not Apple-signed or notarized, and the installer has no Authenticode signature. macOS may show Gatekeeper warnings; Windows may show **Unknown publisher** and Microsoft Defender SmartScreen warnings.
 
-`desktop-v0.3.9-beta.1` is the next unpublished candidate and will use the same unsigned macOS Apple Silicon / Windows x64 boundary. `desktop-v0.3.7-beta.1`, `desktop-v0.3.5-beta.1`, and the `desktop-v0.2.0-beta.*` line remain historical prereleases. None is overwritten by a later beta.
+`desktop-v0.3.8-beta.1`, `desktop-v0.3.7-beta.1`, `desktop-v0.3.5-beta.1`, and the `desktop-v0.2.0-beta.*` line remain historical prereleases. None is overwritten by a later beta.
 
 The signed `desktop-v0.2.0-beta.1` tag is retained as immutable evidence of an aborted publication attempt. Its draft was removed before asset upload, so it has no public Release or downloadable assets.
 

--- a/README.en.md
+++ b/README.en.md
@@ -44,9 +44,9 @@ The Keysmith series **deploys, verifies, and revokes** custom instructions for l
 
 ### Install options
 
-1. **Conservative: stable CLI.** Open the [latest stable Release](https://github.com/Jia-Ethan/codex-keysmith/releases/latest), download `codex-instruct-v*.py` and `SHA256SUMS`, verify, then run; the current stable asset is `codex-instruct-v0.3.8.py`. Do not `curl | python`.
-2. **Easier: unsigned Desktop Beta.** See the [Desktop prerelease](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.3.8-beta.1): macOS Apple Silicon DMG and Windows x64 NSIS, with an embedded CLI sidecar, two presets, four fixture packs, and the inactive-by-config uninstall fix. No signing, no auto-update, no Linux GUI. Install notes: [`CODE_SIGNING_POLICY.md`](CODE_SIGNING_POLICY.md).
-3. **Source.** Clone and run `python3 codex-instruct.py`. This source tree is version `0.3.9`; the latest stable Release remains the immutable `v0.3.8` asset set. Check the Releases page for the published state.
+1. **Conservative: stable CLI.** Open the [latest stable Release](https://github.com/Jia-Ethan/codex-keysmith/releases/latest), download `codex-instruct-v*.py` and `SHA256SUMS`, verify, then run; the current stable asset is `codex-instruct-v0.3.9.py`. Do not `curl | python`.
+2. **Easier: unsigned Desktop Beta.** See the [Desktop prerelease](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.3.9-beta.1): macOS Apple Silicon DMG and Windows x64 NSIS, with an embedded CLI sidecar, two presets, four fixture packs, and Restore Config Reference. No signing, no auto-update, no Linux GUI. Install notes: [`CODE_SIGNING_POLICY.md`](CODE_SIGNING_POLICY.md).
+3. **Source.** Clone and run `python3 codex-instruct.py`. This source tree and the latest stable Release are both version `0.3.9`; check the Releases page for published assets.
 
 ### Quick start
 
@@ -87,11 +87,11 @@ python3 codex-instruct-vX.Y.Z.py --codex-dir ~/.codex --uninstall --lang en
 python3 codex-instruct-vX.Y.Z.py --codex-dir ~/.codex --uninstall --yes --lang en
 ```
 
-Each uninstall peels one layer. `--reactivate` is available from `v0.3.9`; the immutable `v0.3.8` single-file asset does not contain that option. Until `v0.3.9` is formally published, run it only from this source tree:
+Each uninstall peels one layer. `--reactivate` is available from `v0.3.9`:
 
 ```bash
-python3 codex-instruct.py --codex-dir ~/.codex --reactivate --lang en
-python3 codex-instruct.py --codex-dir ~/.codex --reactivate --yes --lang en
+python3 codex-instruct-vX.Y.Z.py --codex-dir ~/.codex --reactivate --lang en
+python3 codex-instruct-vX.Y.Z.py --codex-dir ~/.codex --reactivate --yes --lang en
 ```
 
 If `--status` reports `inactive-by-config`, `--reactivate` restores only the missing top-level `model_instructions_file`. Do not edit `config.toml` by hand or run a full deploy just to put the field back. Catchable batch failures roll back, but reactivation creates no durable journal; after a hard interruption, run `--status` and rerun `--reactivate --yes` to finish the remaining directories when no conflict is present. `--recover` handles interrupted deploy/uninstall transactions only. Do not delete journals, backups, or the manifest by hand.

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Keysmith 系列为本地 AI 工具**安全部署、验证和撤销**自定义指
 
 ### 安装方式
 
-1. **稳妥：稳定 CLI。** 打开 [最新稳定 Release](https://github.com/Jia-Ethan/codex-keysmith/releases/latest)，下载单文件 `codex-instruct-v*.py` 与 `SHA256SUMS`，校验后再运行；当前稳定资产名为 `codex-instruct-v0.3.8.py`。不要 `curl | python`。
-2. **更易用：未签名 Desktop Beta。** 见 [Desktop 预发布](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.3.8-beta.1)：macOS Apple Silicon DMG 与 Windows x64 NSIS，内嵌 CLI sidecar、双 preset 与四个 fixture 包，并包含 inactive-by-config 卸载修复。无签名、无自动更新、无 Linux GUI。安装步骤见 [`CODE_SIGNING_POLICY.md`](CODE_SIGNING_POLICY.md)。
-3. **源码。** clone 后直接 `python3 codex-instruct.py`。此源码树版本为 `0.3.9`；最新稳定 Release 仍是不可变的 `v0.3.8` 资产，以 Releases 页为准。
+1. **稳妥：稳定 CLI。** 打开 [最新稳定 Release](https://github.com/Jia-Ethan/codex-keysmith/releases/latest)，下载单文件 `codex-instruct-v*.py` 与 `SHA256SUMS`，校验后再运行；当前稳定资产名为 `codex-instruct-v0.3.9.py`。不要 `curl | python`。
+2. **更易用：未签名 Desktop Beta。** 见 [Desktop 预发布](https://github.com/Jia-Ethan/codex-keysmith/releases/tag/desktop-v0.3.9-beta.1)：macOS Apple Silicon DMG 与 Windows x64 NSIS，内嵌 CLI sidecar、双 preset、四个 fixture 包与“恢复配置引用”入口。无签名、无自动更新、无 Linux GUI。安装步骤见 [`CODE_SIGNING_POLICY.md`](CODE_SIGNING_POLICY.md)。
+3. **源码。** clone 后直接 `python3 codex-instruct.py`。此源码树与最新稳定 Release 均为 `0.3.9`，以 Releases 页为准。
 
 ### 快速开始
 
@@ -87,11 +87,11 @@ python3 codex-instruct-vX.Y.Z.py --codex-dir ~/.codex --uninstall --lang zh-CN
 python3 codex-instruct-vX.Y.Z.py --codex-dir ~/.codex --uninstall --yes --lang zh-CN
 ```
 
-卸载每次只撤销最新一层。`--reactivate` 从 `v0.3.9` 开始提供，当前不可变的 `v0.3.8` 单文件资产不含该参数；`v0.3.9` 正式发布前，只能从此源码树运行：
+卸载每次只撤销最新一层。`--reactivate` 从 `v0.3.9` 开始提供：
 
 ```bash
-python3 codex-instruct.py --codex-dir ~/.codex --reactivate --lang zh-CN
-python3 codex-instruct.py --codex-dir ~/.codex --reactivate --yes --lang zh-CN
+python3 codex-instruct-vX.Y.Z.py --codex-dir ~/.codex --reactivate --lang zh-CN
+python3 codex-instruct-vX.Y.Z.py --codex-dir ~/.codex --reactivate --yes --lang zh-CN
 ```
 
 若 `--status` 显示 `inactive-by-config`，`--reactivate` 只补回缺失的顶层 `model_instructions_file`，不要手工改 `config.toml`，也不要为补字段再走一遍完整部署。它会回滚可捕获的批量失败，但不创建 durable journal；硬中断后先运行 `--status`，无冲突时重跑 `--reactivate --yes` 完成其余目录。`--recover` 只处理 deploy/uninstall 中断事务。不要手工删除 journal、备份或 manifest。

--- a/gui/README.md
+++ b/gui/README.md
@@ -43,7 +43,7 @@ npm run tauri build
 | macOS Apple Silicon | `codex-keysmith-cli-aarch64-apple-darwin` | `.app` + ARM64 `.dmg` |
 | Windows x64 | `codex-keysmith-cli-x86_64-pc-windows-msvc.exe` | current-user NSIS `.exe` |
 
-当前公开的 `desktop-v0.3.8-beta.1` 提供 macOS Apple Silicon unsigned DMG 与 Windows x64 unsigned NSIS，包含场景库页、双 preset 部署、四个 fixture 包与 inactive-by-config 卸载修复；冻结 sidecar 不依赖源码树即可列出或写入夹具。下一档 `desktop-v0.3.9-beta.1` 候选加入受约束的配置引用恢复，并与 `0.3.9` CLI sidecar 保持同版本；尚未发布。Windows 安装器使用 WebView2 download bootstrapper、禁止降级，当前不生成 MSI；两平台均尚未进行正式签名、公证或实体设备验收。普通用户按平台下载已发布的 DMG 或 setup EXE；正式 Authenticode 发行仍待 SignPath Foundation 审核和独立签名流程。
+当前公开的 `desktop-v0.3.9-beta.1` 提供 macOS Apple Silicon unsigned DMG 与 Windows x64 unsigned NSIS，包含场景库页、双 preset 部署、四个 fixture 包与受约束的配置引用恢复；冻结 sidecar 与 `0.3.9` CLI 保持同版本。Windows 安装器使用 WebView2 download bootstrapper、禁止降级，当前不生成 MSI；两平台均尚未进行正式签名、公证或实体设备验收。普通用户按平台下载已发布的 DMG 或 setup EXE；正式 Authenticode 发行仍待 SignPath Foundation 审核和独立签名流程。
 
 图标以 `src-tauri/icons/source.png` 为唯一源文件。修改后运行：
 

--- a/gui/SPEC.md
+++ b/gui/SPEC.md
@@ -1,6 +1,6 @@
 # codex-keysmith GUI 客户端 — 技术方案与交接文档
 
-> 状态：源码已具备指令层 GUI（M1–M5）、场景库页、preset 选择与 fixture scaffold 页；冻结 sidecar 内嵌 `fixture_packs/`。当前公开安装包是 `desktop-v0.3.8-beta.1`；下一档尚未发布的 unsigned Desktop 候选为 `desktop-v0.3.9-beta.1`。正式签名、公证与实体设备验收仍待完成
+> 状态：源码已具备指令层 GUI（M1–M5）、场景库页、preset 选择与 fixture scaffold 页；冻结 sidecar 内嵌 `fixture_packs/`。当前公开安装包是 unsigned `desktop-v0.3.9-beta.1`。正式签名、公证与实体设备验收仍待完成
 > 关联 issue：[#10「建议」为小白做一个可视化的界面客户端](https://github.com/Jia-Ethan/codex-keysmith/issues/10)
 
 ## 1. 项目背景
@@ -16,7 +16,7 @@ CLI 对熟练用户很好用，但对小白（issue #10 的目标用户）门槛
 | 技术栈 | **Tauri 2**（Rust 后端 + Web 前端） | 打包体积小（几 MB）、原生感强、界面现代化 |
 | 平台范围 | **macOS Apple Silicon + Windows x64** | 每个平台原生冻结 Python 与构建 Tauri bundle，不做跨平台交叉打包；本轮不提供 Intel Mac 包 |
 | 与 CLI 的关系 | **包装现有 CLI**（subprocess 调用），不重实现逻辑 | 复用已测试的部署/回滚/恢复逻辑，CLI 升级客户端不用跟着改 |
-| 本轮交付 | **指令层 M1–M5 + 场景库 + 双通道 GUI** | 部署页可选 preset；夹具页只调用 CLI scaffold；sidecar 内嵌 `fixture_packs/`；下一档尚未发布的 unsigned 候选为 `desktop-v0.3.9-beta.1` |
+| 本轮交付 | **指令层 M1–M5 + 场景库 + 双通道 GUI** | 部署页可选 preset；夹具页只调用 CLI scaffold；sidecar 内嵌 `fixture_packs/`；unsigned `desktop-v0.3.9-beta.1` 已发布 |
 
 ## 3. 总体架构
 
@@ -346,13 +346,13 @@ async fn cli_runtime(cli_path: Option<String>) -> Result<String, String>;
 | **M4 打包基础** ✅ | PyInstaller sidecar、统一图标、macOS app/dmg 配置 | 安装包内置冻结 CLI，不依赖系统 Python；签名/公证/Release CI 单独验收 |
 | **M5 Windows x64 打包基础** ✅ | 原生 sidecar + current-user NSIS + WebView2 bootstrapper | 可在 Windows x64 原生环境产出 `.exe`；CI 安装后验证配置/运行目录隔离、活动 sidecar 期间排队关闭、单实例交接、原生空闲关闭及无 GUI/sidecar 残留；正式发布前仍需 Authenticode 与实体设备验收 |
 | **场景 M4 场景库页** ✅ | 列表、详情、显式 `--target-dir`、preview 门禁、status、uninstall、recovery | GUI 只调用 CLI 场景命令；预览绑定规范目标与场景/部署标识，选择变化后失效；状态与写结果保留 blocker、stdout/stderr，并在每次写操作后刷新；进入 `desktop-v0.3.5-beta.1` |
-| **Desktop 双通道与夹具页** ✅ | Deploy 双 preset、本地文件模式、Fixtures 列表/预览/写入/删除、sidecar 内嵌 fixture packs | GUI 只调用既有 CLI；部署参数互斥；夹具预览绑定 pack/目录/force 并明确未修改 `~/.codex`；当前发布版为 `desktop-v0.3.8-beta.1`，下一候选为 `desktop-v0.3.9-beta.1` |
+| **Desktop 双通道与夹具页** ✅ | Deploy 双 preset、本地文件模式、Fixtures 列表/预览/写入/删除、sidecar 内嵌 fixture packs | GUI 只调用既有 CLI；部署参数互斥；夹具预览绑定 pack/目录/force 并明确未修改 `~/.codex`；当前发布版为 `desktop-v0.3.9-beta.1` |
 
 ## 10. 交接说明（给接手 Agent）
 
 **起点：** canonical 仓库内的 `gui/` 目录；CLI 源码固定取仓库根目录 `codex-instruct.py`，GUI 与 CLI 可绑定到同一提交。
 
-**当前交付（截至 2026-08-20，v0.3.9 源码候选）：**
+**当前交付（截至 2026-08-20，v0.3.9）：**
 
 - `src-tauri/`：Tauri 2 工程，提供 `cli_run` / `read_manifest` / `detect_cli` / `cli_version` / `cli_runtime`
 - `src/`：React 19 前端，六视图（Dashboard / Deploy / Scenarios / Fixtures / Manage / Settings）+ react-i18next + 双主题设计系统（token 沿用 ethanpier.com：深色 tech blue / 浅色 clay）

--- a/tests/test_desktop_prerelease.py
+++ b/tests/test_desktop_prerelease.py
@@ -16,14 +16,13 @@ COMMIT = "a" * 40
 TAG = f"desktop-v{prerelease.VERSION}-beta.1"
 REPO_ROOT = Path(__file__).resolve().parents[1]
 VERSION = prerelease.VERSION
-PUBLISHED_DESKTOP_VERSION = "0.3.8"
+PUBLISHED_DESKTOP_VERSION = "0.3.9"
 PUBLISHED_DESKTOP_TAG = f"desktop-v{PUBLISHED_DESKTOP_VERSION}-beta.1"
-PUBLISHED_SOURCE_VERSION = "0.3.8"
+PUBLISHED_SOURCE_VERSION = "0.3.9"
 HISTORICAL_DESKTOP_VERSION = "0.3.5"
 HISTORICAL_DESKTOP_TAG = f"desktop-v{HISTORICAL_DESKTOP_VERSION}-beta.1"
-PREVIOUS_DESKTOP_VERSION = "0.3.7"
+PREVIOUS_DESKTOP_VERSION = "0.3.8"
 PREVIOUS_DESKTOP_TAG = f"desktop-v{PREVIOUS_DESKTOP_VERSION}-beta.1"
-CANDIDATE_DESKTOP_TAG = f"desktop-v{VERSION}-beta.1"
 
 
 def _sha256(path: Path) -> str:
@@ -597,29 +596,9 @@ def test_historical_desktop_v035_notes_remain_unchanged():
     assert release_notes == expected
 
 
-def test_previous_desktop_v037_notes_remain_unchanged():
+def test_previous_desktop_v038_notes_remain_unchanged():
     release_notes = (
         REPO_ROOT / f"docs/releases/{PREVIOUS_DESKTOP_TAG}.md"
-    ).read_text(encoding="utf-8")
-    assert release_notes.startswith(
-        f"# codex-keysmith v{PREVIOUS_DESKTOP_VERSION} Desktop Beta\n"
-    )
-    for marker in (
-        "WINDOWS_FRESH_DEPLOYMENT_POLICY: EXPLICIT_BETA",
-        f"codex-keysmith-{PREVIOUS_DESKTOP_VERSION}-macos-arm64-unsigned.dmg",
-        f"codex-keysmith-{PREVIOUS_DESKTOP_VERSION}-windows-x64-unsigned-setup.exe",
-        f"v{PREVIOUS_DESKTOP_VERSION}",
-        "SHA256SUMS",
-        "unrestricted",
-        "contract",
-        "fixture_packs/",
-    ):
-        assert marker in release_notes
-
-
-def test_published_prerelease_release_notes_match_approved_compact_copy():
-    release_notes = (
-        REPO_ROOT / f"docs/releases/{PUBLISHED_DESKTOP_TAG}.md"
     ).read_text(encoding="utf-8")
     expected = textwrap.dedent(
         """\
@@ -631,9 +610,9 @@ def test_published_prerelease_release_notes_match_approved_compact_copy():
     assert release_notes == expected
 
 
-def test_candidate_prerelease_release_notes_match_approved_compact_copy():
+def test_published_prerelease_release_notes_match_approved_compact_copy():
     release_notes = (
-        REPO_ROOT / f"docs/releases/{CANDIDATE_DESKTOP_TAG}.md"
+        REPO_ROOT / f"docs/releases/{PUBLISHED_DESKTOP_TAG}.md"
     ).read_text(encoding="utf-8")
     expected = textwrap.dedent(
         """\

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -254,18 +254,17 @@ def test_repository_version_metadata_is_release_state_neutral():
         assert "--codex-dir ~/.codex --dry-run" in quick_start
 
 
-def test_readmes_do_not_attribute_reactivate_to_immutable_v038_asset():
+def test_readmes_use_published_v039_reactivate_command():
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
     english_readme = (REPO_ROOT / "README.en.md").read_text(encoding="utf-8")
 
     assert "`--reactivate` 从 `v0.3.9` 开始提供" in readme
-    assert "`v0.3.8` 单文件资产不含该参数" in readme
-    assert "python3 codex-instruct.py --codex-dir ~/.codex --reactivate" in readme
+    assert "python3 codex-instruct-vX.Y.Z.py --codex-dir ~/.codex --reactivate" in readme
     assert "`--reactivate` is available from `v0.3.9`" in english_readme
-    assert "`v0.3.8` single-file asset does not contain that option" in english_readme
-    assert "python3 codex-instruct.py --codex-dir ~/.codex --reactivate" in english_readme
+    assert "python3 codex-instruct-vX.Y.Z.py --codex-dir ~/.codex --reactivate" in english_readme
     for quick_start in (readme, english_readme):
-        assert "codex-instruct-vX.Y.Z.py --codex-dir ~/.codex --reactivate" not in quick_start
+        assert "v0.3.9` 正式发布前" not in quick_start
+        assert "Until `v0.3.9` is formally published" not in quick_start
 
 
 def test_cli_and_desktop_source_versions_match():


### PR DESCRIPTION
## 变更

- 将稳定 CLI 与 Desktop Beta 链接更新到 `0.3.9`
- 移除未发布候选文案
- 同步 GUI 文档、签名边界和回归断言

## 已发布并验证

- `v0.3.9`：5 项公开资产，SHA256 全部通过
- `desktop-v0.3.9-beta.1`：5 项公开资产，SHA256 全部通过
- DMG `hdiutil verify` 通过
- 两个平台 manifest 均绑定 `9f4f1ba`、`0.3.9`、`unsigned`、`exact-copy`

## 本地验证

- `python3 -m pytest -q tests/test_release_artifacts.py tests/test_desktop_prerelease.py`：93 passed, 1 skipped
- `python3 -m ruff check codex-instruct.py tests scripts`
- `git diff --check`