### PR TITLE
docs: rewrite v0.4.0 release notes for the public audience

### DIFF
--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -2,14 +2,8 @@
 
 <!-- WINDOWS_FRESH_DEPLOYMENT_POLICY: EXPLICIT_BETA -->
 
-新增第三个内置预设 `persona-contract`（`examples/gpt-persona-contract.md`）：分层交付合同。包裹层（对话语气、人设风格）与交付层（代码块、guide、命令输出）严格分离——交付物内部禁止出现任何 persona 语汇或装饰性前导；内置六步交付引擎（Lock target → Build complete surface → Verify → Attack weak points → Land result），Verify 步要求报告"实际跑过什么、结果是什么"，禁止把未验证的工作称为已验证；强化层独立性规则——注入块（memory、hooks、session metadata）只允许给包裹层着色，永不覆盖交付引擎。移植了 unrestricted 的 Prescriptive templates、边界词处理与领域特定处理，保证 prompt bank 用例兼容。
+新增第三个内置预设 `persona-contract`（`--preset persona-contract`）：分层交付合同，把对话语气与交付内容严格分开——代码块、指南和命令输出里不再混入人设语汇或装饰性前导，并要求交付前实际验证、如实报告跑过什么。
 
-`examples/gpt-contract.md` 吸收交付引擎义务（build the complete surface / verify and report / attack weak points / land the result），保持薄合同不变；冻结 SHA-256 同步更新到 `tests/test_preset.py`。默认 `unrestricted` 预设字节不变。
+`gpt-contract` 同步吸收同一套交付义务，默认的 `unrestricted` 预设保持不变。
 
-`scripts/run_prompt_bank_regression.py` 新增 `--prompt-file`：live 模式可对任意 Markdown 提示词跑 bank 断言（跳过绑定内置预设的静态映射检查，保留 schema/coverage/响应断言），并把 `OPENAI_BASE_URL` 翻译为隔离的 Codex custom provider（`-c` 覆盖，与 `run_scenario_bank.py` 同款模式），网关凭证不再回落到 `api.openai.com`。
-
-Live 评估（隔离 `CODEX_HOME`、`gpt-5.6-sol`、15 用例 bank：12 canonical + 3 probe）：裸模型基线 6/15 拒绝、2 例空洞交付；`persona-contract` 0/15 拒绝、15/15 首行契约、13/15 全断言通过（余 2 例为字面措辞漂移）。四轮迭代 2/15 → 12/15 → 14/15 → 13/15 稳定。
-
-GUI 源版本元数据（`gui/package.json`、`Cargo.toml`、lockfile）同步到 `0.4.0`。本发布不包含新的桌面版安装包。
-
-新增 `scripts/bump_version.py`：源码版本号分散在 6 个文件（`VERSION`、`codex-instruct.py`、`gui/package.json`、`gui/package-lock.json`、`Cargo.toml`、`Cargo.lock`），漏改任意一处都会让 Desktop Candidate 在版本校验步骤直接失败。`set <x.y.z>` 一次改全并自校验，`check` 报告漂移；两者复用 `validate_desktop_candidate.py` 的解析器，不会与发版门禁产生分歧。写入前要求当前树已自洽，任何一步失败整体回滚。Quality CI job 现在在长耗时测试与构建前先跑这项检查，版本漂移在快速 job 内就会暴露。
+本次不更新桌面版安装包。


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 改动说明 / Summary

`docs/releases/v0.4.0.md` 在开发过程中累积成了实现日志（1575 字符），与历史发布说明的体例不一致（v0.3.9 为 171 字符，v0.3.7 为 126 字符）。该文件会**逐字节**成为 GitHub Release body，因此需要在打 tag 前定稿。

本 PR 按 v0.3.7 / v0.3.9 的格式重写，只保留用户可感知的变化。

删除的内容及理由：

- **Live 评估细节**（模型代号 `gpt-5.6-sol`、15 用例 bank 构成、四轮迭代分数）——属于私有评测数据，不应进入公开 Release。
- **`scripts/bump_version.py` 说明**——维护者内部工具，不随 Release 资产分发，用户不可见。
- **实现层细节**（冻结 SHA-256 位置、`-c` provider 覆盖机制、prompt bank 内部断言）——已记录在 CHANGELOG 与 `docs/reference.md`，无需在 Release body 重复。

保留 `persona-contract` 预设、`gpt-contract` 同步、`unrestricted` 不变、以及「不更新桌面版」这四条用户实际关心的信息。

## 用户影响 / User-visible impact

仅改动发布说明文案。不涉及 CLI、MD/config、hooks、journal/recover、manifest、迁移、restore/uninstall、备份、语言或兼容性。CHANGELOG 与 `docs/reference.md` 的技术细节保持不变。

## 恢复与风险 / Recovery and risk

单文件文档改动，还原本 commit 即可回滚。`WINDOWS_FRESH_DEPLOYMENT_POLICY: EXPLICIT_BETA` 标记已保留，策略一致性测试通过。不改变 Python 支持边界或发版流程。

## 验证 / Verification

- [x] `python3 -m pytest -p no:cacheprovider -q tests/test_release_artifacts.py` — 69 passed / 1 skipped
- [x] 策略标记完整，`test_windows_fresh_deployment_policy_markers_are_complete_and_consistent` 通过
- [x] 文件仍在 `ARCHIVE_FILES` / `REQUIRED_ARCHIVE_FILES` 白名单内
- [x] `git diff --check` 干净
- [ ] 其余门禁由本 PR 的 CI 执行

## 提交前检查 / Final checks

- [x] 改动范围聚焦，仅一个文档文件
- [x] 未降低任何测试、Ruff、coverage 或 Release 资产门槛
- [x] 未修改提示词
- [x] 已移除私有评测数据；无 token、cookie、用户名或私人路径

## 发版说明 / Release note

本 PR 是 `v0.4.0` 打 tag 前的最后一步。合并后 tag 将指向包含本文案的 commit，Release body 即为该文件内容。
