### PR TITLE
fix: include README preview webp files in the release bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. The format follows [Kee
 ### Changed
 
 - README illustrations (zh/en) now use the shared champagne-key still-life set for hero, usage cards, and dry-run preview.
+- Release archives now include the README dry-run preview webp pair so relative image links stay inside the bundle.
 
 ### Fixed
 

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -31,6 +31,8 @@ ARCHIVE_FILES = (
     "codex-instruct.py",
     "docs/agent-install.md",
     "docs/assets/readme/codex-keysmith-preview.png",
+    "docs/assets/readme/codex-keysmith-preview-dark.webp",
+    "docs/assets/readme/codex-keysmith-preview-light.webp",
     "docs/assets/readme/codex-keysmith-hero-dark.webp",
     "docs/assets/readme/codex-keysmith-hero-light.webp",
     "docs/assets/readme/project-architecture-en-dark.webp",

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -32,6 +32,8 @@ REQUIRED_ARCHIVE_FILES = {
     "codex-instruct.py",
     "docs/agent-install.md",
     "docs/assets/readme/codex-keysmith-preview.png",
+    "docs/assets/readme/codex-keysmith-preview-dark.webp",
+    "docs/assets/readme/codex-keysmith-preview-light.webp",
     "docs/assets/readme/codex-keysmith-hero-dark.webp",
     "docs/assets/readme/codex-keysmith-hero-light.webp",
     "docs/assets/readme/project-architecture-en-dark.webp",


### PR DESCRIPTION
macOS 3.9 CI on #82 failed because README.en.md now links `docs/assets/readme/codex-keysmith-preview-light.webp`, which was not in `ARCHIVE_FILES`. Adds the preview light/dark webp pair to the release archive and the matching test list.